### PR TITLE
[codex] Clarify repo-local precedence

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -15,7 +15,7 @@
 
 - Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
 - Treat `AGENTS.md` as the repo-local execution layer.
-- Repo-local rules override playbook rules when they differ.
+- Repo-local rules take precedence only for repo-specific behavior.
 
 ## Notes vs Playbook
 


### PR DESCRIPTION
## Summary

- Updated `docs/start-here.md` to state that repo-local rules take precedence only for repo-specific behavior.

## Rationale

The previous wording implied that repo-local `AGENTS.md` files could broadly override the playbook. This aligns the start-here guidance with the intended authority model: the playbook remains the canonical reusable workflow source, while repo-local files act only as execution layers for repository-specific behavior.

## Validation

- Fetched `origin/main`
- Created `codex/repo-local-precedence` from `origin/main`
- Confirmed only `docs/start-here.md` changed
- Ran `make check` successfully