### PR TITLE
docs: add playbook start-here entry point

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -20,10 +20,10 @@
 ## Notes vs Playbook
 
 - `cross-repo-threads` is a staging layer for ideas and experiments.
-- It is not canonical; always verify against repo state and playbook guidance.
+- It is not canonical; treat repository code, tests, and docs as the source of truth and verify against playbook guidance.
 
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
 - Validate with the repo's Makefile.
-- Open PRs ready for review by default.
+- Open PRs ready for review by default unless explicitly instructed otherwise.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,0 +1,29 @@
+# Start Here
+
+## Purpose
+
+- This playbook defines the canonical workflow for AI-assisted repository work.
+- Use this page to quickly orient before performing tasks.
+
+## Read Order
+
+- `docs/engineering-baseline.md` -> foundational engineering expectations
+- `docs/repo-readiness.md` -> repository workflow expectations
+- `docs/prompts.md` -> reusable prompt templates
+
+## Execution Model
+
+- Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
+- Treat `AGENTS.md` as the repo-local execution layer.
+- Repo-local rules override playbook rules when they differ.
+
+## Notes vs Playbook
+
+- `cross-repo-threads` is a staging layer for ideas and experiments.
+- It is not canonical; always verify against repo state and playbook guidance.
+
+## Rule of Thumb
+
+- Prefer small, scoped changes.
+- Validate with the repo's Makefile.
+- Open PRs ready for review by default.


### PR DESCRIPTION
## Summary

- Add `docs/start-here.md` as a concise entry point for agents using the playbook.
- Point readers to the foundational docs in the intended read order.
- Clarify the relationship between the reusable playbook, repo-local `AGENTS.md`, and notes staging areas.

## Validation

- `make check`