### PR TITLE
[codex] docs: capture worktree follow-up lessons

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -49,6 +49,9 @@ Start same-repo arcs from fresh `origin/main`. Do not reuse an old feature branc
 
 When parallel arcs target the same repository, use separate worktrees or otherwise isolated directories. Treat repository identity and execution-context identity as separate checks.
 
+Before starting a same-repo worktree run, inspect existing worktree metadata and
+clear stale entries so an old attempt does not distort the new setup.
+
 The expected pattern is:
 
 1. Merge the current phase
@@ -57,5 +60,9 @@ The expected pattern is:
 4. Complete post-release capture before starting the next major arc
 
 When overlapping PRs touch the same shared surface, merge behavior, workflow, or other source-of-truth changes before formatting, restructuring, or cleanup. Let cleanup absorb the settled state last.
+
+When concurrent PRs have no file overlap and no open review concerns, merge order
+is flexible. Say that explicitly in the review packet instead of inventing a
+false dependency.
 
 Do not roll multiple lifecycle phases into one long-running branch unless there is a strong reason and the review surface remains clear.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -25,12 +25,22 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - for medium or large arcs, verify the working branch is based on current `origin/main` before meaningful edits begin
 - if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
 - when parallel repo-scoped work targets the same repository, use separate worktrees or otherwise isolated directories for each arc, do not run concurrent arcs against the same checkout, and treat each worktree or directory as its own execution container with its own branch, validation run, and PR or review surface
+- before starting a same-repo worktree batch, inspect `git worktree list` and
+  the underlying worktree metadata so stale entries from an earlier attempt do
+  not confuse setup or cleanup
+- when checking a worktree experiment at the end, distinguish the worktrees that
+  belong to the experiment from unrelated pre-existing entries so success does
+  not depend on an artificially empty global worktree list
 
 ## Local Permissions Model
 
 Codex operates inside a local permissions model. Some actions require approval, especially for network access, privileged writes, or potentially destructive commands.
 
 Treat permission boundaries as part of the execution environment, not as incidental friction. If a task depends on elevated access, surface that early and keep the requested action narrowly scoped.
+
+Worktree cleanup can require elevated permission even when the visible worktree
+paths sit inside the repository, because Git also updates internal worktree
+metadata outside the leaf directories being removed.
 
 ## Autonomous Lane
 
@@ -88,6 +98,8 @@ When behavior or supported capability changes, quickly check the existing docs f
 - adapt branch, commit, and PR naming to repo context: in playbook or workflow repos, use Codex-explicit naming such as `codex/<topic>` and `[codex] docs: ...` to make automation-driven changes obvious; in product or implementation repos, follow standard development naming such as `feat/<topic>`, `fix/<topic>`, `feat: ...`, and `fix: ...`
 - preserve a clean review narrative rather than one long-running branch
 - open a new PR when the work changes phase or review surface
+- prefer creating same-repo PRs serially unless parallel creation materially
+  reduces latency and the connector flow is known to be stable
 
 ## Repo Baseline
 


### PR DESCRIPTION
Summary:
- capture reusable same-repo worktree lessons from the second worktree experiment
- document stale-worktree preflight and flexible merge ordering when concurrent PRs have no overlap or open review concerns
- add Codex-specific guidance on worktree metadata checks, cleanup permissions, experiment-specific success checks, and preferring serial PR creation when connector parallelism is less smooth

Why:
- the second worktree experiment completed cleanly and exposed a few practical guardrails worth preserving in the playbook without adding one-off run logs

Validation:
- make check
- passing: markdownlint-cli2 reported 0 errors
