### PR TITLE
[codex] Add linode-image-lab to repo inventory

### DIFF
--- a/docs/context-refresh.md
+++ b/docs/context-refresh.md
@@ -49,6 +49,7 @@ Working Context:
   - knowledge-adapters
   - ai-workflow-playbook
   - ka-destinations
+  - linode-image-lab
 - Local notes layer:
   - cross-repo-threads
   - reference only
@@ -117,10 +118,11 @@ For each repo, provide:
 - current focus (top 1-2 items only, or unknown if not verifiable)
 
 6. Produce Cross-Repo Health
-Assess whether the org still has a clean three-layer model:
+Assess whether the org still has clean repo boundaries:
 - knowledge-adapters = ingestion
 - ka-destinations = publishing
 - ai-workflow-playbook = guidance
+- linode-image-lab = public-safe Linode image freeze/thaw workflow lab
 
 Call out only meaningful drift, overlap, or ambiguity.
 Maximum 3 bullets.
@@ -155,11 +157,13 @@ Output Format (strict):
 - knowledge-adapters:
 - ai-workflow-playbook:
 - ka-destinations:
+- linode-image-lab:
 
 ## Current State
 - knowledge-adapters:
 - ai-workflow-playbook:
 - ka-destinations:
+- linode-image-lab:
 
 ## Cross-Repo Health
 - ...


### PR DESCRIPTION
## Summary
- add linode-image-lab to the canonical context refresh repo list
- include the public-safe Linode image freeze/thaw workflow lab description in the repo boundary map and output template

## Validation
- make check

## Notes
- cross-repo-threads was updated separately as local-only staging/reference material.