### PR TITLE
docs: add deferred note issue-promotion guidance

### DIFF
--- a/docs/notes-repositories.md
+++ b/docs/notes-repositories.md
@@ -27,6 +27,49 @@ Keep material in notes when it is still one or more of the following:
 
 Notes are allowed to be early, messy, and local. The playbook is not.
 
+## Working States
+
+Use these states to keep capture, defer, repo action, and playbook promotion
+separate:
+
+- Raw notes: fresh capture, partial observations, and rough ideas that are not
+  ready to guide action yet
+- Deferred ideas: notes worth revisiting later, but still too broad,
+  speculative, duplicated, or blocked to become repo work now
+- Bounded repo issues: action-ready work for a specific repository with a clear
+  scope, value, and acceptance shape
+- Playbook candidates: validated lessons that may later become reusable
+  cross-repo guidance after repo work proves the pattern
+
+Do not treat these states as a conveyor belt where every note must advance.
+Many notes should stay raw, many ideas should stay deferred, and only a narrow
+subset should become repo issues or playbook guidance.
+
+## Deferred Work Promotion
+
+Promote deferred notes into GitHub issues only when at least one of the
+following is true:
+
+- the same friction, gap, or cleanup need shows up repeatedly
+- the value is clear enough that repo-local action is justified now
+- the work is ready to be scoped, assigned, and validated in a specific repo
+
+Keep the item as a deferred idea when it is still mostly brainstorming,
+duplicate with existing backlog items, blocked on outside decisions, or too
+large to describe as one bounded change.
+
+When promotion is justified:
+
+- group related notes into one issue by theme instead of filing one issue per
+  line item
+- target the repository that would actually own the work
+- write the issue so it can be completed in a focused PR or short arc
+- include acceptance criteria that show what done looks like
+
+Do not create issues for every interesting thought immediately. Use notes for
+capture, use deferred ideas for backlog staging, and create repo issues only
+when the work is concrete enough to support action.
+
 ## Promotion Criteria
 
 Promote notes into the playbook when the guidance is:
@@ -46,9 +89,11 @@ context, keep refining it in notes instead of promoting it early.
 Use this general sequence:
 
 1. Capture the emerging pattern in notes while the work is fresh.
-2. Tighten the wording until the guidance is reusable and actionable.
-3. Promote the reusable rule into the playbook as the canonical version.
-4. Update or trim the notes so they no longer compete with the promoted source.
+2. Defer, group, or trim ideas that are not ready for action yet.
+3. Promote only action-ready, repo-local work into bounded repository issues.
+4. Tighten validated reusable guidance until it is ready for the playbook.
+5. Promote the reusable rule into the playbook as the canonical version.
+6. Update or trim the notes so they no longer compete with the promoted source.
 
 Promotion should move the durable guidance, not copy the entire notes history.
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -18,6 +18,7 @@ tooling.
 - [Repo Readiness Audit](#repo-readiness-audit)
 - [Playbook Update](#playbook-update)
 - [Notes vs Playbook Alignment Audit](#notes-vs-playbook-alignment-audit)
+- [Deferred Notes Issue Promotion](#deferred-notes-issue-promotion)
 - [AGENTS Update](#agents-update)
 - [Workflow Scaffolding](#workflow-scaffolding)
 - [PR Creation](#pr-creation)
@@ -230,6 +231,97 @@ Output format:
 This audit is for cleanup, not promotion. Run it after promotion work, then use a
 follow-up re-audit to confirm the notes set has converged on the playbook as the
 canonical source.
+
+## Deferred Notes Issue Promotion
+
+### Deferred Notes Issue Promotion Use When
+
+Use this prompt when notes or deferred ideas should be reviewed for possible
+promotion into bounded GitHub issues without turning every captured thought into
+backlog work.
+
+### Deferred Notes Issue Promotion Required Inputs
+
+- `source_material_root`
+- `target_repositories`
+- `duplicate_check_scope` (for example open issues, recent closed issues, or a
+  named backlog board)
+- `arc_suggestions` (optional; use `none` when not needed)
+
+### Deferred Notes Issue Promotion Repo-Type Notes
+
+- The source material stays a staging layer, not a commitment queue.
+- Target repositories own actionable issues only when the work is ready for a
+  bounded repo change.
+- Cross-repo workflow lessons should remain playbook candidates until validated
+  by repo work; do not skip straight from raw notes to playbook updates.
+
+### Deferred Notes Issue Promotion Prompt
+
+```text
+Task:
+Review deferred notes and propose or create bounded GitHub issues where the
+work is ready.
+
+Inputs:
+- Source material / notes root: [source_material_root]
+- Target repository or repositories: [target_repositories]
+- Duplicate check scope: [duplicate_check_scope]
+- Optional arc suggestions: [arc_suggestions]
+
+Instructions:
+- Review the source material inside [source_material_root] and identify notes
+  or deferred ideas that may be ready for issue promotion.
+- Distinguish among raw notes, deferred ideas, bounded repo issues, and
+  playbook candidates.
+- Keep raw notes as raw notes when they are still capture, rough thinking, or
+  incomplete observations.
+- Keep items as deferred ideas when they are still speculative, blocked,
+  duplicated, or too broad for one bounded repo change.
+- Promote an item into a bounded repo issue only when repeated friction, clear
+  value, or readiness for action makes repo work justified now.
+- Check [duplicate_check_scope] before proposing or creating any issue.
+- Group closely related notes by theme instead of creating one issue per line
+  item.
+- For each proposed issue, name the owning repository, define a narrow scope,
+  and include concise acceptance criteria.
+- When useful, suggest an optional arc that groups several related issues into
+  a coherent sequence, but do not force arc structure when standalone issues are
+  clearer.
+- Identify playbook candidates separately when the note points to a possible
+  reusable rule that still needs repo validation before promotion.
+
+Constraints:
+- Do not create issues for every interesting idea.
+- Do not reopen duplicate or already-covered backlog items.
+- Do not turn vague themes into oversized umbrella issues.
+- Do not treat deferred-note triage as a general backlog-management rewrite.
+- Keep recommendations concise, operational, and tied to visible source
+  material.
+
+Validation:
+- Verify that each proposed or created issue maps to a specific repository.
+- Verify that each issue is small enough to support a focused PR or short arc.
+- Verify that acceptance criteria describe what done looks like.
+- Verify that grouped items belong together and are not masking unrelated work.
+- Verify that any playbook candidate is called out separately from repo issue
+  promotion.
+
+Output format:
+1. Triage summary: one short paragraph.
+2. Keep deferred: short bullets for items that should remain notes or deferred
+   ideas.
+3. Proposed or created issues: short bullets with repository, scope,
+   acceptance criteria, and duplicate-check result.
+4. Optional arcs: short bullets only when grouping adds real clarity.
+5. Playbook candidates: optional bullets for reusable lessons that should wait
+   for repo validation.
+```
+
+### Deferred Notes Issue Promotion Notes
+
+Use this prompt to decide when deferred material should become repo work. Use
+the notes cleanup audit separately after promotion or implementation work lands.
 
 ## AGENTS Update
 


### PR DESCRIPTION
Summary:
- add concise notes lifecycle guidance for when raw notes or deferred ideas should become bounded repo issues
- clarify the separation between raw notes, deferred ideas, bounded repo issues, and playbook candidates
- add a reusable deferred-notes issue-promotion prompt in `docs/prompts.md`

Validation:
- make check

Closes #45
Closes #46