### PR TITLE
[codex] docs: define lint-safe template placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ This repository uses the shared playbook in `docs/` as the canonical source for 
 - Keep each PR scoped to one logical change.
 - Include a clear summary and rationale.
 - Include validation notes.
-- Add `Closes #<issue number>` when applicable.
+- Add `Closes #[issue number]` when applicable.
 
 ## Playbook Reference
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,9 +1,12 @@
 # Reusable Workflow Prompt Templates
 
 These prompts capture repeatable workflow tasks in a generic, parameterized form.
-Use the placeholders in angle brackets as inputs. Treat the referenced playbook as
-the canonical source for cross-repo workflow rules, and keep repo-local behavior in
-repo-local files such as `AGENTS.md`.
+Use the placeholders shown in each prompt as inputs. In plain-text prompt bodies,
+angle-bracket placeholders are acceptable, but in markdown templates or copied
+instructions prefer lint-safe placeholders such as `[repository]` or backticked
+tokens. Angle-bracket placeholders can be interpreted as inline HTML by markdown
+tooling. Treat the referenced playbook as the canonical source for cross-repo
+workflow rules, and keep repo-local behavior in repo-local files such as `AGENTS.md`.
 
 ## Repo Readiness Audit
 
@@ -238,6 +241,9 @@ Constraints:
 Validation:
 - Verify that each scaffolded file has a clear job and does not duplicate another file.
 - Verify that placeholders and instructions match the repository's real workflow.
+- Verify that markdown-facing placeholders use lint-safe forms such as `[issue number]`
+  or backticked tokens instead of angle-bracket placeholders that markdown tooling
+  can interpret as inline HTML.
 - Verify that release guidance stays human-gated unless the repository already documents automation.
 - Verify that the resulting scaffolding is appropriate for the stated repo type.
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -47,4 +47,4 @@ Human review is for judgment, prioritization, and standards enforcement. It shou
 Before merge:
 
 - the PR diff must contain only the intended arc
-- issue-driven PRs must include `Closes #<issue number>`
+- issue-driven PRs must include `Closes #[issue number]`


### PR DESCRIPTION
Summary:
- define a reusable lint-safe placeholder convention for markdown templates in the shared playbook
- update the playbook's own PR guidance examples to use the approved placeholder form

Why:
- angle-bracket placeholders in markdown can be interpreted as inline HTML and trigger markdownlint MD033
- this standard keeps copied template text readable while avoiding recurring lint friction

Validation:
- make check

Closes #23