### PR TITLE
[codex] Clarify non-draft PR footer default

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -589,7 +589,7 @@ Delivery:
 - Stage only the relevant changes.
 - Commit with a clear message.
 - Push the branch.
-- Open a PR against the intended base branch, usually `main`.
+- Open a non-draft PR against the intended base branch, usually `main`, unless a draft PR is explicitly requested.
 - Report the PR link, files changed, and validation results.
 ```
 


### PR DESCRIPTION
## Summary
- Update the reusable Implementation Delivery Footer to require opening a non-draft PR by default.
- Preserve the draft PR exception when explicitly requested.

## Why
This makes the footer align with the playbook's existing PR expectations and prevents regressions where Codex opens draft PRs unintentionally.

## Validation
- `make check`