### PR TITLE
[codex] docs: require Codex worktree isolation

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -144,6 +144,9 @@ Validation:
 Deliverable:
 - Create a new focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
 - Do not default to `codex/...` in product or implementation repositories.
+- If an isolated workspace is needed, follow the Codex adapter workspace
+  isolation rule: use `git worktree`, and stop for explicit approval before
+  using any full copy or clone.
 - Stage only relevant changes.
 - Commit and push only the intended changes.
 - Open a non-draft PR against `main` unless explicitly instructed otherwise.
@@ -636,6 +639,9 @@ they are also expected to make and deliver repo changes.
 Delivery:
 - Create a focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
 - Do not default to `codex/...` in product or implementation repositories.
+- If isolated workspace setup is needed, use `git worktree` as required by the
+  Codex adapter guidance; do not create a full copy or clone without explicit
+  approval.
 - Stage only the relevant changes.
 - Commit with a clear message.
 - Push the branch.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -28,7 +28,24 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - make exceptions only when the task explicitly requires rebasing or when a real conflict or blocker appears that prevents finishing the requested work cleanly
 - do not treat transient GitHub `BLOCKED` or pending states as mid-run failures by default; inspect whether the cause is pending checks, pending review requirements, dependency ordering, or a true merge conflict, then wait or act accordingly
 - if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
-- when parallel repo-scoped work targets the same repository, prefer one worktree per issue or task from current `origin/main`; keep the main checkout clean and on `main`, do not run concurrent arcs against the same checkout, and treat each worktree as its own execution container with its own branch, validation run, and PR or review surface
+
+## Workspace Isolation
+
+- read-only exploration, audit, or review work may use the active checkout when
+  no repo changes are required
+- for repo-changing implementation work that needs an isolated workspace, use
+  `git worktree` from the target repository; do not create ad hoc sibling
+  full-copy repositories under the project root
+- when parallel repo-scoped work targets the same repository, use one worktree
+  per issue or task from current `origin/main`; keep the main checkout clean
+  and on `main`, do not run concurrent arcs against the same checkout, and
+  treat each worktree as its own execution container with its own branch,
+  validation run, and PR or review surface
+- if a worktree cannot be used and Codex believes a full copy or clone is
+  necessary, stop before making changes and report why a worktree is not
+  possible, what alternative workspace is proposed, where it would be created,
+  and how it will be cleaned up
+- wait for explicit human approval before proceeding with a full copy or clone
 - before starting a same-repo worktree batch, inspect `git worktree list` and
   the underlying worktree metadata so stale entries from an earlier attempt do
   not confuse setup or cleanup
@@ -46,6 +63,9 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   created for that run are removed or clearly accounted for
 - if removal is blocked or deferred, report it clearly, avoid deleting
   unrelated worktrees, and leave the repo in a known, intelligible state
+- when a PR created from a Codex worktree is merged and the worktree is no
+  longer needed, remove the worktree and prune stale worktree metadata when
+  appropriate
 
 ## GitHub Access Preflight
 


### PR DESCRIPTION
## Summary

- Add a Codex workspace isolation section that makes `git worktree` the required mechanism for repo-changing implementation work that needs an isolated workspace.
- Explicitly prohibit ad hoc sibling full-copy repositories under the project root.
- Add exception reporting and approval requirements before Codex may use a full copy or clone.
- Update reusable implementation prompt guidance so implementation prompts inherit the isolation rule.

## Rule Added

Codex must use `git worktree` for isolated repo-changing implementation work. If a worktree cannot be used, Codex must stop before making changes, report why, describe the proposed alternative workspace and location, explain cleanup, and wait for explicit approval before using a full copy or clone.

## Validation

- `make check` passed.