### PR TITLE
[codex] Add minimal markdown CI

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,22 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  markdownlint:
+    name: markdownlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: |
+            **/*.md

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,4 @@
+{
+  "default": true,
+  "MD013": false
+}

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -47,6 +47,6 @@ After bootstrap, configure these as the basic merge-safety baseline:
 - require CI or checks before merge when available
 - keep release and tag actions human-gated
 
-This repository now enforces that baseline on `main`, including the `markdownlint` check. Apply the same baseline after bootstrap when creating a new repo.
+This repository now enforces the `main` branch-protection portion of that baseline, including the required `markdownlint` check. Release and tag actions remain human-gated as an operational rule rather than something enforced by branch protection. Apply the same baseline after bootstrap when creating a new repo.
 
 Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -46,6 +46,6 @@ After bootstrap, configure these as the basic merge-safety baseline:
 - require CI or checks before merge when available
 - keep release and tag actions human-gated
 
-This repository does not enforce that baseline yet, so treat it as the next safety step after bootstrap rather than an already-configured guarantee.
+This repository now enforces that baseline on `main`. Apply the same baseline after bootstrap when creating a new repo.
 
 Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -25,6 +25,7 @@ Treat permission boundaries as part of the execution environment, not as inciden
 ## CI Expectations
 
 - run the repo-local validation path when it exists
+- in this repo, the current minimal CI path is the `markdownlint` GitHub Actions check
 - report clearly when no local validation path exists
 - until a formal validation path exists, use internal consistency review, path checks, and scope review
 - treat passing CI as necessary but not sufficient
@@ -46,6 +47,6 @@ After bootstrap, configure these as the basic merge-safety baseline:
 - require CI or checks before merge when available
 - keep release and tag actions human-gated
 
-This repository now enforces that baseline on `main`. Apply the same baseline after bootstrap when creating a new repo.
+This repository now enforces that baseline on `main`, including the `markdownlint` check. Apply the same baseline after bootstrap when creating a new repo.
 
 Codex should follow the core model, but this adapter exists to document the tooling realities that shape how the model is applied in practice.


### PR DESCRIPTION
## Summary

Adds the smallest practical CI path for this docs-first repo and aligns the baseline docs with the resulting protection state.

This PR adds:

- a lightweight GitHub Actions workflow that runs `markdownlint` on Markdown files
- a minimal `.markdownlint.jsonc` config that disables line-length enforcement for this repo
- a short Codex adapter note describing `markdownlint` as the current minimal CI path
- an updated baseline note that now truthfully states `main` enforces the baseline, including the `markdownlint` check

## Why

The goal is to make the documented baseline fully real: there is now a genuine CI check for this repo, and `main` can require that check before merge.

## Validation

- locally parsed the workflow YAML and markdownlint config
- confirmed the workflow job name is `markdownlint`
- confirmed the `markdownlint` GitHub Actions check passed on this PR
- branch protection was updated outside the PR so `main` now requires the `markdownlint` check before merge
