### PR TITLE
docs: require authoritative sources for public API baselines

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -37,22 +37,28 @@ sources before making the change.
 
 - Applies to public APIs, SDKs, SaaS APIs, cloud providers, GitHub APIs, CLIs,
   package managers, and other external systems.
-- Prefer official docs, API references, SDK docs, provider changelogs, and
-  official release notes.
+- Prefer authoritative, provider-controlled sources:
+  - official provider documentation, such as TechDocs or API references
+  - official OpenAPI or schema definitions
+  - official SDK documentation
+  - official release notes or changelogs
 - Check official sources for behavior such as resource lifecycle or status
   semantics, region or location availability, pagination, rate limits and
   retryability, auth or token error behavior, deletion and idempotency
   semantics, eventual consistency or timing behavior, and SDK or CLI command
   behavior.
-- Do not rely on model memory, stale historical knowledge, or inference where
-  official docs are available.
-- If official docs are ambiguous or cannot confirm the behavior, state that
-  uncertainty, choose conservative behavior, and avoid encoding a false
-  guarantee or limitation.
-- PR notes or docs should summarize the verified official source when relevant.
+- If authoritative docs exist, use them as the primary source.
+- Do not rely on blogs, forum posts, StackOverflow, third-party summaries,
+  AI-generated content, model memory, stale historical knowledge, or inference
+  where authoritative docs are available.
+- If authoritative docs are ambiguous or cannot confirm the behavior, state the
+  uncertainty, choose conservative behavior, and avoid asserting or encoding a
+  false guarantee or limitation.
+- When citing sources in PRs, link directly to official docs and avoid indirect
+  or derivative sources.
 
-This requirement does not apply to purely internal refactors that do not depend
-on external API semantics.
+This requirement does not apply to trivial changes or internal-only refactors
+that do not depend on external API semantics.
 
 ## Relationship to Playbook
 


### PR DESCRIPTION
Summary:
- Tighten Public API Baselines rule to require authoritative, provider-controlled sources
- Define acceptable official source types
- Reject non-authoritative/derivative sources
- Require explicit uncertainty when official docs are unclear
- Limit scope to external API-dependent behavior

Validation:
- make check passed