### PR TITLE
[codex] docs: add safe parallel execution guidance

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -31,6 +31,48 @@ Define shared engineering expectations across repositories. This baseline forms 
 - Keep commits clean and focused.
 - PRs are ready for review by default.
 
+## Parallel Execution And Merge Ordering
+
+Prefer parallel task execution when work can be cleanly separated by repository,
+file area, or risk surface. Parallelism should improve throughput without
+weakening reviewability, validation, or merge safety.
+
+Before launching parallel work, classify each task by lane:
+
+- docs/governance
+- isolated code path
+- shared API/client behavior
+- mutation/safety-critical path
+- release/checking
+
+Do not parallelize changes that share mutation paths, release state, schema
+contracts, or fragile overlapping files unless the dependency is explicit and a
+clear merge order exists before work starts.
+
+For every parallel batch, define the intended merge order up front. If the work
+is truly independent, say that merge order is flexible and why. When ordering
+does matter, prefer the order that reduces conflict and review risk:
+
+- docs/governance before dependent docs
+- reusable infrastructure before repo adoption
+- shared client/API behavior before callers
+- safety/mutation changes after dependent semantics are clear
+
+If two PRs overlap unexpectedly, pause and re-establish the order before merging:
+
+- rebase or update branches in the intended order
+- rerun canonical validation after each update
+- inspect the PR surfaces directly
+- do not merge based only on local cleanliness
+
+Parallelism must not weaken:
+
+- one repository, one branch, one PR scope integrity
+- workspace or worktree isolation
+- canonical validation
+- direct PR inspection
+- authoritative source requirements
+
 ## Public API Baselines
 
 When a task changes code, tests, docs, risks, or user-facing claims that depend

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -144,6 +144,25 @@ External State Verification:
 - If official docs cannot confirm the behavior, state that uncertainty and avoid
   encoding a false guarantee or limitation.
 
+Parallel Execution Plan:
+- Prefer parallel task execution when work can be separated cleanly by
+  repository, file area, or risk surface.
+- Before launching parallel runs, classify each task by lane: docs/governance,
+  isolated code path, shared API/client behavior, mutation/safety-critical path,
+  or release/checking.
+- Do not parallelize changes that share mutation paths, release state, schema
+  contracts, or fragile overlapping files unless a clear merge order exists.
+- Define merge order up front for parallel runs. Prefer docs/governance before
+  dependent docs, reusable infrastructure before repo adoption, shared
+  client/API behavior before callers, and safety/mutation changes after
+  dependent semantics are clear.
+- If two PRs overlap unexpectedly, pause, update or rebase in order, rerun the
+  repository's canonical validation, inspect the PRs directly, and do not merge
+  based only on local cleanliness.
+- Parallelism must preserve one-repo/one-branch/one-PR scope integrity,
+  workspace isolation, canonical validation, direct PR inspection, and
+  authoritative source requirements.
+
 Tasks:
 1. Inspect the existing structure and related docs or code.
 2. Make the smallest scoped change that satisfies the goal.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -41,6 +41,17 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   and on `main`, do not run concurrent arcs against the same checkout, and
   treat each worktree as its own execution container with its own branch,
   validation run, and PR or review surface
+- before launching a Codex parallel batch, apply the engineering baseline's
+  parallel execution guidance: classify each task by lane, confirm the work can
+  be separated by repository, file area, or risk surface, and define the merge
+  order before work starts
+- do not run parallel Codex arcs across shared mutation paths, release state,
+  schema contracts, or fragile overlapping files unless a clear merge order and
+  dependency chain have been stated up front
+- if Codex PRs in a parallel batch overlap unexpectedly, pause the batch,
+  update or rebase in the intended order, rerun the repository's canonical
+  validation in each affected worktree, and inspect the current PR surfaces
+  before recommending or performing any merge
 - if a worktree cannot be used and Codex believes a full copy or clone is
   necessary, stop before making changes and report why a worktree is not
   possible, what alternative workspace is proposed, where it would be created,


### PR DESCRIPTION
## Summary

- Add canonical engineering-baseline guidance for safe parallel task execution and explicit merge ordering.
- Extend Codex adapter worktree guidance so Codex parallel batches inherit lane classification, merge ordering, validation, and PR inspection expectations.
- Update the reusable Codex task prompt template with parallel planning guidance.

## Validation

- `make check` passed.

## Residual Risks

- Documentation-only change; no implementation or automation behavior changed.