### PR TITLE
[codex] Harden authoritative source scanner

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: changed
+      official_domains:
+        description: Additional official documentation domain suffixes, separated by commas or spaces.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -47,6 +52,7 @@ jobs:
         working-directory: caller-repository
         env:
           SCAN_MODE: ${{ inputs.scan_mode || 'changed' }}
+          AUTHORITATIVE_SOURCE_OFFICIAL_DOMAINS: ${{ inputs.official_domains || '' }}
         run: |
           set -euo pipefail
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check check-env authoritative-source-check
+.PHONY: check check-env authoritative-source-check scanner-test
 
 check:
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
@@ -12,6 +12,7 @@ check:
 		echo "Install markdownlint-cli2 or markdownlint, then rerun 'make check'."; \
 		exit 1; \
 	fi
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
 
 check-env:
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
@@ -26,3 +27,6 @@ check-env:
 
 authoritative-source-check:
 	python3 scripts/check_authoritative_sources.py --base-ref origin/main --head-ref HEAD
+
+scanner-test:
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -134,15 +134,22 @@ jobs:
     uses: ctrl-alt-keith/ai-workflow-playbook/.github/workflows/authoritative-source-check.yml@main
     with:
       scan_mode: changed
+      official_domains: docs.example-provider.com
 ```
 
 The reusable workflow checks out both the caller repository and
 `ctrl-alt-keith/ai-workflow-playbook`, then runs the canonical
 `scripts/check_authoritative_sources.py` scanner against the caller repository.
 The check is advisory and emits warnings without blocking the pull request.
+The scanner reports non-authoritative links only when they appear near public
+API evidence terms such as API, SDK, CLI, endpoint, pagination, rate limits, or
+retry behavior. This keeps normal repository links quiet while still surfacing
+third-party sources used to support external API behavior claims.
 
 Use `scan_mode: all` only when the caller intentionally wants to scan every
 Markdown file instead of the pull request's changed Markdown files. Use
+`official_domains` to add provider-controlled documentation domains that are
+authoritative for the caller repository but not built into the scanner. Use
 `playbook_ref` only when testing or pinning a non-`main` playbook ref.
 
 ## Relationship to Playbook

--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -13,9 +13,17 @@ from urllib.parse import urlparse
 
 
 URL_RE = re.compile(r"https?://[^\s<>)\]}\"']+")
-GUIDANCE = "Prefer official provider documentation per Public API Baselines rule"
+GUIDANCE = "Use official provider documentation for public API evidence"
+PUBLIC_API_CONTEXT_RE = re.compile(
+    r"\b("
+    r"api reference|cloud provider|eventual consistency|rate limits?|release notes|"
+    r"saas api|api|auth|authentication|authorization|changelog|cli|endpoint|graphql|"
+    r"idempotency|openapi|pagination|rest|retry|retryability|sdk|token|webhook"
+    r")\b",
+    re.IGNORECASE,
+)
 
-OFFICIAL_SUFFIXES = ("akamai.com", "linode.com", "python.org")
+DEFAULT_OFFICIAL_SUFFIXES = ("akamai.com", "linode.com", "python.org")
 OFFICIAL_GITHUB_DOMAINS = {"api.github.com", "docs.github.com"}
 OFFICIAL_GITHUB_PATH_MARKERS = (
     "/github/docs",
@@ -55,12 +63,28 @@ def is_same_org_github_repo(path: str) -> bool:
     return len(parts) >= 2 and parts[0] in SAME_ORG_GITHUB_OWNERS
 
 
-def is_official(url: str) -> bool:
+def configured_domains(raw_values: list[str]) -> tuple[str, ...]:
+    domains: list[str] = []
+    for raw_value in raw_values:
+        for value in re.split(r"[\s,]+", raw_value):
+            if not value:
+                continue
+            parsed = urlparse(value if "://" in value else f"//{value}")
+            domain = normalize_domain(parsed.hostname or value)
+            if domain and domain not in domains:
+                domains.append(domain)
+    return tuple(domains)
+
+
+def is_official(
+    url: str,
+    official_suffixes: tuple[str, ...] = DEFAULT_OFFICIAL_SUFFIXES,
+) -> bool:
     parsed = urlparse(url)
     domain = normalize_domain(parsed.hostname)
     path = parsed.path.lower()
 
-    if any(matches(domain, suffix) for suffix in OFFICIAL_SUFFIXES):
+    if any(matches(domain, suffix) for suffix in official_suffixes):
         return True
     if domain in OFFICIAL_GITHUB_DOMAINS:
         return True
@@ -83,14 +107,28 @@ def justified(lines: list[str], index: int) -> bool:
     return any(marker in nearby for marker in JUSTIFICATION_MARKERS)
 
 
-def scan_text(label: str, text: str) -> list[dict[str, object]]:
+def public_api_context(lines: list[str], index: int) -> str | None:
+    """Return the nearby API evidence phrase that makes a URL worth checking."""
+    nearby = " ".join(lines[max(0, index - 1) : min(len(lines), index + 2)])
+    match = PUBLIC_API_CONTEXT_RE.search(nearby)
+    return match.group(0) if match else None
+
+
+def scan_text(
+    label: str,
+    text: str,
+    official_suffixes: tuple[str, ...] = DEFAULT_OFFICIAL_SUFFIXES,
+) -> list[dict[str, object]]:
     findings: list[dict[str, object]] = []
     lines = text.splitlines()
 
     for index, line in enumerate(lines):
         for match in URL_RE.findall(line):
             url = clean_url(match)
-            if is_official(url) or justified(lines, index):
+            if is_official(url, official_suffixes) or justified(lines, index):
+                continue
+            context = public_api_context(lines, index)
+            if context is None:
                 continue
 
             domain, reason = reason_for(url)
@@ -101,6 +139,7 @@ def scan_text(label: str, text: str) -> list[dict[str, object]]:
                     "label": label,
                     "line": index + 1,
                     "reason": reason,
+                    "context": context,
                     "count": 1,
                 }
             )
@@ -177,10 +216,13 @@ def warning_line(finding: dict[str, object]) -> str:
     message = f"{finding['url']} detected. {GUIDANCE}."
     if int(finding["count"]) > 1:
         message += f" {finding['count']} URLs from this domain were detected."
-    message += " Add a source justification if official docs are unavailable."
+    message += (
+        f" Matched public API context: {finding['context']}. "
+        "Replace with official docs or add a source justification if official docs are unavailable."
+    )
     message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
-    title = "Non-authoritative source domain"
+    title = "Non-authoritative public API source"
     label = str(finding["label"])
     if label.endswith(".md"):
         return f"::warning file={label},line={finding['line']},title={title}::{message}"
@@ -202,6 +244,7 @@ def report(findings: list[dict[str, object]]) -> None:
         print(f"- {finding['domain']}: {finding['url']}")
         print(f"  location: {location}")
         print(f"  reason: {finding['reason']}")
+        print(f"  matched public API context: {finding['context']}")
         print(f"  guidance: {GUIDANCE}.")
 
 
@@ -211,12 +254,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--head-ref")
     parser.add_argument("--all-markdown", action="store_true")
     parser.add_argument("--pr-body-file", type=Path)
+    parser.add_argument(
+        "--official-domain",
+        action="append",
+        default=[],
+        help="Additional official documentation domain suffix. May be repeated or comma-separated.",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     payload = event_payload()
+    official_suffixes = DEFAULT_OFFICIAL_SUFFIXES + configured_domains(
+        args.official_domain + [os.environ.get("AUTHORITATIVE_SOURCE_OFFICIAL_DOMAINS", "")]
+    )
     sources: list[tuple[str, str]] = []
 
     if args.pr_body_file:
@@ -243,7 +295,7 @@ def main() -> int:
 
     findings: list[dict[str, object]] = []
     for label, text in sources + markdown_sources(markdown_files):
-        findings.extend(scan_text(label, text))
+        findings.extend(scan_text(label, text, official_suffixes))
 
     report(dedupe(findings))
     return 0

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_authoritative_sources.py"
+SPEC = importlib.util.spec_from_file_location("check_authoritative_sources", SCRIPT_PATH)
+assert SPEC is not None
+scanner = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(scanner)
+
+
+class AuthoritativeSourceScannerTest(unittest.TestCase):
+    def test_flags_third_party_url_in_public_api_context(self) -> None:
+        findings = scanner.scan_text(
+            "PR body",
+            "GitHub API pagination behavior source: https://stackoverflow.com/questions/1",
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["domain"], "stackoverflow.com")
+        self.assertEqual(findings[0]["context"].lower(), "api")
+
+    def test_ignores_non_api_context_url(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "Planning notes live at https://example.com/roadmap for reference.",
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_ignores_official_url_in_public_api_context(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "GitHub API pagination source: https://docs.github.com/en/rest/using-the-rest-api",
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_configured_official_domain_suppresses_warning(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "Cloud provider API source: https://docs.aws.amazon.com/lambda/latest/dg/welcome.html",
+            scanner.DEFAULT_OFFICIAL_SUFFIXES + ("docs.aws.amazon.com",),
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_configured_domains_accept_comma_and_space_separated_values(self) -> None:
+        domains = scanner.configured_domains(
+            ["https://docs.aws.amazon.com, cloud.google.com learn.microsoft.com"]
+        )
+
+        self.assertEqual(
+            domains,
+            ("docs.aws.amazon.com", "cloud.google.com", "learn.microsoft.com"),
+        )
+
+    def test_nearby_source_justification_suppresses_warning(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "\n".join(
+                [
+                    "Source justification: official docs unavailable for this API edge case.",
+                    "Fallback context: https://medium.com/example/post",
+                ]
+            ),
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_warning_line_describes_actionable_public_api_remediation(self) -> None:
+        finding = scanner.scan_text(
+            "docs/example.md",
+            "REST retry behavior source: https://dev.to/example/post",
+        )[0]
+
+        warning = scanner.warning_line(finding)
+
+        self.assertIn("Non-authoritative public API source", warning)
+        self.assertIn("Matched public API context: REST", warning)
+        self.assertIn("Replace with official docs", warning)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Scope authoritative source warnings to links near public API evidence terms so normal repository links do not create noisy advisory output.
- Add configurable official documentation domains through the scanner CLI/env and reusable workflow input for downstream repositories.
- Add stdlib unit tests for PR-body warnings, changed-Markdown warning formatting, official domain configuration, justification handling, and non-API link quieting.

## Rationale

The playbook requires public API behavior claims to use authoritative official documentation. The scanner now focuses on that evidence surface and gives a concrete remediation: replace third-party evidence with official docs or add a source justification when official docs are unavailable.

Workflow input wiring follows GitHub's reusable workflow input model: https://docs.github.com/actions/how-tos/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

## Validation

- `make check` passed: markdownlint-cli2 linted 23 Markdown files with 0 errors, then `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests` ran 7 tests successfully.
- PR-body sample with a StackOverflow API source emitted an advisory warning including the matched API context and remediation.
- PR-body sample with `--official-domain docs.aws.amazon.com` for an AWS docs URL emitted no warning.
- Changed-Markdown scan for this branch emitted no non-authoritative source warnings.

## Residual risks

- Public API context detection is keyword-based by design. It may miss unusually worded API claims, and downstream repositories may need to configure additional official domains for their providers.