### PR TITLE
[codex] docs: add AGENTS.md and PR template for repo execution

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+# Summary
+
+## What changed
+
+<!-- Briefly describe the change. -->
+
+## Why
+
+<!-- Briefly explain the reason for the change. -->
+
+## Scope check
+
+- [ ] This PR contains one logical change.
+
+## Validation
+
+- [ ] `markdownlint`
+- [ ] Manual review
+
+## Risks / notes
+
+<!-- Optional. -->
+
+## Issue closure
+
+<!-- Add `Closes #<issue number>` when applicable. -->
+
+Closes #<issue number>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,5 +24,3 @@
 ## Issue closure
 
 <!-- Add `Closes #<issue number>` when applicable. -->
-
-Closes #123

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,4 +25,4 @@
 
 <!-- Add `Closes #<issue number>` when applicable. -->
 
-Closes #<issue number>
+Closes #123

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+This repository uses the shared playbook in `docs/` as the canonical source for general workflow rules. This file is the thin repo-local execution layer.
+
+## Repo Scope
+
+- This repo contains reusable AI workflow and playbook guidance.
+- It does not contain implementation code or project-specific automation.
+
+## Start State
+
+- Verify the working directory is `ctrl-alt-keith/ai-workflow-playbook`.
+- Start from fresh `origin/main` unless intentionally continuing an existing branch or PR.
+
+## File Placement Rules
+
+- Put core reusable guidance in `docs/`.
+- Put tool-specific guidance in `docs/tool-adapters/`.
+- Do not add project-specific logic or implementation examples.
+
+## Validation
+
+- CI uses `markdownlint`.
+- Ensure `markdownlint` passes before opening or updating a PR.
+- If no local wrapper exists, run `markdownlint` in a standard way when available or rely on CI.
+
+## Pull Requests
+
+- Keep each PR scoped to one logical change.
+- Include a clear summary and rationale.
+- Include validation notes.
+- Add `Closes #<issue number>` when applicable.
+
+## Playbook Reference
+
+- For general workflow rules, refer to the playbook documents instead of duplicating them here.
+- Start with `docs/core-model.md`, `docs/feature-lifecycle.md`, `docs/alignment-checkpoints.md`, `docs/review-packet.md`, and `docs/tool-adapters/codex.md`.


### PR DESCRIPTION
# Summary

## What changed

- Add a thin `AGENTS.md` with repo-local execution constraints for this playbook repository.
- Add a lightweight `.github/pull_request_template.md` for scoped, validation-aware PRs.

## Why

- Make Codex-driven work in this repository safer and easier without duplicating playbook-level guidance.

## Scope check

- [x] This PR contains one logical change.

## Validation

- [x] Manual review
- [ ] `markdownlint` not available locally in this checkout; repo CI runs the required `markdownlint` check.

## Risks / notes

- Minimal doc-only change.

## Issue closure

Not applicable.
