### PR TITLE
[codex] refine Codex autonomous-lane guidance

### DIFF
--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -10,20 +10,19 @@ The packet should include:
 
 - Objective: what this phase was meant to accomplish
 - Scope: what changed and what intentionally did not
-- Contract: the tests, checks, or acceptance criteria that define correctness
 - Validation: what was run and what the results were
 - Risks: remaining concerns, edge cases, or follow-up work
-- Review focus: where the human reviewer should spend attention
+- Recommendation: `ready to merge`, `needs decision`, or `blocked`
 
 ## What Codex Should Summarize
 
 Codex should summarize:
 
-- the purpose of the change
-- the key files or surfaces affected
+- the objective
+- the actual scope
 - the validation evidence
-- the most important tradeoffs made
-- any known weak spots or unresolved questions
+- the main risks
+- an explicit recommendation: `ready to merge`, `needs decision`, or `blocked`
 
 The goal is not to restate the diff line by line. The goal is to make human review targeted and efficient.
 
@@ -34,7 +33,7 @@ If the repo does not have a formal validation path yet, say that directly and su
 The human reviewer should focus on:
 
 - whether the phase objective was actually met
-- whether the contract is correct, not just passing
+- whether the validation and acceptance criteria are correct, not just passing
 - whether risks are understood and acceptable
 - whether the change is appropriately scoped for the phase
 - whether the work is ready to merge or release

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -20,6 +20,29 @@ Codex operates inside a local permissions model. Some actions require approval, 
 
 Treat permission boundaries as part of the execution environment, not as incidental friction. If a task depends on elevated access, surface that early and keep the requested action narrowly scoped.
 
+## Autonomous Lane
+
+Codex should continue executing without pausing for human input when:
+
+- the task scope is clear and bounded
+- the current repo or project context matches the intended target
+- there is no meaningful ambiguity about the requested outcome
+- a validation path is available and the relevant checks pass
+- no security-, policy-, release-, tag-, or merge-sensitive decision is required
+
+This is a low-risk execution lane. It is not a reason to widen scope, reinterpret intent, or take ownership of human-gated decisions.
+
+## Stop Conditions
+
+Codex should pause and ask for human input when:
+
+- the repo or project context appears to be wrong or mismatched
+- the requested scope is ambiguous or appears to have shifted
+- more than one valid implementation path exists and the choice depends on human judgment
+- validation fails in a way that suggests broader changes than the requested task
+- the next step is a merge, release, or tag decision
+- the work touches sensitive auth, secrets, permissions, or policy interpretation
+
 ## PR Expectations
 
 - keep PRs phase-shaped and reviewable


### PR DESCRIPTION
## Summary
- add a small Codex-specific autonomous-lane rule for low-risk execution without extra pauses
- add explicit stop conditions that preserve human-gated merge, release, and tag decisions
- tighten the review packet so Codex summarizes objective, scope, validation, risks, and a clear recommendation

## Review Packet
- Objective: refine the playbook so Codex can continue through low-risk work with fewer human interruptions while keeping clear stop conditions and human-gated decisions intact
- Scope: updated `docs/tool-adapters/codex.md` and `docs/review-packet.md`; did not add workflow phases or broaden the core model
- Validation: internal consistency review across touched docs, verified linked doc targets exist, and ran `git diff --check`
- Risks: this is documentation-only guidance, so the main risk is interpretation drift if future adapters diverge
- Recommendation: ready to merge
