### PR TITLE
[codex] Align CI with make check

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v20
-        with:
-          globs: |
-            **/*.md
+      - name: Install markdownlint-cli2
+        run: npm install --global markdownlint-cli2
+
+      - name: Run checks
+        run: make check

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -15,6 +15,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
       - name: Install markdownlint-cli2
         run: npm install --global markdownlint-cli2
 


### PR DESCRIPTION
## Summary

- Replace the direct markdownlint action invocation with an explicit markdownlint-cli2 install step.
- Run `make check` in CI so pull requests and pushes exercise the same validation entrypoint used locally.

## Validation

- `make check`

Closes #81