### PR TITLE
[codex] allow same-org GitHub source links

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -22,6 +22,7 @@ OFFICIAL_GITHUB_PATH_MARKERS = (
     "/github/rest-api-description",
     "openapi",
 )
+SAME_ORG_GITHUB_OWNERS = {"ctrl-alt-keith"}
 KNOWN_THIRD_PARTY_SUFFIXES = ("stackoverflow.com", "medium.com", "dev.to")
 JUSTIFICATION_MARKERS = (
     "source justification:",
@@ -49,6 +50,11 @@ def clean_url(url: str) -> str:
     return url
 
 
+def is_same_org_github_repo(path: str) -> bool:
+    parts = [part for part in path.lower().split("/") if part]
+    return len(parts) >= 2 and parts[0] in SAME_ORG_GITHUB_OWNERS
+
+
 def is_official(url: str) -> bool:
     parsed = urlparse(url)
     domain = normalize_domain(parsed.hostname)
@@ -59,7 +65,9 @@ def is_official(url: str) -> bool:
     if domain in OFFICIAL_GITHUB_DOMAINS:
         return True
     if domain == "github.com":
-        return any(marker in path for marker in OFFICIAL_GITHUB_PATH_MARKERS)
+        return is_same_org_github_repo(path) or any(
+            marker in path for marker in OFFICIAL_GITHUB_PATH_MARKERS
+        )
     return False
 
 


### PR DESCRIPTION
## Summary

- Allow `github.com/ctrl-alt-keith/<repo>` links in the authoritative source scanner.
- Keep official GitHub docs/API/OpenAPI allowances intact.
- Preserve advisory warnings for generic GitHub repositories and known third-party discussion/publishing domains.

## Rationale

The reusable authoritative source check was warning on same-org repository install references such as `https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0`. Those links are project repository references, not third-party public API evidence, so they should not be classified as non-authoritative source domains.

## Validation

- `make check`
- `make authoritative-source-check`
- Sample `https://github.com/ctrl-alt-keith/linode-image-lab.git@v0.1.0` produced 0 findings.
- Sample `https://github.com/random-user/random-repo` produced a GitHub warning finding.
- Sample `https://stackoverflow.com/questions/123/example` produced a StackOverflow warning finding.
- Official GitHub docs/API sample produced 0 findings.
- Duplicate StackOverflow sample deduped to 1 domain finding with count 2.