### PR TITLE
docs: align validation guidance with make targets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 
 ## Validation
 
-- [ ] `markdownlint`
+- [ ] `make check`
 - [ ] Manual review
 
 ## Risks / notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,9 @@ This repository uses the shared playbook in `docs/` as the canonical source for 
 
 - CI uses `markdownlint`.
 - Use `make check` as the canonical local validation entrypoint.
-- Ensure `markdownlint` passes before opening or updating a PR.
+- Run `make check` before opening or updating a PR.
+- Treat direct `markdownlint` invocation as an implementation detail of the
+  Makefile target.
 - If `markdownlint` is not installed locally, `make check` should fail clearly and CI remains the enforcing authority.
 
 ## Pull Requests


### PR DESCRIPTION
## Summary
- Update repo-local validation guidance to run `make check` before PR work.
- Mark direct `markdownlint` invocation as a Makefile implementation detail.
- Update the PR template validation checklist to use `make check`.

## Validation
- `make check`