### PR TITLE
[codex] docs: require PR delivery for implementation tasks

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -88,6 +88,17 @@ do not open a PR, or draft this but do not ship it.
 
 Passing checks validates the change; opening the PR delivers it.
 
+For implementation tasks, treat PR delivery as required by default. Use a
+focused branch, stage only the relevant changes, create a clear commit, push
+the branch, open the PR against the intended base branch, usually `main`, and
+report the PR link, changed files, and validation results when closing out the
+task.
+
+For exploration, design, or review-only tasks that do not change repo files,
+stop after the findings or recommendations unless the request also asks for
+shipped changes. If those tasks do produce repo changes, follow the same
+branch, validation, and PR flow before calling them complete.
+
 For mixed-purpose repos that contain code, docs, tests, and release or
 workflow content, keep purpose-based branch prefixes such as `feat/`, `fix/`,
 `docs/`, `chore/`, `refactor/`, and `test/`. Reserve broad tool-oriented

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -22,6 +22,7 @@ tooling.
 - [Deferred Notes Issue Promotion](#deferred-notes-issue-promotion)
 - [AGENTS Update](#agents-update)
 - [Workflow Scaffolding](#workflow-scaffolding)
+- [Implementation Delivery Footer](#implementation-delivery-footer)
 - [PR Creation](#pr-creation)
 
 ## Context Refresh Primitive
@@ -459,6 +460,31 @@ Output format:
 
 Prefer a minimal baseline that can be extended later over an elaborate template set that no one will keep current.
 
+## Implementation Delivery Footer
+
+### Implementation Delivery Footer Use When
+
+Append this footer to implementation prompts when the task is expected to make
+repo changes and deliver them through the normal branch, commit, push, and PR
+flow.
+
+### Implementation Delivery Footer Do Not Use When
+
+Do not append this footer for exploration, design, or review-only tasks unless
+they are also expected to make and deliver repo changes.
+
+### Implementation Delivery Footer Snippet
+
+```text
+Delivery:
+- Create a focused branch.
+- Stage only the relevant changes.
+- Commit with a clear message.
+- Push the branch.
+- Open a PR against the intended base branch, usually `main`.
+- Report the PR link, files changed, and validation results.
+```
+
 ## PR Creation
 
 ### PR Creation Use When
@@ -520,3 +546,6 @@ Output format:
 ### PR Creation Notes
 
 This prompt is for packaging existing work cleanly, not for doing the implementation itself.
+For implementation prompts that are expected to ship repo changes, append the
+Implementation Delivery Footer instead of assuming branch and PR delivery are
+implied.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -100,6 +100,17 @@ Codex should pause and ask for human input when:
 - keep PRs phase-shaped and reviewable
 - summarize intent, scope, validation, and known risks
 - make PRs ready for review by default when the phase objective is met
+- for implementation tasks that change repo files, do not stop at local edits
+  and local validation; finish the delivery path by using a focused branch,
+  staging only the relevant changes, creating a clear commit, pushing, and
+  opening or updating the PR against the intended base branch, usually `main`
+- when reporting completion for implementation tasks, include the PR link,
+  files changed, and validation results
+- for exploration, design, audit, or review-only tasks, do not force a PR when
+  no repo changes are required; report findings, recommendations, and any
+  validation or evidence gathered instead
+- if an exploration, design, audit, or review-only task produces repo changes,
+  switch back to the implementation delivery path before calling it complete
 - before recommending merge readiness on an existing PR, confirm current remote mergeability and required checks rather than relying on local branch cleanliness alone
 - use draft PRs only for intentionally incomplete work or early feedback
 - when refining an active PR within the same arc, update the existing branch and PR rather than opening a new PR; open a new PR only when the work changes phase, scope, or review surface


### PR DESCRIPTION
Summary
- reinforce in the feature lifecycle that implementation work is not done until branch, commit, push, and PR delivery are complete
- add a reusable implementation delivery footer for prompts that are expected to ship repo changes
- clarify in the Codex adapter that implementation tasks require PR delivery, while exploration and review-only tasks do not unless they create repo changes

Validation
- make check