### PR TITLE
[codex] docs: clarify GitHub workflow state handling

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -30,6 +30,7 @@ Prefer semantic assertions over formatting-sensitive assertions when formatting 
 Build only what is needed to satisfy the contract. Keep feedback loops short and avoid mixing extra polish into the first pass.
 
 For same-repo runs, anchor implementation to one fetched `origin/main` snapshot at task start and treat that snapshot as the canonical base for the duration of the run. Check mergeability against current `main` at the end as a separate release-readiness concern rather than repeatedly re-anchoring mid-run.
+A clean local branch at the end means the run stayed coherent against that anchored base; it does not by itself prove that a remote PR is still mergeable after `main` moves.
 
 ### Hardening
 
@@ -38,6 +39,7 @@ Address edge cases, refactors, failure handling, review findings, and CI quality
 ### Release
 
 Prepare the work to ship with a clean review packet, validation evidence, and any final release checks. If the repo does not have a formal validation path yet, record the lightweight validation that was used instead.
+If GitHub shows `BLOCKED` or pending status at this stage, check the underlying cause before reacting: pending checks or reviews usually mean wait, while failed required checks or true merge conflicts require action.
 
 ### Capture
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -24,7 +24,9 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - if the active worktree or directory is not on up-to-date `main`, switch or recreate the branch from current `origin/main` before making changes
 - for medium or large arcs, verify the working branch is based on current `origin/main` before meaningful edits begin
 - after the run, check whether the resulting branch or PR is still mergeable against current `main`; if upstream moved in the meantime, treat that as a final-state mergeability check rather than a reason to restart or rebase mid-run by default
+- distinguish local execution state from remote PR state: a clean local branch means the run completed cleanly against its anchored base, while GitHub mergeability reflects the current remote state after newer `main` movement, required checks, and review requirements
 - make exceptions only when the task explicitly requires rebasing or when a real conflict or blocker appears that prevents finishing the requested work cleanly
+- do not treat transient GitHub `BLOCKED` or pending states as mid-run failures by default; inspect whether the cause is pending checks, pending review requirements, dependency ordering, or a true merge conflict, then wait or act accordingly
 - if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
 - when parallel repo-scoped work targets the same repository, prefer one worktree per issue or task from current `origin/main`; keep the main checkout clean and on `main`, do not run concurrent arcs against the same checkout, and treat each worktree as its own execution container with its own branch, validation run, and PR or review surface
 - before starting a same-repo worktree batch, inspect `git worktree list` and
@@ -97,6 +99,7 @@ Codex should pause and ask for human input when:
 - keep PRs phase-shaped and reviewable
 - summarize intent, scope, validation, and known risks
 - make PRs ready for review by default when the phase objective is met
+- before recommending merge readiness on an existing PR, confirm current remote mergeability and required checks rather than relying on local branch cleanliness alone
 - use draft PRs only for intentionally incomplete work or early feedback
 - when refining an active PR within the same arc, update the existing branch and PR rather than opening a new PR; open a new PR only when the work changes phase, scope, or review surface
 - avoid bundling unrelated cleanup into the same PR


### PR DESCRIPTION
Summary:
- clarify that a clean local run and a mergeable remote PR are related but distinct states
- add a short rule for interpreting transient GitHub `BLOCKED` or pending states without overreacting
- reinforce start-state anchoring to `origin/main` and end-of-run mergeability checks without recommending mid-run rebases

Validation:
- make check

Closes #47
Closes #48