### PR TITLE
[codex] docs: tighten repo-state hygiene guidance

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -16,7 +16,7 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - before making changes, confirm the current Codex project or working context matches the intended task target
 - if the task appears to target a different repository, a new repository, or a cross-repo comparison while the current context is repo-scoped, pause and confirm with the human before proceeding
 - keep this lightweight for normal same-repo work; a quick sanity check is enough
-- at the start of repo-scoped work, inspect the current git state; if the branch maps to a merged PR and the working tree is clean, switch to `main` and update from the remote before continuing; if the tree is not clean, the branch is still active, or the state is unclear, pause and report rather than forcing cleanup
+- at the start of repo-scoped work, inspect the current git state; for new repo-scoped work, default to clean, updated `main`; do not start a new arc from an existing feature branch just because the working tree is clean; only remain on or reuse the current branch when the task explicitly says to continue that branch or PR; if the current branch is not `main` and the task does not explicitly continue it, normalize to `main` before creating a new branch when it is safe to do so; if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
 
 ## Local Permissions Model
 


### PR DESCRIPTION
## Summary
- tighten the start-of-task repo-state guidance in the Codex adapter
- make new repo-scoped work default to clean, updated `main`
- clarify that an existing feature branch is reused only when the task explicitly says to continue that branch or PR

## Validation
- internal consistency review of `docs/tool-adapters/codex.md`
- confirmed the updated wording still aligns with the existing project-context and git workflow guidance

## Notes
- wording-only change in `docs/tool-adapters/codex.md`