### PR TITLE
[codex] Clarify make check validation surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: check check-env authoritative-source-check
 
+# Canonical validation entrypoint for local work and CI.
 check:
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
 		echo "Running markdownlint-cli2"; \
@@ -13,6 +14,7 @@ check:
 		exit 1; \
 	fi
 
+# Environment probe for the tool behind check; not a validation substitute.
 check-env:
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
 		echo "Found markdownlint-cli2"; \
@@ -24,5 +26,6 @@ check-env:
 		exit 1; \
 	fi
 
+# Advisory source scan; CI runs this separately from required make check.
 authoritative-source-check:
 	python3 scripts/check_authoritative_sources.py --base-ref origin/main --head-ref HEAD


### PR DESCRIPTION
## Summary

- Added Makefile comments that identify `make check` as the canonical validation entrypoint for local work and CI.
- Marked `check-env` as an environment probe and `authoritative-source-check` as an advisory source scan so nearby targets are not confused with required validation.
- Preserved the existing `make check` behavior: CI-backed Markdown lint through the Makefile.

## Validation

- [x] `make check`
  - Ran `markdownlint-cli2 v0.22.1` against 23 Markdown files.
  - Result: 0 errors.

## Residual risks

- `git fetch origin main` could not update `FETCH_HEAD` in this sandbox, but `git ls-remote origin refs/heads/main` matched local `origin/main` at `422139c057da65d9d0eacb5a53a551f63bc5e496` before commit.

Closes #111