### PR TITLE
chore: add minimal .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# macOS
+.DS_Store
+
+# Local worktrees
+.worktrees/


### PR DESCRIPTION
Summary:
- add a minimal root `.gitignore` for macOS metadata files and local worktree directories

Validation:
- make check