### PR TITLE
[codex] docs: promote destination boundary guidance

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -64,6 +64,7 @@ Codex should continue executing without pausing for human input when:
 - the task scope is clear and bounded
 - the current repo or project context matches the intended target
 - there is no meaningful ambiguity about the requested outcome
+- when working on destination layers, keep publish behavior explicit and scoped; avoid expanding capabilities such as updates, sharing, or permissions unless the task requires it
 - a validation path is available and the relevant checks pass
 - no security-, policy-, release-, tag-, or merge-sensitive decision is required
 


### PR DESCRIPTION
Summary
- promote the destination-boundary constraint into the playbook as a reusable cross-repo rule
- keep the addition to a single bullet in the Codex adapter guidance

Validation
- make check