### PR TITLE
[codex] docs: clarify validation and CI enforcement

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -10,6 +10,8 @@ Define shared engineering expectations across repositories. This baseline forms 
   - One PR = one reason.
 - Validate before PR
   - Use the repository's canonical validation command, such as `make check`.
+  - Run available canonical local validation before opening or updating a PR;
+    do not treat CI as a substitute for that local step.
   - Do not add or substitute alternate local validation tools outside the
     repo-defined workflow.
 - Repository isolation

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -169,14 +169,16 @@ Tasks:
 3. Update nearby docs or tests only when they are part of the same change.
 
 Validation:
-- Run the repository's canonical validation command, for example `make check`.
+- Run the repository's canonical validation command, for example `make check`,
+  before opening or updating a PR when it exists and can run locally.
+- Do not treat CI as a substitute for available local canonical validation.
 - Do not add or rely on alternate validation tools unless they are explicitly
   part of the repository-defined workflow.
 - Report the actual result of validation; do not assume success.
 - If validation fails, include the failure details.
 - If a local tool needed by the canonical command is unavailable, do not
-  substitute another tool; report the limitation and rely on CI for final
-  validation.
+  substitute another tool; report the limitation and rely on CI for enforcement
+  of checks that cannot be run locally.
 - If validation cannot be run, explain why.
 
 Deliverable:

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -69,12 +69,18 @@ Reusable workflow rules belong in the playbook, not duplicated into each reposit
 ## Validation
 
 - `make check` is the canonical validation entrypoint when the repository provides one.
+- When the canonical entrypoint exists and can run locally, run it before
+  opening or updating a pull request; do not treat CI as a replacement for
+  available local validation.
 - Use repository Makefile targets for validation. Do not invoke underlying tools directly when a Makefile target exists; tools such as `pytest`, `ruff`, `mypy`, `markdownlint`, or `npx` are implementation details of the repo validation contract.
 - Do not introduce or rely on alternate local validation tools unless they are
   explicitly part of the repository-defined workflow.
 - If a local tool required by the canonical command is unavailable, report the
-  limitation, do not substitute another tool, and rely on CI as the final
-  validation authority.
+  limitation, do not substitute another tool, and rely on CI for enforcement of
+  checks that cannot be run locally.
+- CI-only checks are acceptable only when the repository does not expose a local
+  canonical path for them or the local canonical path cannot run in the current
+  environment.
 - CI is the enforcement layer.
 - Local validation should match CI behavior as closely as practical.
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -203,11 +203,18 @@ When behavior or supported capability changes, quickly check the existing docs f
 
 - use the repository's canonical validation command, such as `make check`, when
   one exists
+- when the canonical validation command exists and can run locally, run it
+  before opening or updating a PR; do not treat CI as a replacement for that
+  local step
 - do not introduce, invoke, or rely on alternate local validation tools unless
   they are explicitly part of the repository-defined workflow
 - if a tool needed by the canonical command is missing locally, report that
   limitation, do not substitute another parser, linter, or manual validation
-  path, and rely on required CI checks as the final validation authority
+  path, and rely on required CI checks for enforcement of checks that cannot be
+  run locally
+- treat checks as CI-only only when the repository does not expose a local
+  canonical path for them or the local canonical path cannot run in the current
+  environment
 - report clearly when no local validation path exists
 - until a formal validation path exists, report that gap and keep any review to
   scope and consistency notes rather than presenting it as substitute


### PR DESCRIPTION
## Summary
- Clarifies that runnable repo-defined local validation, such as `make check`, must be run before opening or updating a PR.
- Defines CI-only checks as limited to checks without a local canonical path or cases where the local canonical path cannot run in the current environment.
- Aligns the reusable Codex task prompt, repo readiness baseline, engineering baseline, and Codex adapter wording.

## Validation
- `make check` passed locally: markdownlint-cli2 linted 23 Markdown files with 0 errors.

## Residual Risks
- No repository logic or CI configuration changed; this only tightens documentation and prompt wording.