### PR TITLE
docs: clarify PR readiness issue semantics

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -25,6 +25,7 @@ Open a pull request as ready for review when all of the following are true:
 - validation passes
 - no known follow-up work is required before merge
 - overlap and coordination risk are low
+- issue lifecycle should not affect pull request readiness; using `Closes #<issue>` follows standard GitHub behavior and should not delay marking a pull request as ready
 
 Open a pull request as draft when any of the following are true:
 


### PR DESCRIPTION
## Summary
- add a small clarification to the repo-readiness PR readiness baseline
- note that standard GitHub issue-closing behavior with   `Closes #<issue>` should not delay PR readiness

## Context
A PR was opened as draft due to uncertainty about issue lifecycle behavior. This change clarifies that issue-closing semantics are standardized and should not affect whether a PR is marked ready.

## Scope
This is a clarification only; it does not expand the playbook into issue-management guidance.

## Validation
- `make check`