### PR TITLE
[codex] docs: add public API baseline guidance

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -29,6 +29,31 @@ Define shared engineering expectations across repositories. This baseline forms 
 - Keep commits clean and focused.
 - PRs are ready for review by default.
 
+## Public API Baselines
+
+When a task changes code, tests, docs, risks, or user-facing claims that depend
+on external public API behavior, establish the current behavior from official
+sources before making the change.
+
+- Applies to public APIs, SDKs, SaaS APIs, cloud providers, GitHub APIs, CLIs,
+  package managers, and other external systems.
+- Prefer official docs, API references, SDK docs, provider changelogs, and
+  official release notes.
+- Check official sources for behavior such as resource lifecycle or status
+  semantics, region or location availability, pagination, rate limits and
+  retryability, auth or token error behavior, deletion and idempotency
+  semantics, eventual consistency or timing behavior, and SDK or CLI command
+  behavior.
+- Do not rely on model memory, stale historical knowledge, or inference where
+  official docs are available.
+- If official docs are ambiguous or cannot confirm the behavior, state that
+  uncertainty, choose conservative behavior, and avoid encoding a false
+  guarantee or limitation.
+- PR notes or docs should summarize the verified official source when relevant.
+
+This requirement does not apply to purely internal refactors that do not depend
+on external API semantics.
+
 ## Relationship to Playbook
 
 - The AI workflow playbook builds on this baseline.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -129,6 +129,13 @@ External State Verification:
 - If live state cannot be verified, explicitly state that limitation.
 - Do not infer PR status, CI status, or branch protection from summaries or
   local files.
+- When code, tests, docs, risks, or user-facing claims depend on external public
+  API behavior, establish the current behavior from official docs, API
+  references, SDK docs, provider changelogs, or official release notes before
+  making the change.
+- Do not rely on memory or inference where official docs are available.
+- If official docs cannot confirm the behavior, state that uncertainty and avoid
+  encoding a false guarantee or limitation.
 
 Tasks:
 1. Inspect the existing structure and related docs or code.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -78,6 +78,21 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   blocker instead of inferring remote state
 - do not assume mergeability, checks, or branch protection without verification
 
+## Public API Baseline Check
+
+- before changing code, tests, docs, risks, or user-facing claims that depend on
+  external public API behavior, verify the current behavior from official
+  sources
+- use official docs, API references, SDK docs, provider changelogs, or official
+  release notes as the baseline; do not rely on model memory or inferred
+  provider behavior where official docs are available
+- include the verified source in PR notes or docs when it materially supports
+  the change
+- if official docs are ambiguous or unavailable for the behavior, state that
+  limitation and avoid encoding guessed guarantees or limitations
+- skip this check for purely internal refactors that do not depend on external
+  API semantics
+
 ## Local Permissions Model
 
 Codex operates inside a local permissions model. Some actions require approval, especially for network access, privileged writes, or potentially destructive commands.


### PR DESCRIPTION
## Summary

- Add a shared Public API Baselines rule to the engineering baseline.
- Require current official sources before changing behavior, docs, risks, tests, or user-facing claims that depend on external public API semantics.
- Carry the rule into Codex adapter guidance and reusable implementation prompts.

## Rationale

Recent provider-dependent work exposed a reusable workflow gap: public API behavior should be established from current official documentation before agents encode assumptions. This PR keeps the rule generic across APIs, SDKs, SaaS APIs, cloud providers, GitHub APIs, CLIs, package managers, and other external systems.

## Validation

- `make check` passed locally.

## Residual Risk

- Docs-only change; no implementation behavior changed.