### PR TITLE
[codex] docs: clarify repo naming context

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -75,6 +75,7 @@ When behavior or supported capability changes, quickly check the existing docs f
 
 - use a fresh branch for each lifecycle phase after merge
 - keep commit messages and PR titles clear and phase-oriented
+- adapt branch, commit, and PR naming to repo context: in playbook or workflow repos, use Codex-explicit naming such as `codex/<topic>` and `[codex] docs: ...` to make automation-driven changes obvious; in product or implementation repos, follow standard development naming such as `feat/<topic>`, `fix/<topic>`, `feat: ...`, and `fix: ...`
 - preserve a clean review narrative rather than one long-running branch
 - open a new PR when the work changes phase or review surface
 


### PR DESCRIPTION
Summary
- clarify that Codex should adapt branch, commit, and PR naming to the repository context
- make the playbook/workflow repo naming style explicit alongside standard product repo conventions

Validation
- internal consistency review
- placement reviewed against existing Git and GitHub workflow guidance