### PR TITLE
Enforce repo-local worktree convention

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -68,7 +68,7 @@ If two PRs overlap unexpectedly, pause and re-establish the order before merging
 Parallelism must not weaken:
 
 - one repository, one branch, one PR scope integrity
-- workspace or worktree isolation
+- repo-local `.worktrees/` isolation when worktrees are used
 - canonical validation
 - direct PR inspection
 - authoritative source requirements

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -183,8 +183,9 @@ Deliverable:
 - Create a new focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
 - Do not default to `codex/...` in product or implementation repositories.
 - If an isolated workspace is needed, follow the Codex adapter workspace
-  isolation rule: use `git worktree`, and stop for explicit approval before
-  using any full copy or clone.
+  isolation rule: use `git worktree` under the repo's `.worktrees/` directory,
+  and stop for explicit approval before using any sibling worktree, full copy,
+  or clone.
 - Stage only relevant changes.
 - Commit and push only the intended changes.
 - Open a non-draft PR against `main` unless explicitly instructed otherwise.
@@ -677,9 +678,9 @@ they are also expected to make and deliver repo changes.
 Delivery:
 - Create a focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
 - Do not default to `codex/...` in product or implementation repositories.
-- If isolated workspace setup is needed, use `git worktree` as required by the
-  Codex adapter guidance; do not create a full copy or clone without explicit
-  approval.
+- If isolated workspace setup is needed, use `git worktree` under the repo's
+  `.worktrees/` directory as required by the Codex adapter guidance; do not
+  create a sibling worktree, full copy, or clone without explicit approval.
 - Stage only the relevant changes.
 - Commit with a clear message.
 - Push the branch.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -34,13 +34,19 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - read-only exploration, audit, or review work may use the active checkout when
   no repo changes are required
 - for repo-changing implementation work that needs an isolated workspace, use
-  `git worktree` from the target repository; do not create ad hoc sibling
-  full-copy repositories under the project root
+  `git worktree` from the target repository and place every repo-changing
+  worktree under `<repo>/.worktrees/`; do not create sibling repo directories,
+  sibling worktree directories, or ad hoc full-copy repositories under the
+  project root
+- before creating or reusing a repo-changing worktree, run `git worktree list`,
+  select a repo-local `.worktrees/...` path, and report that selected path in
+  setup or delivery notes
 - when parallel repo-scoped work targets the same repository, use one worktree
-  per issue or task from current `origin/main`; keep the main checkout clean
-  and on `main`, do not run concurrent arcs against the same checkout, and
-  treat each worktree as its own execution container with its own branch,
-  validation run, and PR or review surface
+  per issue or task from current `origin/main`, with each worktree located
+  under the repository's `.worktrees/` directory; keep the main checkout clean
+  and on `main`, do not run concurrent arcs against the same checkout, and treat
+  each worktree as its own execution container with its own branch, validation
+  run, and PR or review surface
 - before launching a Codex parallel batch, apply the engineering baseline's
   parallel execution guidance: classify each task by lane, confirm the work can
   be separated by repository, file area, or risk surface, and define the merge
@@ -52,10 +58,10 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   update or rebase in the intended order, rerun the repository's canonical
   validation in each affected worktree, and inspect the current PR surfaces
   before recommending or performing any merge
-- if a worktree cannot be used and Codex believes a full copy or clone is
-  necessary, stop before making changes and report why a worktree is not
-  possible, what alternative workspace is proposed, where it would be created,
-  and how it will be cleaned up
+- if `<repo>/.worktrees/` cannot be used, stop before making changes and report
+  why the required repo-local worktree location is not possible, what
+  alternative workspace is proposed, where it would be created, and how it will
+  be cleaned up
 - wait for explicit human approval before proceeding with a full copy or clone
 - before starting a same-repo worktree batch, inspect `git worktree list` and
   the underlying worktree metadata so stale entries from an earlier attempt do


### PR DESCRIPTION
## Summary
- Require repo-changing Codex worktrees to live under `<repo>/.worktrees/`.
- Require `git worktree list`, selected `.worktrees/...` path reporting, and stopping when the repo-local location cannot be used.
- Update reusable implementation prompt snippets and engineering baseline wording to match the convention.

## Validation
- `make check` passed.

## Residual risks
- None known.