### PR TITLE
[codex] Bootstrap playbook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# AI Workflow Playbook
+
+`ai-workflow-playbook` is a reusable playbook for disciplined AI-assisted work.
+
+Its purpose is to capture workflow patterns that have been proven in practice or are necessary to explain the core operating model behind reliable AI-assisted delivery. It is intentionally narrow: this is not a notebook, idea dump, or project-specific implementation repo.
+
+## Scope
+
+This repository should contain:
+
+- Repeatable workflow patterns
+- Proven heuristics
+- Decision frameworks
+- Reusable prompt structures
+- Core operating-model guidance needed to apply the playbook well
+
+## Non-Scope
+
+This repository should not contain:
+
+- Raw brainstorms
+- One-off notes
+- Vendor news or trend commentary
+- Project-specific implementation docs
+- Automation code or orchestration systems that belong in a separate implementation repo
+
+If an area grows into implementation, tooling, or automation, it should eventually move to its own repository.
+
+## Guardrails
+
+Use this repo only when content is:
+
+- Reusable across more than one project
+- Specific enough to guide execution
+- Grounded in real usage, not speculation
+- Small enough to strengthen the playbook instead of diluting it
+
+Do not add content that behaves like a working notebook. If material is exploratory, unstable, or tied to one codebase, it does not belong here yet.
+
+## Core And Adapters
+
+Core guidance should stay tool-agnostic whenever possible. The core docs should describe the operating model, lifecycle, checkpoints, and review expectations in language that survives tool changes.
+
+Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/tool-adapters/). Adapters may explain how a specific tool maps onto the core model, but they should not redefine the model itself.
+
+## Current Focus
+
+The first core module is delivery. Additional workflow families may be added later, but only if they meet the same discipline standards and stay aligned with the repository intent.
+
+## Initial Map
+
+- [`docs/core-model.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/core-model.md): high-level operating model
+- [`docs/feature-lifecycle.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/feature-lifecycle.md): delivery lifecycle
+- [`docs/alignment-checkpoints.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/alignment-checkpoints.md): pause points and branch/PR rules
+- [`docs/review-packet.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/review-packet.md): standard human review packet
+- [`docs/tool-adapters/codex.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/tool-adapters/codex.md): Codex-specific adapter notes
+- [`docs/playbook-integrity-check.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/playbook-integrity-check.md): lightweight anti-drift check

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Do not add content that behaves like a working notebook. If material is explorat
 
 Core guidance should stay tool-agnostic whenever possible. The core docs should describe the operating model, lifecycle, checkpoints, and review expectations in language that survives tool changes.
 
-Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/tool-adapters/). Adapters may explain how a specific tool maps onto the core model, but they should not redefine the model itself.
+Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](docs/tool-adapters/). Adapters may explain how a specific tool maps onto the core model, but they should not redefine the model itself.
 
 ## Current Focus
 
@@ -49,9 +49,9 @@ The first core module is delivery. Additional workflow families may be added lat
 
 ## Initial Map
 
-- [`docs/core-model.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/core-model.md): high-level operating model
-- [`docs/feature-lifecycle.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/feature-lifecycle.md): delivery lifecycle
-- [`docs/alignment-checkpoints.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/alignment-checkpoints.md): pause points and branch/PR rules
-- [`docs/review-packet.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/review-packet.md): standard human review packet
-- [`docs/tool-adapters/codex.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/tool-adapters/codex.md): Codex-specific adapter notes
-- [`docs/playbook-integrity-check.md`](/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook/docs/playbook-integrity-check.md): lightweight anti-drift check
+- [`docs/core-model.md`](docs/core-model.md): high-level operating model
+- [`docs/feature-lifecycle.md`](docs/feature-lifecycle.md): delivery lifecycle
+- [`docs/alignment-checkpoints.md`](docs/alignment-checkpoints.md): pause points and branch/PR rules
+- [`docs/review-packet.md`](docs/review-packet.md): standard human review packet
+- [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md): Codex-specific adapter notes
+- [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check

--- a/docs/alignment-checkpoints.md
+++ b/docs/alignment-checkpoints.md
@@ -1,0 +1,55 @@
+# Alignment Checkpoints
+
+These checkpoints are the explicit version of the "back-channel glue" that keeps AI-assisted delivery coherent.
+
+## Pause When
+
+Pause and realign when:
+
+- scope changes materially
+- the task crosses into a new lifecycle phase
+- validation results conflict with the current plan
+- the AI is about to make a non-obvious tradeoff
+- the work starts looking reusable enough to capture
+
+## Ask Whether Capture Is Needed
+
+Ask whether capture is needed when:
+
+- a pattern worked well more than once
+- a repeated failure mode produced a useful guardrail
+- a review habit clearly improved delivery quality
+- release or post-release work exposed a reusable heuristic
+
+Capture should happen before the next major arc, while context is still fresh.
+
+## Optional Pre-Merge Sanity Check
+
+Use a pre-merge sanity check when:
+
+- the PR is large relative to the phase goal
+- the change path was unusually twisty
+- validation passed but confidence still feels soft
+- the reviewer needs a compact re-baseline before approving
+
+This check is optional, but useful when the branch technically passes while the narrative still feels fuzzy.
+
+## Start A New Thread When
+
+Start a new thread when:
+
+- the work moves into a different lifecycle phase after merge
+- the context window is carrying too much stale implementation detail
+- the new task needs a clean brief and a fresh review surface
+- capture work would otherwise be buried inside delivery chatter
+
+## New Branch And PR Required When
+
+A new branch and PR are required when:
+
+- the current phase has merged and the next phase begins
+- release is complete and post-release capture starts
+- the work changes from delivery to reusable playbook capture
+- the review audience or decision surface changes materially
+
+The default should be smaller, phase-shaped branches rather than one branch that tries to carry the whole story.

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -1,0 +1,50 @@
+# Core Model
+
+The operating model is simple: humans own intent, standards, and decisions; AI accelerates drafting, execution, synthesis, and iteration inside clear boundaries.
+
+## Roles
+
+### Human role
+
+- Define the goal, scope, and quality bar
+- Set or approve the execution plan
+- Review meaningful deltas, risks, and tradeoffs
+- Decide when work is complete
+- Decide what is worth capturing into the playbook
+
+### AI role
+
+- Turn direction into concrete next steps
+- Execute bounded work quickly and consistently
+- Surface ambiguity, risk, and missing information
+- Summarize changes, evidence, and open questions
+- Help capture reusable patterns after delivery
+
+## Workflow
+
+The default loop is:
+
+1. Align on the goal and the current phase.
+2. Let AI execute the next bounded unit of work.
+3. Validate outputs against the contract, tests, or review criteria.
+4. Tighten based on feedback.
+5. Capture reusable learning before the next arc begins.
+
+## Feedback Loops
+
+Reliable AI-assisted work depends on short feedback loops:
+
+- Execution loop: produce a change, then validate it quickly
+- Review loop: summarize what changed so a human can inspect the right things
+- Capture loop: turn proven practice into reusable guidance before context fades
+
+## Discipline
+
+Speed is only useful when paired with disciplined execution. This model assumes:
+
+- Clear scope boundaries
+- Frequent validation
+- Explicit pauses when uncertainty increases
+- Written capture of reusable lessons
+
+Without those controls, AI work tends to drift, overproduce, or hide weak reasoning behind fluent output.

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -1,0 +1,51 @@
+# Feature Lifecycle
+
+The delivery lifecycle is:
+
+1. Design
+2. Contract tests
+3. Implementation
+4. Hardening
+5. Release
+6. Capture
+
+Each phase should have a clear goal, a clear review surface, and a natural stopping point before the next phase begins.
+
+## Phase Guidance
+
+### Design
+
+Define the intended behavior, constraints, risks, and acceptance shape. The goal is alignment, not code volume.
+
+### Contract tests
+
+Write or update the tests, checks, or examples that define what must be true. This anchors implementation to an explicit contract.
+
+### Implementation
+
+Build only what is needed to satisfy the contract. Keep feedback loops short and avoid mixing extra polish into the first pass.
+
+### Hardening
+
+Address edge cases, refactors, failure handling, review findings, and CI quality. This is where robustness catches up to correctness.
+
+### Release
+
+Prepare the work to ship with a clean review packet, validation evidence, and any final release checks.
+
+### Capture
+
+Record what should become reusable guidance before the next delivery arc starts.
+
+## Branch And PR Rules
+
+After each merged phase, start a new branch and PR for the next lifecycle phase. This keeps the review surface narrow and preserves clean checkpoints.
+
+The expected pattern is:
+
+1. Merge the current phase
+2. Open a new branch for the next phase
+3. Open a new PR for that phase
+4. Complete post-release capture before starting the next major arc
+
+Do not roll multiple lifecycle phases into one long-running branch unless there is a strong reason and the review surface remains clear.

--- a/docs/playbook-integrity-check.md
+++ b/docs/playbook-integrity-check.md
@@ -1,0 +1,38 @@
+# Playbook Integrity Check
+
+The integrity check is a lightweight periodic review to keep this repository a playbook instead of a dumping ground.
+
+## Goal
+
+Confirm that the repository still contains reusable guidance rather than drifting into notes, implementation, or tool sprawl.
+
+## When To Run It
+
+Run the check when:
+
+- a new workflow family is proposed
+- several docs were added in a short period
+- a capture step produces more material than expected
+- the repo starts feeling harder to navigate or easier to misuse
+- a periodic maintenance pass is due
+
+## What To Look For
+
+Look for:
+
+- scope drift toward project-specific implementation
+- duplicated guidance that should be merged
+- notebook behavior such as raw notes, scratch thinking, or incomplete fragments
+- weak guidance that describes ideas without telling people how to act
+- tool-specific material leaking into core docs instead of adapter docs
+
+## Review Questions
+
+Ask:
+
+1. Is this content reusable across multiple projects?
+2. Is it proven or necessary to explain the core model?
+3. Is it specific enough to guide action?
+4. Does it belong here, or in another repo?
+
+If the answer is weak on multiple questions, the content probably does not belong in this repository in its current form.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -1,0 +1,38 @@
+# Review Packet
+
+Before merge or release, prepare a standard review packet for the human reviewer.
+
+## Packet Format
+
+The packet should include:
+
+- Objective: what this phase was meant to accomplish
+- Scope: what changed and what intentionally did not
+- Contract: the tests, checks, or acceptance criteria that define correctness
+- Validation: what was run and what the results were
+- Risks: remaining concerns, edge cases, or follow-up work
+- Review focus: where the human reviewer should spend attention
+
+## What Codex Should Summarize
+
+Codex should summarize:
+
+- the purpose of the change
+- the key files or surfaces affected
+- the validation evidence
+- the most important tradeoffs made
+- any known weak spots or unresolved questions
+
+The goal is not to restate the diff line by line. The goal is to make human review targeted and efficient.
+
+## What The Human Should Focus On
+
+The human reviewer should focus on:
+
+- whether the phase objective was actually met
+- whether the contract is correct, not just passing
+- whether risks are understood and acceptable
+- whether the change is appropriately scoped for the phase
+- whether the work is ready to merge or release
+
+Human review is for judgment, prioritization, and standards enforcement. It should not be wasted on reconstructing context that the review packet should have provided.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -1,0 +1,38 @@
+# Codex Adapter
+
+This document explains how Codex maps onto the core playbook. It is adapter-specific guidance, not part of the core operating model.
+
+## Codex-Specific Quirks
+
+- Codex can move quickly from brief to implementation, so phase boundaries need to be stated explicitly
+- Codex benefits from narrow, well-shaped tasks with clear validation targets
+- Codex can produce fluent output that still needs human judgment on scope, tradeoffs, and completeness
+
+## Local Permissions Model
+
+Codex operates inside a local permissions model. Some actions may require approval, especially for network access, privileged writes, or potentially destructive commands.
+
+Treat permission boundaries as part of the execution environment, not as incidental friction. If a task depends on elevated access, surface that early and keep the requested action narrowly scoped.
+
+## PR Expectations
+
+- keep PRs phase-shaped and reviewable
+- summarize intent, scope, validation, and known risks
+- prefer draft PRs until the phase objective is actually met
+- avoid bundling unrelated cleanup into the same PR
+
+## CI Expectations
+
+- run the repo-local validation path when it exists
+- report clearly when no local validation path exists
+- treat passing CI as necessary but not sufficient
+- use hardening to close gaps exposed by CI, review, or edge cases
+
+## Git And GitHub Workflow Notes
+
+- use a fresh branch for each lifecycle phase after merge
+- keep commit messages and PR titles clear and phase-oriented
+- preserve a clean review narrative rather than one long-running branch
+- open a new PR when the work changes phase or review surface
+
+Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -18,7 +18,8 @@ Treat permission boundaries as part of the execution environment, not as inciden
 
 - keep PRs phase-shaped and reviewable
 - summarize intent, scope, validation, and known risks
-- prefer draft PRs until the phase objective is actually met
+- make PRs ready for review by default when the phase objective is met
+- use draft PRs only for intentionally incomplete work or early feedback
 - avoid bundling unrelated cleanup into the same PR
 
 ## CI Expectations
@@ -34,5 +35,14 @@ Treat permission boundaries as part of the execution environment, not as inciden
 - keep commit messages and PR titles clear and phase-oriented
 - preserve a clean review narrative rather than one long-running branch
 - open a new PR when the work changes phase or review surface
+
+## Repo Baseline
+
+After bootstrap, check the repository for basic merge safety:
+
+- protect `main`
+- require PR-based changes to `main`
+- require CI or checks before merge when available
+- keep release and tag actions human-gated
 
 Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.


### PR DESCRIPTION
## Summary

Bootstraps `ai-workflow-playbook` as a tightly scoped repository for reusable AI-assisted workflow patterns.

This PR adds:

- a purpose-driven `README.md` with scope, non-scope, and anti-clutter guardrails
- core docs for the operating model, feature lifecycle, alignment checkpoints, and review packet
- a Codex-specific adapter doc under `docs/tool-adapters/`
- a lightweight playbook integrity check to keep the repo from drifting into a dumping ground

## Why

The goal is to establish a minimal but opinionated foundation for proven AI-assisted workflow guidance while keeping core content tool-agnostic and pushing adapter-specific behavior to the edge.

## Validation

- repo-local consistency review of the initial docs set
- verified clean separation between core docs and the Codex adapter
- no repo-local automation or validation path exists yet, so no additional checks were run

## Bootstrap note

Because GitHub requires a base branch before a pull request can exist, the repository was initialized with a minimal empty `main` commit. The actual bootstrap content in this PR lives entirely on `codex/bootstrap-playbook-docs`.
