### PR TITLE
[codex] Clarify Codex repo context and AGENTS reference pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Core guidance should stay tool-agnostic. The core docs should describe the opera
 
 Tool-specific behavior belongs in adapter docs under [`docs/tool-adapters/`](docs/tool-adapters/). Adapters should explain how a specific tool maps onto the core model, but they should not redefine the model itself.
 
+## Repo-Local AGENTS.md
+
+The playbook is the canonical home for reusable workflow patterns. Repositories can reference it from a local `AGENTS.md`, but that local file should stay self-contained for execution and should remain the source of truth for repo-specific validation, commands, and PR expectations.
+
+Reusable pattern:
+
+> This repository uses the shared AI workflow model defined in `ai-workflow-playbook` as a reference. `AGENTS.md` provides the repo-specific instructions (validation, commands, PR expectations) that take precedence when working here.
+
 ## Current Focus
 
 The first core module is delivery. Additional workflow families may be added later, but only if they meet the same discipline standards and stay aligned with the repository intent.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -8,6 +8,12 @@ This document explains how Codex maps onto the core playbook. It is adapter-spec
 - Codex benefits from narrow, well-shaped tasks with clear validation targets
 - Codex can produce fluent output that still needs human judgment on scope, tradeoffs, and completeness
 
+## Project-Context Check
+
+- before making changes, confirm the current Codex project or working context matches the intended task target
+- if the task appears to target a different repository, a new repository, or a cross-repo comparison while the current context is repo-scoped, pause and confirm with the human before proceeding
+- keep this lightweight for normal same-repo work; a quick sanity check is enough
+
 ## Local Permissions Model
 
 Codex operates inside a local permissions model. Some actions require approval, especially for network access, privileged writes, or potentially destructive commands.


### PR DESCRIPTION
## Summary
- add a lightweight Codex project-context check before repo-scoped changes
- add a reusable `AGENTS.md` reference pattern that points repositories back to `ai-workflow-playbook`
- reinforce that reusable workflow patterns live here while repo-local instructions remain authoritative for execution

## Validation
- internal consistency review across touched docs
- `git diff --check`
- verified existing relative links remain unchanged and clean