### PR TITLE
[codex] Align Codex workflow prompt example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This repository uses the shared playbook in `docs/` as the canonical source for 
 ## Pull Requests
 
 - Keep each PR scoped to one logical change.
+- Open PRs as non-draft when the work is complete unless explicitly instructed otherwise.
 - Include a clear summary and rationale.
 - Include validation notes.
 - Add `Closes #[issue number]` when applicable.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -126,20 +126,23 @@ Scope:
 - Do not redesign the settings page or introduce a new state-management layer.
 
 Constraints:
-- Preserve existing preference behavior.
-- Avoid unrelated cleanup.
+- Do not include unrelated changes or opportunistic cleanup.
+- Preserve existing preference behavior unless explicitly required.
 - Keep copy and controls consistent with the current interface.
+- Report blockers or incomplete work instead of skipping required steps.
 
 Tasks:
 1. Inspect the settings implementation and tests.
-2. Add the new preference through the existing path.
+2. Add the new preference through the smallest existing path.
 3. Update focused tests or docs if needed.
 
 Validation:
 - Run `make check`.
+- Report the actual result, including failure details if it fails.
 
 Deliverable:
-- Push a focused branch and open a PR with summary and validation notes.
+- Open a non-draft PR against `main` with summary, validation results, and
+  residual risks.
 ```
 
 ### Model Selection And Cost Guidance


### PR DESCRIPTION
## Summary of findings
- The hardened Codex Task Prompt Template was aligned, but the adjacent example still reflected older, looser prompt behavior.
- The repo-local AGENTS PR guidance did not explicitly state the non-draft default now expected for complete work.

## What was fixed
- Updated the Codex task prompt example to show scoped-change constraints, actual validation reporting, and non-draft PR delivery.
- Added a concise AGENTS.md PR expectation for non-draft PRs when work is complete unless explicitly instructed otherwise.

## Intentionally left unchanged
- No other prompt templates were changed.
- No playbook structure or new workflow concepts were added.

## Validation
- Passed: `make check` (markdownlint-cli2 v0.22.1, 20 files, 0 errors).
- Passed: `git diff --check`.

## Residual gaps
- Low: this is documentation-only alignment; future real prompts still depend on users copying the hardened template.
