### PR TITLE
[codex] docs: refine PR lifecycle hygiene

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -65,6 +65,7 @@ Codex should pause and ask for human input when:
 - summarize intent, scope, validation, and known risks
 - make PRs ready for review by default when the phase objective is met
 - use draft PRs only for intentionally incomplete work or early feedback
+- when refining an active PR within the same arc, update the existing branch and PR rather than opening a new PR; open a new PR only when the work changes phase, scope, or review surface
 - avoid bundling unrelated cleanup into the same PR
 - before calling the work complete, verify the PR diff contains only the intended arc; if `main` moved underneath the branch and overlap occurred, sync with current `main`, resolve conflicts, and rerun validation; if the branch carries unrelated history, rebuild the work onto a clean branch from current `main`
 


### PR DESCRIPTION
## Summary
- add a concise `PR Expectations` rule to keep in-arc refinement on the existing branch and PR
- reserve new PRs for work that changes phase, scope, or review surface
- keep the update surgical and aligned with the surrounding Codex adapter guidance

## Why
The adapter already distinguishes ready-for-review work, draft PRs, fresh lifecycle phases, and when a new PR is warranted. This wording makes the in-arc refinement case explicit without adding a new section or duplicating the existing branch and diff hygiene guidance.

## Validation
- internal consistency review against the surrounding `PR Expectations` bullets and `Git And GitHub Workflow Notes`
- confirmed the new rule complements the existing `ready for review`, `draft PR`, and `open a new PR when the work changes phase or review surface` guidance