### PR TITLE
[codex] Add licensing baseline guidance

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -31,6 +31,15 @@ Define shared engineering expectations across repositories. This baseline forms 
 - Keep commits clean and focused.
 - PRs are ready for review by default.
 
+## Licensing Baseline
+
+- Use Apache License 2.0 as the default license for public repositories unless
+  the repository has an explicit reason to choose another license.
+- Public repositories must include a root `LICENSE` file before normal delivery
+  work begins.
+- Keep licensing guidance simple and reusable; put repository-specific
+  exceptions in the repository's own setup notes.
+
 ## Parallel Execution And Merge Ordering
 
 Prefer parallel task execution when work can be cleanly separated by repository,

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -15,6 +15,8 @@ Define the smallest reusable baseline a repository should have before normal AI-
 - All changes go through pull requests.
 - Validation must pass before a pull request is considered complete.
 - Pull requests should stay small, scoped, and single-purpose.
+- Public repositories include a root `LICENSE` file, defaulting to Apache License
+  2.0 unless the repository documents another choice.
 - Defaults should favor safe, explicit behavior over implied shortcuts.
 
 ## PR Readiness


### PR DESCRIPTION
## Summary

- Add a concise licensing baseline to `docs/engineering-baseline.md`.
- Set Apache License 2.0 as the default for public repositories unless a repo documents another choice.
- Add a repo-readiness expectation that public repositories include a root `LICENSE` file.

## Validation

- `make check`