### PR TITLE
[codex] make authoritative source check reusable

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -2,6 +2,18 @@ name: Authoritative Source Check
 
 on:
   pull_request:
+  workflow_call:
+    inputs:
+      playbook_ref:
+        description: Ref to check out from ctrl-alt-keith/ai-workflow-playbook.
+        required: false
+        type: string
+        default: main
+      scan_mode:
+        description: Scan changed Markdown files or all Markdown files.
+        required: false
+        type: string
+        default: changed
 
 permissions:
   contents: read
@@ -13,15 +25,40 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: Check out repository
+      - name: Check out caller repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: caller-repository
+
+      - name: Check out ai-workflow-playbook
+        uses: actions/checkout@v4
+        with:
+          repository: ctrl-alt-keith/ai-workflow-playbook
+          ref: ${{ inputs.playbook_ref || github.ref }}
+          path: ai-workflow-playbook
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Scan PR sources
-        run: python3 scripts/check_authoritative_sources.py
+      - name: Scan sources
+        working-directory: caller-repository
+        env:
+          SCAN_MODE: ${{ inputs.scan_mode || 'changed' }}
+        run: |
+          set -euo pipefail
+
+          case "$SCAN_MODE" in
+            changed)
+              python3 ../ai-workflow-playbook/scripts/check_authoritative_sources.py
+              ;;
+            all)
+              python3 ../ai-workflow-playbook/scripts/check_authoritative_sources.py --all-markdown
+              ;;
+            *)
+              echo "::error title=Invalid scan_mode::scan_mode must be changed or all"
+              exit 1
+              ;;
+          esac

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -62,6 +62,36 @@ sources before making the change.
 This requirement does not apply to trivial changes or internal-only refactors
 that do not depend on external API semantics.
 
+### Reusable Advisory Check
+
+Repositories can call the canonical advisory scanner from this playbook instead
+of copying scanner logic. Add a local workflow that calls the reusable workflow:
+
+```yaml
+name: Authoritative Source Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  authoritative-source-check:
+    uses: ctrl-alt-keith/ai-workflow-playbook/.github/workflows/authoritative-source-check.yml@main
+    with:
+      scan_mode: changed
+```
+
+The reusable workflow checks out both the caller repository and
+`ctrl-alt-keith/ai-workflow-playbook`, then runs the canonical
+`scripts/check_authoritative_sources.py` scanner against the caller repository.
+The check is advisory and emits warnings without blocking the pull request.
+
+Use `scan_mode: all` only when the caller intentionally wants to scan every
+Markdown file instead of the pull request's changed Markdown files. Use
+`playbook_ref` only when testing or pinning a non-`main` playbook ref.
+
 ## Relationship to Playbook
 
 - The AI workflow playbook builds on this baseline.


### PR DESCRIPTION
## Summary

- Add `workflow_call` support to the authoritative source check workflow.
- Check out the caller repository separately from `ctrl-alt-keith/ai-workflow-playbook` so the canonical scanner runs against the caller's Markdown changes.
- Document the reusable workflow call pattern and available `scan_mode` / `playbook_ref` inputs.

## Validation

- `make check`
- `make authoritative-source-check`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/authoritative-source-check.yml"); puts "workflow yaml parses"'`
- `GOCACHE=/private/tmp/go-cache GOPATH=/private/tmp/go go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/authoritative-source-check.yml`