### PR TITLE
docs: tighten GitHub scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/lightweight-issue.md
+++ b/.github/ISSUE_TEMPLATE/lightweight-issue.md
@@ -1,0 +1,22 @@
+---
+name: Lightweight issue
+about: Capture a small, scoped improvement.
+---
+
+# Lightweight issue
+
+## Summary / description
+
+<!-- Optional: what needs attention? -->
+
+## Why it matters
+
+<!-- Optional: why is this worth doing? -->
+
+## Proposed scope
+
+<!-- Optional: keep this narrow and avoid over-specifying the solution. -->
+
+## Acceptance criteria
+
+<!-- Optional: list the outcomes that would make this done. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,4 +23,4 @@
 
 ## Issue closure
 
-<!-- Add `Closes #<issue number>` when applicable. -->
+<!-- Add `Closes #[issue number]` when applicable. -->


### PR DESCRIPTION
Summary:
- add one lightweight issue template for small, scoped repo follow-ups
- update the PR template issue-closure comment to the current lint-safe placeholder form

Why:
- align the repo-local GitHub scaffolding with the current playbook guidance
- keep issue and PR intake minimal without adding heavier process

Validation:
- make check

Closes #41