### PR TITLE
[codex] docs: require direct PR inspection

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -24,6 +24,7 @@ tooling.
 - [AGENTS Update](#agents-update)
 - [Workflow Scaffolding](#workflow-scaffolding)
 - [Implementation Delivery Footer](#implementation-delivery-footer)
+- [PR Review](#pr-review)
 - [PR Creation](#pr-creation)
 
 ## Context Refresh Primitive
@@ -126,6 +127,12 @@ External State Verification:
   before relying on it.
 - When available, fetch current repo or PR metadata before making decisions that
   depend on it.
+- When asked to review, check, assess, approve, or comment on a PR, inspect the
+  PR directly unless explicitly asked for summary-only discussion.
+- Treat user-provided PR summaries as navigation and context only, not review
+  evidence.
+- If direct PR access is unavailable for a PR review, stop the review, state the
+  access blocker, and do not provide a merge or readiness recommendation.
 - If live state cannot be verified, explicitly state that limitation.
 - Do not infer PR status, CI status, or branch protection from summaries or
   local files.
@@ -659,6 +666,57 @@ Delivery:
 - Push the branch.
 - Open a non-draft PR against the intended base branch, usually `main`, unless a draft PR is explicitly requested.
 - Report the PR link, files changed, and validation results.
+```
+
+## PR Review
+
+### PR Review Use When
+
+Use this prompt when the task is to review, check, assess, approve, or comment
+on an existing pull request.
+
+### PR Review Required Inputs
+
+- `repository`
+- `pull_request`
+- `task_or_issue_context` (optional; use `none` when not available)
+- `summary_only` (`yes` or `no`)
+
+### PR Review Prompt
+
+```text
+Task:
+Review pull request [pull_request] in [repository].
+
+Inputs:
+- Repository: [repository]
+- Pull request: [pull_request]
+- Task or issue context: [task_or_issue_context]
+- Summary-only requested: [summary_only]
+
+Instructions:
+- Unless Summary-only requested is `yes`, inspect the PR directly before giving
+  any review, approval, readiness, or merge recommendation.
+- Treat user-provided summaries as navigation and context only, not review
+  evidence.
+- Inspect the PR title and body, changed files, relevant diffs, CI and check
+  status, mergeability, and scope against the task or issue where those inputs
+  are available.
+- If direct PR access is unavailable and Summary-only requested is not `yes`,
+  stop the PR review, state that direct PR access is unavailable, and ask for
+  access to be restored or for the PR and files to be made available.
+- Do not claim the PR is safe to merge, ready to merge, or approved without
+  direct evidence from the PR itself.
+- If Summary-only requested is `yes`, state that the response is based only on
+  the supplied summary and does not establish merge readiness.
+
+Output format:
+1. Review findings: severity-ordered findings with file or PR references where
+   possible.
+2. Scope and evidence notes: concise notes on inspected PR surface, CI/checks,
+   mergeability, and task fit.
+3. Recommendation: `ready to merge`, `needs decision`, or `blocked`, only when
+   direct PR evidence supports it.
 ```
 
 ## PR Creation

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -30,6 +30,30 @@ If the repo does not have a formal validation path yet, say that directly and su
 
 When relevant, say explicitly whether validation was mocked, contract-level, or exercised against real behavior, and treat that gap as a risk.
 
+## Direct PR Inspection
+
+When asked to review, check, assess, approve, or comment on a PR, inspect the PR
+directly unless the human explicitly asks for summary-only discussion.
+
+User-provided PR summaries are useful navigation and context, but they are not
+review evidence. A PR review must be grounded in the actual PR surface,
+including, where available:
+
+- PR title and body
+- changed files
+- relevant diffs
+- CI and check status
+- mergeability
+- scope against the task, issue, or stated goal
+
+Do not claim a PR is safe to merge, ready to merge, or approved without direct
+evidence from the PR itself.
+
+If direct PR access is unavailable, stop the PR review and say that direct PR
+access is unavailable. Do not provide a merge or readiness recommendation from
+secondhand text. Ask for access to be restored or for the PR and files to be
+made available for direct inspection.
+
 ## Optional Trust Or Evidence Context
 
 When prior validation, repeated usage, or unresolved uncertainty affects review

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -74,8 +74,18 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - use `gh repo view` to confirm the target repository is reachable
 - when PR state matters, use `gh pr view` to fetch current PR metadata before
   making decisions
+- when asked to review, check, assess, approve, or comment on a PR, inspect the
+  PR directly unless the human explicitly asks for summary-only discussion
+- treat user-provided PR summaries as navigation and context only, not review
+  evidence
+- direct PR inspection should include the PR title and body, changed files,
+  relevant diffs, CI and check status, mergeability, and scope against the task
+  or issue where those inputs are available
 - if the required `gh` commands fail, stop and report the access or state
   blocker instead of inferring remote state
+- if direct PR access is unavailable for a PR review, stop the review, state
+  that direct PR access is unavailable, and ask for access to be restored or for
+  the PR and files to be made available
 - do not assume mergeability, checks, or branch protection without verification
 
 ## Public API Baseline Check
@@ -161,7 +171,11 @@ Codex should pause and ask for human input when:
   validation or evidence gathered instead
 - if an exploration, design, audit, or review-only task produces repo changes,
   switch back to the implementation delivery path before calling it complete
-- before recommending merge readiness on an existing PR, confirm current remote mergeability and required checks rather than relying on local branch cleanliness alone
+- do not recommend merge readiness on an existing PR without direct evidence
+  from the PR itself
+- before recommending merge readiness on an existing PR, confirm current remote
+  mergeability and required checks rather than relying on local branch
+  cleanliness alone
 - when refining an active PR within the same arc, update the existing branch and PR rather than opening a new PR; open a new PR only when the work changes phase, scope, or review surface
 - avoid bundling unrelated cleanup into the same PR
 - before calling the work complete, verify the PR diff contains only the intended arc; if `main` moved underneath the branch and overlap occurred, sync with current `main`, resolve conflicts, and rerun validation; if the branch carries unrelated history, rebuild the work onto a clean branch from current `main`


### PR DESCRIPTION
## Summary
- Add canonical review guidance requiring direct PR inspection by default.
- Clarify Codex PR-review behavior around summaries, direct evidence, CI/checks, mergeability, and access blockers.
- Add a reusable PR review prompt that inherits the direct-inspection rule and supports explicit summary-only discussion.

## Validation
- `make check`

## Risks
- Documentation-only change; residual risk is prompt users may need to notice the new PR Review template for review-only workflows.