### PR TITLE
[codex] docs: recommend worktrees for same-repo parallel work

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -47,10 +47,16 @@ After each merged phase, start a new branch and PR for the next lifecycle phase.
 
 Start same-repo arcs from fresh `origin/main`. Do not reuse an old feature branch unless intentionally continuing that PR.
 
-When parallel arcs target the same repository, use separate worktrees or otherwise isolated directories. Treat repository identity and execution-context identity as separate checks.
+For same-repo parallel work, prefer isolated Git worktrees over multiple arcs
+sharing one checkout. Keep the main checkout clean and on `main`, fetch before
+creating task worktrees so `origin/main` is current, create one worktree per
+issue or task from that current `origin/main`, and do the issue work only
+inside its worktree.
 
 Before starting a same-repo worktree run, inspect existing worktree metadata and
-clear stale entries so an old attempt does not distort the new setup.
+clear stale entries so an old attempt does not distort the new setup. After
+merge, clean up the experiment or task worktrees that were created for that run
+without treating unrelated pre-existing worktrees as cleanup failures.
 
 The expected pattern is:
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -24,7 +24,7 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - if the active worktree or directory is not on up-to-date `main`, switch or recreate the branch from current `origin/main` before making changes
 - for medium or large arcs, verify the working branch is based on current `origin/main` before meaningful edits begin
 - if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
-- when parallel repo-scoped work targets the same repository, use separate worktrees or otherwise isolated directories for each arc, do not run concurrent arcs against the same checkout, and treat each worktree or directory as its own execution container with its own branch, validation run, and PR or review surface
+- when parallel repo-scoped work targets the same repository, prefer one worktree per issue or task from current `origin/main`; keep the main checkout clean and on `main`, do not run concurrent arcs against the same checkout, and treat each worktree as its own execution container with its own branch, validation run, and PR or review surface
 - before starting a same-repo worktree batch, inspect `git worktree list` and
   the underlying worktree metadata so stale entries from an earlier attempt do
   not confuse setup or cleanup
@@ -98,8 +98,9 @@ When behavior or supported capability changes, quickly check the existing docs f
 - adapt branch, commit, and PR naming to repo context: in playbook or workflow repos, use Codex-explicit naming such as `codex/<topic>` and `[codex] docs: ...` to make automation-driven changes obvious; in product or implementation repos, follow standard development naming such as `feat/<topic>`, `fix/<topic>`, `feat: ...`, and `fix: ...`
 - preserve a clean review narrative rather than one long-running branch
 - open a new PR when the work changes phase or review surface
-- prefer creating same-repo PRs serially unless parallel creation materially
-  reduces latency and the connector flow is known to be stable
+- for same-repo worktree batches, prefer opening PRs serially unless parallel
+  creation materially reduces latency and the connector flow is known to be
+  stable
 
 ## Repo Baseline
 


### PR DESCRIPTION
Summary:
Promote isolated Git worktrees as the recommended pattern for same-repo parallel Codex work.

Why:
Capture the validated worktree experiment as concise reusable playbook guidance while keeping it advisory rather than mandatory.

Validation:
- make check