### PR TITLE
[codex] docs: define reusable workflow pinning

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -154,6 +154,36 @@ Markdown file instead of the pull request's changed Markdown files. Use
 authoritative for the caller repository but not built into the scanner. Use
 `playbook_ref` only when testing or pinning a non-`main` playbook ref.
 
+### Reusable Workflow Pinning
+
+Reusable workflows consumed by other repositories should be treated as
+cross-repo dependencies. GitHub documents that reusable workflows can be
+referenced by SHA, release tag, or branch, and that commit SHA references are
+the safest option for stability and security:
+
+- [Reusable workflow reference](https://docs.github.com/en/actions/reference/workflows-and-actions/reusable-workflows#behavior-of-reusable-workflows-when-re-running-jobs)
+- [Secure use guidance](https://docs.github.com/en/actions/reference/security/secure-use#reusing-third-party-workflows)
+
+Default stable callers to a release tag or full-length commit SHA instead of
+`@main`. Use a full-length commit SHA for security-sensitive, release-blocking,
+or otherwise behavior-sensitive checks. Use a release tag when readable version
+intent and routine update ergonomics matter more than strict immutability, and
+the workflow owner has a clear tag-publishing practice.
+
+`@main` is acceptable only while the reusable workflow is actively iterating
+with known downstream callers, while the workflow is unpublished or explicitly
+experimental, or when the caller intentionally wants every default-branch change
+immediately. Before treating the workflow as a stable shared contract, replace
+`@main` with a tag or SHA and document the expected update path.
+
+When rolling out updates, publish or choose the next workflow ref first, then
+update downstream callers in scoped pull requests. Each downstream update should
+state the old and new refs, run the caller repository's canonical validation and
+CI path, and keep any required compatibility fixes in the same review surface.
+For this playbook's advisory scanner, pin `playbook_ref` to the same tag or SHA
+as the reusable workflow unless the caller is deliberately testing a split
+workflow/scanner ref.
+
 ## Relationship to Playbook
 
 - The AI workflow playbook builds on this baseline.


### PR DESCRIPTION
## Summary

- Add reusable workflow pinning guidance to the engineering baseline.
- Recommend release tags or full-length commit SHAs for stable downstream consumers, with SHAs preferred for behavior-sensitive or security-sensitive checks.
- Define narrow cases where `@main` is acceptable during active iteration or experimental use.
- Add rollout expectations for downstream updates, including validation and aligning `playbook_ref` with the pinned workflow ref for the advisory scanner.

## Rationale

Reusable workflows consumed through `@main` can change behavior unexpectedly in downstream repositories. Treating them as cross-repo dependencies makes updates explicit and reviewable while still allowing `@main` during active iteration.

Official references used:

- https://docs.github.com/en/actions/reference/workflows-and-actions/reusable-workflows#behavior-of-reusable-workflows-when-re-running-jobs
- https://docs.github.com/en/actions/reference/security/secure-use#reusing-third-party-workflows

## Validation

- `make check`

## Residual Risks

- This only defines playbook guidance; it does not update downstream repositories or add release automation.
- Local SSH fetch/push was unavailable because the SSH agent refused GitHub keys, so the branch was pushed over HTTPS after verifying remote `main` at `f40b646`.

Closes #107