### PR TITLE
[codex] add authoritative source advisory check

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -1,0 +1,27 @@
+name: Authoritative Source Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  authoritative-source-check:
+    name: authoritative-source-check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Scan PR sources
+        run: python3 scripts/check_authoritative_sources.py

--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Scan PR sources
         run: python3 scripts/check_authoritative_sources.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check check-env
+.PHONY: check check-env authoritative-source-check
 
 check:
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
@@ -23,3 +23,6 @@ check-env:
 		echo "Install markdownlint-cli2 or markdownlint to enable local validation."; \
 		exit 1; \
 	fi
+
+authoritative-source-check:
+	python3 scripts/check_authoritative_sources.py --base-ref origin/main --head-ref HEAD

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -56,6 +56,8 @@ sources before making the change.
   false guarantee or limitation.
 - When citing sources in PRs, link directly to official docs and avoid indirect
   or derivative sources.
+- If a third-party source is still useful for context, keep it secondary and add
+  an explicit source justification near the link.
 
 This requirement does not apply to trivial changes or internal-only refactors
 that do not depend on external API semantics.

--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Emit advisory warnings for non-authoritative public API source links."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+URL_RE = re.compile(r"https?://[^\s<>)\]}\"']+")
+GUIDANCE = "Prefer official provider documentation per Public API Baselines rule"
+
+OFFICIAL_SUFFIXES = ("akamai.com", "linode.com", "python.org")
+OFFICIAL_GITHUB_DOMAINS = {"api.github.com", "docs.github.com"}
+OFFICIAL_GITHUB_PATH_MARKERS = (
+    "/github/docs",
+    "/github/rest-api-description",
+    "openapi",
+)
+KNOWN_THIRD_PARTY_SUFFIXES = ("stackoverflow.com", "medium.com", "dev.to")
+JUSTIFICATION_MARKERS = (
+    "source justification:",
+    "source exception:",
+    "non-authoritative-source-ok",
+    "third-party-source-ok",
+    "official docs unavailable",
+    "authoritative docs unavailable",
+)
+
+
+def normalize_domain(hostname: str | None) -> str:
+    domain = (hostname or "").lower().rstrip(".")
+    return domain[4:] if domain.startswith("www.") else domain
+
+
+def matches(domain: str, suffix: str) -> bool:
+    return domain == suffix or domain.endswith(f".{suffix}")
+
+
+def clean_url(url: str) -> str:
+    url = url.rstrip(".,;:!?")
+    while url.endswith(")") and url.count("(") < url.count(")"):
+        url = url[:-1]
+    return url
+
+
+def is_official(url: str) -> bool:
+    parsed = urlparse(url)
+    domain = normalize_domain(parsed.hostname)
+    path = parsed.path.lower()
+
+    if any(matches(domain, suffix) for suffix in OFFICIAL_SUFFIXES):
+        return True
+    if domain in OFFICIAL_GITHUB_DOMAINS:
+        return True
+    if domain == "github.com":
+        return any(marker in path for marker in OFFICIAL_GITHUB_PATH_MARKERS)
+    return False
+
+
+def reason_for(url: str) -> tuple[str, str]:
+    domain = normalize_domain(urlparse(url).hostname)
+    if any(matches(domain, suffix) for suffix in KNOWN_THIRD_PARTY_SUFFIXES):
+        return domain, "known third-party discussion or publishing domain"
+    return domain, "domain is not in the authoritative source allowlist"
+
+
+def justified(lines: list[str], index: int) -> bool:
+    nearby = " ".join(lines[max(0, index - 1) : min(len(lines), index + 2)]).lower()
+    return any(marker in nearby for marker in JUSTIFICATION_MARKERS)
+
+
+def scan_text(label: str, text: str) -> list[dict[str, object]]:
+    findings: list[dict[str, object]] = []
+    lines = text.splitlines()
+
+    for index, line in enumerate(lines):
+        for match in URL_RE.findall(line):
+            url = clean_url(match)
+            if is_official(url) or justified(lines, index):
+                continue
+
+            domain, reason = reason_for(url)
+            findings.append(
+                {
+                    "domain": domain,
+                    "url": url,
+                    "label": label,
+                    "line": index + 1,
+                    "reason": reason,
+                    "count": 1,
+                }
+            )
+
+    return findings
+
+
+def event_payload() -> dict:
+    path = Path(os.environ.get("GITHUB_EVENT_PATH", ""))
+    if not path.is_file():
+        return {}
+
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def pr_body(payload: dict) -> str | None:
+    return os.environ.get("AUTHORITATIVE_SOURCE_PR_BODY") or payload.get("pull_request", {}).get("body")
+
+
+def changed_markdown_files(base_ref: str | None, head_ref: str | None) -> list[Path]:
+    if not base_ref or not head_ref:
+        return []
+
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMRT",
+            base_ref,
+            head_ref,
+            "--",
+            "*.md",
+        ],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    if result.returncode != 0:
+        print("authoritative-source-check: changed Markdown detection unavailable; scanning PR body only")
+        return []
+
+    return [Path(line) for line in result.stdout.splitlines() if line.strip()]
+
+
+def markdown_sources(paths: list[Path]) -> list[tuple[str, str]]:
+    sources: list[tuple[str, str]] = []
+    for path in paths:
+        if not path.is_file():
+            continue
+        try:
+            sources.append((str(path), path.read_text(encoding="utf-8")))
+        except UnicodeDecodeError:
+            print(f"authoritative-source-check: skipped non-UTF-8 file {path}")
+    return sources
+
+
+def dedupe(findings: list[dict[str, object]]) -> list[dict[str, object]]:
+    by_domain: dict[str, dict[str, object]] = {}
+    for finding in findings:
+        domain = str(finding["domain"])
+        if domain in by_domain:
+            by_domain[domain]["count"] = int(by_domain[domain]["count"]) + 1
+        else:
+            by_domain[domain] = finding
+    return [by_domain[domain] for domain in sorted(by_domain)]
+
+
+def warning_line(finding: dict[str, object]) -> str:
+    message = f"{finding['url']} detected. {GUIDANCE}."
+    if int(finding["count"]) > 1:
+        message += f" {finding['count']} URLs from this domain were detected."
+    message += " Add a source justification if official docs are unavailable."
+    message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+    title = "Non-authoritative source domain"
+    label = str(finding["label"])
+    if label.endswith(".md"):
+        return f"::warning file={label},line={finding['line']},title={title}::{message}"
+    return f"::warning title={title}::{message}"
+
+
+def report(findings: list[dict[str, object]]) -> None:
+    if not findings:
+        print("Authoritative source check: no non-authoritative source URLs found.")
+        return
+
+    print("Authoritative source check: advisory warnings only; build will continue.")
+    for finding in findings:
+        location = str(finding["label"])
+        if location.endswith(".md"):
+            location = f"{location}:{finding['line']}"
+
+        print(warning_line(finding))
+        print(f"- {finding['domain']}: {finding['url']}")
+        print(f"  location: {location}")
+        print(f"  reason: {finding['reason']}")
+        print(f"  guidance: {GUIDANCE}.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref")
+    parser.add_argument("--head-ref")
+    parser.add_argument("--all-markdown", action="store_true")
+    parser.add_argument("--pr-body-file", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    payload = event_payload()
+    sources: list[tuple[str, str]] = []
+
+    if args.pr_body_file:
+        sources.append(("PR body", args.pr_body_file.read_text(encoding="utf-8")))
+    elif body := pr_body(payload):
+        sources.append(("PR body", body))
+
+    if args.all_markdown:
+        markdown_files = sorted(Path(".").glob("**/*.md"))
+    else:
+        pull_request = payload.get("pull_request", {})
+        base_ref = (
+            args.base_ref
+            or os.environ.get("AUTHORITATIVE_SOURCE_BASE_REF")
+            or pull_request.get("base", {}).get("sha")
+        )
+        head_ref = (
+            args.head_ref
+            or os.environ.get("AUTHORITATIVE_SOURCE_HEAD_REF")
+            or os.environ.get("GITHUB_SHA")
+            or pull_request.get("head", {}).get("sha")
+        )
+        markdown_files = changed_markdown_files(base_ref, head_ref)
+
+    findings: list[dict[str, object]] = []
+    for label, text in sources + markdown_sources(markdown_files):
+        findings.extend(scan_text(label, text))
+
+    report(dedupe(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
# Summary

## What changed

- Added a PR-only GitHub Actions workflow that runs an advisory authoritative-source scan.
- Added `scripts/check_authoritative_sources.py` to scan PR descriptions and changed Markdown files for URLs, classify domains, and emit one warning per non-authoritative domain.
- Added a local `make authoritative-source-check` helper and documented the source-justification escape hatch in the Public API Baselines rule.

## Why

Public API Baselines now asks contributors to prefer provider-controlled sources, but there was no lightweight enforcement. This adds a nudge without blocking normal work or doing deep semantic validation.

## Sample output

```text
Authoritative source check: advisory warnings only; build will continue.
::warning title=Non-authoritative source domain::https://stackoverflow.com/a/1 detected. Prefer official provider documentation per Public API Baselines rule. 2 URLs from this domain were detected. Add a source justification if official docs are unavailable.
- stackoverflow.com: https://stackoverflow.com/a/1
  location: PR body
  reason: known third-party discussion or publishing domain
  guidance: Prefer official provider documentation per Public API Baselines rule.
```

## Validation

- [x] `make check`
- [x] `make authoritative-source-check`
- [x] `git diff --check`
- [x] Official-doc-only sample produced no warnings
- [x] StackOverflow sample produced one warning per domain
- [x] Explicit source justification sample produced no warning

## Risks / notes

This is intentionally warning-level only. Generic domains are flagged unless allowlisted or explicitly justified, so the initial allowlist can grow as real provider-doc use cases appear.