### PR TITLE
chore: add minimal local validation entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,9 @@ This repository uses the shared playbook in `docs/` as the canonical source for 
 ## Validation
 
 - CI uses `markdownlint`.
+- Use `make check` as the canonical local validation entrypoint.
 - Ensure `markdownlint` passes before opening or updating a PR.
-- If no local wrapper exists, run `markdownlint` in a standard way when available or rely on CI.
+- If `markdownlint` is not installed locally, `make check` should fail clearly and CI remains the enforcing authority.
 
 ## Pull Requests
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: check check-env
+
+check:
+	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
+		echo "Running markdownlint-cli2"; \
+		markdownlint-cli2 "**/*.md"; \
+	elif command -v markdownlint >/dev/null 2>&1; then \
+		echo "Running markdownlint"; \
+		markdownlint "**/*.md"; \
+	else \
+		echo "markdownlint is not installed."; \
+		echo "Install markdownlint-cli2 or markdownlint, then rerun 'make check'."; \
+		exit 1; \
+	fi
+
+check-env:
+	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
+		echo "Found markdownlint-cli2"; \
+	elif command -v markdownlint >/dev/null 2>&1; then \
+		echo "Found markdownlint"; \
+	else \
+		echo "markdownlint is not installed."; \
+		echo "Install markdownlint-cli2 or markdownlint to enable local validation."; \
+		exit 1; \
+	fi


### PR DESCRIPTION
Summary
- add a minimal Makefile with check and check-env targets for repo-local validation
- update AGENTS.md to point contributors and Codex at make check

Why
- provide a simple local wrapper around the existing markdownlint expectation without changing CI behavior
- make missing local tooling fail with clear operator guidance while keeping CI as the enforcing authority

Validation
- make check (fails clearly when markdownlint is not installed locally)
- make check-env (fails clearly when markdownlint is not installed locally)