### PR TITLE
[codex] clarify same-repo worktree reuse and cleanup

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -56,9 +56,18 @@ issue or task from that current `origin/main`, and do the issue work only
 inside its worktree.
 
 Before starting a same-repo worktree run, inspect existing worktree metadata and
-clear stale entries so an old attempt does not distort the new setup. After
-merge, clean up the experiment or task worktrees that were created for that run
-without treating unrelated pre-existing worktrees as cleanup failures.
+clear stale entries so an old attempt does not distort the new setup. Reuse an
+existing same-repo worktree only when it is clearly the same active issue, PR,
+or arc and its state is still clean and intelligible; otherwise recreate from
+current `origin/main`, especially when the worktree belongs to a different arc,
+the state is stale or unclear, or cleanup and recovery would be more confusing
+than starting fresh. Bias toward clarity over clever reuse.
+
+After merge, cleanup succeeds when the experiment or task worktrees created for
+that run are removed or clearly accounted for. Do not treat unrelated
+pre-existing worktrees as cleanup failures. If removal is blocked or deferred,
+report that clearly, avoid deleting unrelated worktrees, and leave the repo in
+a known, intelligible state.
 
 The expected pattern is:
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -30,9 +30,20 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - before starting a same-repo worktree batch, inspect `git worktree list` and
   the underlying worktree metadata so stale entries from an earlier attempt do
   not confuse setup or cleanup
+- reuse an existing same-repo worktree only when it is clearly the same active
+  issue, PR, or arc and its state is still clean and intelligible; otherwise
+  recreate from current `origin/main`, with a bias toward clarity over clever
+  reuse
+- recreate rather than recover when the worktree belongs to a different arc,
+  the state is stale or unclear, or cleanup and recovery would be more
+  confusing than starting fresh
 - when checking a worktree experiment at the end, distinguish the worktrees that
   belong to the experiment from unrelated pre-existing entries so success does
   not depend on an artificially empty global worktree list
+- treat worktree cleanup as successful when the experiment or task worktrees
+  created for that run are removed or clearly accounted for
+- if removal is blocked or deferred, report it clearly, avoid deleting
+  unrelated worktrees, and leave the repo in a known, intelligible state
 
 ## Local Permissions Model
 


### PR DESCRIPTION
Summary:
- clarify when an existing same-repo worktree should be reused versus recreated
- define practical successful cleanup outcomes when worktree removal is blocked or deferred
- keep the guidance concise across the lifecycle and Codex adapter docs

Why:
- issues #37 and #38 refine the same worktree guidance seam and read more cleanly as one small documentation pass

Validation:
- make check

Closes #37
Closes #38