### PR TITLE
[codex] Tighten playbook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Do not add content that behaves like a working notebook. If material is explorat
 
 ## Core And Adapters
 
-Core guidance should stay tool-agnostic whenever possible. The core docs should describe the operating model, lifecycle, checkpoints, and review expectations in language that survives tool changes.
+Core guidance should stay tool-agnostic. The core docs should describe the operating model, lifecycle, checkpoints, and review expectations in language that survives tool changes.
 
-Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](docs/tool-adapters/). Adapters may explain how a specific tool maps onto the core model, but they should not redefine the model itself.
+Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](docs/tool-adapters/). Adapters should explain how a specific tool maps onto the core model, but they should not redefine the model itself.
 
 ## Current Focus
 

--- a/docs/alignment-checkpoints.md
+++ b/docs/alignment-checkpoints.md
@@ -2,6 +2,8 @@
 
 These checkpoints are the explicit version of the "back-channel glue" that keeps AI-assisted delivery coherent.
 
+Use these checkpoints alongside [`feature-lifecycle.md`](feature-lifecycle.md) and [`review-packet.md`](review-packet.md).
+
 ## Pause When
 
 Pause and realign when:

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -11,6 +11,8 @@ The delivery lifecycle is:
 
 Each phase should have a clear goal, a clear review surface, and a natural stopping point before the next phase begins.
 
+Use [`alignment-checkpoints.md`](alignment-checkpoints.md) to decide when to pause or split work, and use [`review-packet.md`](review-packet.md) to prepare the review surface before merge or release.
+
 ## Phase Guidance
 
 ### Design
@@ -31,7 +33,7 @@ Address edge cases, refactors, failure handling, review findings, and CI quality
 
 ### Release
 
-Prepare the work to ship with a clean review packet, validation evidence, and any final release checks.
+Prepare the work to ship with a clean review packet, validation evidence, and any final release checks. If the repo does not have a formal validation path yet, record the lightweight validation that was used instead.
 
 ### Capture
 

--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -30,7 +30,7 @@ Repo docs should use relative links from the start. Absolute local filesystem pa
 
 ### Validation In A Docs-First Repo
 
-A brand-new docs-first repo may not have a repo-local validation path yet. Until it does, validation falls back to:
+A brand-new docs-first repo often does not have a repo-local validation path yet. Until it does, validation falls back to:
 
 - internal consistency review
 - path portability checks
@@ -46,4 +46,4 @@ Keep the bootstrap workflow tool-aware but practical:
 
 ## Reuse
 
-Treat this as a reusable bootstrap pattern for new repositories, not as a one-off retrospective. Reapply it when a new repo needs a clean starting point, a reviewable bootstrap PR, and lightweight validation before richer tooling exists.
+Treat this as a reusable bootstrap pattern for new repositories, not as a one-off retrospective. Reapply it when a new repo needs a clean starting point, a reviewable bootstrap PR, and lightweight validation before richer tooling exists. Review it with [`playbook-integrity-check.md`](playbook-integrity-check.md) if similar bootstrap capture docs start to accumulate.

--- a/docs/playbook-integrity-check.md
+++ b/docs/playbook-integrity-check.md
@@ -2,6 +2,8 @@
 
 The integrity check is a lightweight periodic review to keep this repository a playbook instead of a dumping ground.
 
+Use this check to review new capture docs such as [`new-repo-bootstrap.md`](new-repo-bootstrap.md) before the repository accumulates one-off material.
+
 ## Goal
 
 Confirm that the repository still contains reusable guidance rather than drifting into notes, implementation, or tool sprawl.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -2,6 +2,8 @@
 
 Before merge or release, prepare a standard review packet for the human reviewer.
 
+Use this packet at the release point described in [`feature-lifecycle.md`](feature-lifecycle.md), and use [`alignment-checkpoints.md`](alignment-checkpoints.md) when deciding whether a pre-merge sanity check is needed.
+
 ## Packet Format
 
 The packet should include:
@@ -24,6 +26,8 @@ Codex should summarize:
 - any known weak spots or unresolved questions
 
 The goal is not to restate the diff line by line. The goal is to make human review targeted and efficient.
+
+If the repo does not have a formal validation path yet, say that directly and summarize the lightweight validation that was used.
 
 ## What The Human Should Focus On
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -10,7 +10,7 @@ This document explains how Codex maps onto the core playbook. It is adapter-spec
 
 ## Local Permissions Model
 
-Codex operates inside a local permissions model. Some actions may require approval, especially for network access, privileged writes, or potentially destructive commands.
+Codex operates inside a local permissions model. Some actions require approval, especially for network access, privileged writes, or potentially destructive commands.
 
 Treat permission boundaries as part of the execution environment, not as incidental friction. If a task depends on elevated access, surface that early and keep the requested action narrowly scoped.
 
@@ -26,6 +26,7 @@ Treat permission boundaries as part of the execution environment, not as inciden
 
 - run the repo-local validation path when it exists
 - report clearly when no local validation path exists
+- until a formal validation path exists, use internal consistency review, path checks, and scope review
 - treat passing CI as necessary but not sufficient
 - use hardening to close gaps exposed by CI, review, or edge cases
 
@@ -38,11 +39,13 @@ Treat permission boundaries as part of the execution environment, not as inciden
 
 ## Repo Baseline
 
-After bootstrap, check the repository for basic merge safety:
+After bootstrap, configure these as the basic merge-safety baseline:
 
 - protect `main`
 - require PR-based changes to `main`
 - require CI or checks before merge when available
 - keep release and tag actions human-gated
+
+This repository does not enforce that baseline yet, so treat it as the next safety step after bootstrap rather than an already-configured guarantee.
 
 Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.


### PR DESCRIPTION
## Summary

Performs a focused tightening pass across the existing playbook docs without expanding scope.

This PR:

- tightens soft wording in the README and Codex adapter
- adds lightweight cross-links between lifecycle, checkpoints, review packet, integrity, and bootstrap guidance
- clarifies how to document validation when a formal validation path does not exist yet
- aligns the Codex adapter's repo-baseline wording with the repo's current unprotected `main` state
- keeps the README doc map accurate and unchanged in scope

## Why

The goal is to improve clarity, consistency, and navigation while keeping the repo minimal, directive, and playbook-focused.

## Validation

- internal consistency review across `README.md` and `docs/`
- relative-link verification across the doc set
- GitHub API check of the current `main` branch protection state to align baseline wording with reality
