### PR TITLE
[codex] Enforce canonical validation command

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -9,7 +9,9 @@ Define shared engineering expectations across repositories. This baseline forms 
 - Small, scoped changes
   - One PR = one reason.
 - Validate before PR
-  - Use repo-defined validation, such as `make check`.
+  - Use the repository's canonical validation command, such as `make check`.
+  - Do not add or substitute alternate local validation tools outside the
+    repo-defined workflow.
 - Repository isolation
   - One repository per PR.
   - No cross-repo commits.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -143,9 +143,14 @@ Tasks:
 3. Update nearby docs or tests only when they are part of the same change.
 
 Validation:
-- Run [repo validation command], for example `make check`.
+- Run the repository's canonical validation command, for example `make check`.
+- Do not add or rely on alternate validation tools unless they are explicitly
+  part of the repository-defined workflow.
 - Report the actual result of validation; do not assume success.
 - If validation fails, include the failure details.
+- If a local tool needed by the canonical command is unavailable, do not
+  substitute another tool; report the limitation and rely on CI for final
+  validation.
 - If validation cannot be run, explain why.
 
 Deliverable:

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -68,6 +68,11 @@ Reusable workflow rules belong in the playbook, not duplicated into each reposit
 
 - `make check` is the canonical validation entrypoint when the repository provides one.
 - Use repository Makefile targets for validation. Do not invoke underlying tools directly when a Makefile target exists; tools such as `pytest`, `ruff`, `mypy`, `markdownlint`, or `npx` are implementation details of the repo validation contract.
+- Do not introduce or rely on alternate local validation tools unless they are
+  explicitly part of the repository-defined workflow.
+- If a local tool required by the canonical command is unavailable, report the
+  limitation, do not substitute another tool, and rely on CI as the final
+  validation authority.
 - CI is the enforcement layer.
 - Local validation should match CI behavior as closely as practical.
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -170,10 +170,17 @@ When behavior or supported capability changes, quickly check the existing docs f
 
 ## CI Expectations
 
-- use the repository's validation entrypoint, such as `make check`, when one exists
-- attempt local validation when the needed tools are clearly available; if a tool is missing locally, do not treat that as a failure and rely on required CI checks as the source of truth
+- use the repository's canonical validation command, such as `make check`, when
+  one exists
+- do not introduce, invoke, or rely on alternate local validation tools unless
+  they are explicitly part of the repository-defined workflow
+- if a tool needed by the canonical command is missing locally, report that
+  limitation, do not substitute another parser, linter, or manual validation
+  path, and rely on required CI checks as the final validation authority
 - report clearly when no local validation path exists
-- until a formal validation path exists, use internal consistency review, path checks, and scope review
+- until a formal validation path exists, report that gap and keep any review to
+  scope and consistency notes rather than presenting it as substitute
+  validation
 - treat passing CI as necessary but not sufficient
 - use hardening to close gaps exposed by CI, review, or edge cases
 


### PR DESCRIPTION
## Summary
- require repo canonical validation commands, such as `make check`, in the shared engineering baseline
- tighten repo-readiness and Codex adapter guidance to forbid alternate local validation substitutions
- update reusable Codex task prompts so generated tasks inherit the same rule

## Validation
- `make check`

## Residual risks
- None known; CI remains the final validation authority when local tooling is unavailable.