### PR TITLE
[codex] require PR delivery for implementation prompts

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -70,6 +70,11 @@ branch and PR. Simple one-step tasks do not need this much structure.
 Keep prompts concise but complete. The goal is to remove ambiguity that would
 cause retries, not to turn every task into a process document.
 
+Any implementation task that modifies repository files MUST include the
+Implementation Delivery Footer unless PR delivery is explicitly excluded.
+Omitting the footer can leave delivery incomplete: changes made locally but not
+pushed and opened for review in a PR.
+
 ### Optional: Trust and Evidence Context
 
 Include trust and evidence context when prior work should shape how cautiously


### PR DESCRIPTION
## Summary

- Require implementation tasks that modify repository files to include the existing Implementation Delivery Footer unless PR delivery is explicitly excluded.
- Keep the change scoped to the Codex Task Prompt Format guidance without rewriting the template or examples.

## Rationale

A recent implementation prompt changed repository files but omitted the delivery footer, which allowed the work to stop before branch, push, and PR delivery. This tightens the default so modified files are reviewable unless the prompt explicitly opts out.

## Validation

- `make check`