### PR TITLE
[codex] docs: add GitHub state preflight guidance

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -116,6 +116,15 @@ Constraints:
 - Follow existing repo patterns and validation paths.
 - Do not silently skip required steps; report any blockers or incomplete work.
 
+External State Verification:
+- Verify live external state, such as GitHub repository or pull request state,
+  before relying on it.
+- When available, fetch current repo or PR metadata before making decisions that
+  depend on it.
+- If live state cannot be verified, explicitly state that limitation.
+- Do not infer PR status, CI status, or branch protection from summaries or
+  local files.
+
 Tasks:
 1. Inspect the existing structure and related docs or code.
 2. Make the smallest scoped change that satisfies the goal.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -47,6 +47,17 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - if removal is blocked or deferred, report it clearly, avoid deleting
   unrelated worktrees, and leave the repo in a known, intelligible state
 
+## GitHub Access Preflight
+
+- before repo- or PR-dependent work, verify GitHub access instead of relying on
+  cached context, summaries, or local branch state
+- use `gh repo view` to confirm the target repository is reachable
+- when PR state matters, use `gh pr view` to fetch current PR metadata before
+  making decisions
+- if the required `gh` commands fail, stop and report the access or state
+  blocker instead of inferring remote state
+- do not assume mergeability, checks, or branch protection without verification
+
 ## Local Permissions Model
 
 Codex operates inside a local permissions model. Some actions require approval, especially for network access, privileged writes, or potentially destructive commands.


### PR DESCRIPTION
## Summary

- Add a Codex adapter preflight that requires verifying GitHub access with `gh repo view` before repo-dependent work and `gh pr view` when PR state matters.
- Add a reusable prompt-template block for tool-agnostic external-state verification before relying on live GitHub or similar state.

## Files Changed

- `docs/tool-adapters/codex.md`
- `docs/prompts.md`

## Validation

- `make check` passed.
- Markdownlint reported 0 errors across 23 Markdown files.
- Remote comparison against `main` shows this branch is 1 commit ahead, 0 behind, and changes only the two target files.

## Placement Rationale

- Codex-specific `gh` commands belong in the tool adapter because they describe concrete Codex execution behavior.
- Portable external-state requirements belong in the prompt template so the guidance works for both ChatGPT and Codex without depending on a specific tool surface.