### PR TITLE
docs: add repo-readiness baseline

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -1,0 +1,70 @@
+# Repo Readiness Baseline
+
+## Purpose
+
+Define the smallest reusable baseline a repository should have before normal AI-assisted delivery work begins.
+
+## Scope
+
+- This is a practical baseline, not a full policy or checklist.
+- It covers pull request flow, readiness state, validation, branch protection expectations, and the role of `AGENTS.md`.
+- Repo-specific security, compliance, release, or approval rules should be defined only when needed by that repository.
+
+## Baseline Expectations
+
+- All changes go through pull requests.
+- Validation must pass before a pull request is considered complete.
+- Pull requests should stay small, scoped, and single-purpose.
+- Defaults should favor safe, explicit behavior over implied shortcuts.
+
+## PR Readiness
+
+Open a pull request as ready for review when all of the following are true:
+
+- implementation is complete
+- validation passes
+- no known follow-up work is required before merge
+- overlap and coordination risk are low
+
+Open a pull request as draft when any of the following are true:
+
+- work is incomplete
+- the change is part of a coordinated batch with sequencing risk
+- reconciliation with other pending work is likely
+- the branch is intentionally staged for later promotion
+
+Docs-only changes should default to ready for review when they are validated and isolated.
+
+## Branch Protection
+
+Treat the following as the default branch protection baseline for `main`:
+
+- pull requests are required for changes to `main`
+- the repository validation check is required, typically `make check` or an equivalent single entrypoint
+- admins follow the same merge rules
+- required approvals are not part of the default baseline unless a repository defines stricter repo-specific rules
+
+This document defines expectations, not exact GitHub settings.
+
+## AGENTS.md Responsibilities
+
+`AGENTS.md` should stay thin and repo-specific. It should define:
+
+- repo-local execution rules
+- the canonical validation entrypoint, typically `make check`
+- branch or commit conventions that are specific to the repository
+- repo-specific constraints, boundaries, or file placement rules
+
+Reusable workflow rules belong in the playbook, not duplicated into each repository's `AGENTS.md`.
+
+## Validation
+
+- `make check` is the canonical validation entrypoint when the repository provides one.
+- CI is the enforcement layer.
+- Local validation should match CI behavior as closely as practical.
+
+## Notes
+
+- Repositories can add stricter rules, but they should start from a small default baseline.
+- Keep this baseline easy to apply and easy to explain.
+- Use more specific playbook docs only when the repository needs guidance beyond these primitives.


### PR DESCRIPTION
## Summary
- add a compact repo-readiness baseline to the playbook
- define the minimal shared expectations for PR readiness, branch protection, validation, and AGENTS.md

## Why
- capture missing primitives that were drifting across repos
- reduce cross-repo drift without turning this into a full policy or checklist
- keep the baseline small, reusable, and easy to apply

## Validation
- make check