### PR TITLE
[codex] docs: reconcile playbook lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,6 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md): Codex-specific adapter notes
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
-- [`docs/context-refresh.md`](docs/context-refresh.md): validated context refresh primitive for baseline briefs plus verified repo state
-- [`docs/maintenance-automations.md`](docs/maintenance-automations.md): concise inventory and operating rules for recurring Codex maintenance automation
+- [`docs/context-refresh.md`](docs/context-refresh.md): verified context refresh primitive for baseline briefs plus verified repo state
+- [`docs/maintenance-automations.md`](docs/maintenance-automations.md): reusable operating rules plus reference inventory notes for recurring Codex maintenance automation
 - [`docs/prompts.md`](docs/prompts.md): reusable prompt templates, including the standard Codex task prompt format

--- a/docs/context-refresh.md
+++ b/docs/context-refresh.md
@@ -137,7 +137,7 @@ Maximum 3 bullets.
 - Each item must be small, high leverage, and directly actionable.
 - Prefer moves that reduce ambiguity, unblock near-term work, or protect repo boundaries.
 
-Validation Requirements:
+Verification Requirements:
 - Ground all statements in verified repo state.
 - Do not guess or infer missing information.
 - Do not mark Drift as `accurate` unless the repo was actually verified.

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -28,8 +28,12 @@ Define shared engineering expectations across repositories. This baseline forms 
 
 ## Git and PR Expectations
 
-- Branch from current `main`.
-- Update the branch against current `main` before PR.
+- Fetch current `origin/main` at task start and anchor implementation to that
+  fetched baseline.
+- Before opening or updating a PR, verify current mergeability against `main`.
+- Update or rebase only for conflicts, overlapping upstream changes, repo
+  policy, or explicit human request.
+- Rerun canonical validation after any update or rebase.
 - Keep commits clean and focused.
 - PRs are ready for review by default.
 

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -29,8 +29,14 @@ Prefer semantic assertions over formatting-sensitive assertions when formatting 
 
 Build only what is needed to satisfy the contract. Keep feedback loops short and avoid mixing extra polish into the first pass.
 
-For same-repo runs, anchor implementation to one fetched `origin/main` snapshot at task start and treat that snapshot as the canonical base for the duration of the run. Check mergeability against current `main` at the end as a separate release-readiness concern rather than repeatedly re-anchoring mid-run.
-A clean local branch at the end means the run stayed coherent against that anchored base; it does not by itself prove that a remote PR is still mergeable after `main` moves.
+For same-repo runs, fetch current `origin/main` at task start and anchor
+implementation to that fetched baseline. Check mergeability against current
+`main` before opening or updating the PR. Update or rebase only when there is a
+conflict, overlapping upstream change, repo policy requirement, or explicit
+human request, then rerun the repository's canonical validation entrypoint.
+A clean local branch at the end means the run stayed coherent against its
+anchored base; it does not by itself prove that a remote PR is still mergeable
+after `main` moves.
 
 ### Hardening
 
@@ -43,7 +49,9 @@ If GitHub shows `BLOCKED` or pending status at this stage, check the underlying 
 
 ### Capture
 
-Record what should become reusable guidance before the next delivery arc starts.
+Record any evidence-supported reusable lesson before the next delivery arc
+starts. If the lesson is promoted into the playbook, include a notes cleanup
+follow-up or state explicitly that no notes cleanup is needed.
 
 ## Project Maps
 
@@ -77,7 +85,8 @@ project-map-only PRs for release updates.
 
 After each merged phase, start a new branch and PR for the next lifecycle phase. This keeps the review surface narrow and preserves clean checkpoints.
 
-Start same-repo arcs from fresh `origin/main`. Do not reuse an old feature branch unless intentionally continuing that PR.
+Start same-repo arcs from freshly fetched `origin/main`. Do not reuse an old
+feature branch unless intentionally continuing that PR.
 
 ### Repo Change Completion
 

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -4,11 +4,13 @@ Codex maintenance automations are part of the orchestration model: they keep
 recurring checks visible, bounded, and reviewable without turning the playbook
 into an automation implementation repo.
 
-This inventory reflects the current local Codex `automation.toml` configs. It
-summarizes purpose, cadence, scope, mutation behavior, and safety expectations
-without copying long prompts or local execution paths.
+This document owns reusable policy and pattern guidance for maintenance
+automation. The inventory below is non-canonical reference material copied from
+current local Codex `automation.toml` configs; the active local automation
+configs remain the owning source for runtime state, schedules, prompts, and
+execution paths.
 
-## Inventory
+## Reference Inventory
 
 | Automation | ID | Purpose | Cadence | Target Scope | Mode | Safety Expectations / Skip Conditions |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -29,11 +31,12 @@ without copying long prompts or local execution paths.
 
 ## Configuration Notes
 
-- Entries reflect currently active maintenance automations.
+- Entries reflect currently active maintenance automations at the time this
+  reference was updated.
 - This document summarizes behavior and intent; it does not replicate full prompt
   bodies or local configuration.
-- Treat automation configuration as local operational state, not canonical
-  workflow guidance.
+- Treat automation configuration, run state, schedules, and logs as local
+  operational state, not canonical workflow guidance.
 - Detailed automation configuration should remain in local configuration files,
   not in the playbook.
 - Do not expose secrets, local-only paths, raw prompts containing private

--- a/docs/notes-repositories.md
+++ b/docs/notes-repositories.md
@@ -1,8 +1,9 @@
 # Notes Repositories
 
 Use a notes repository as a staging layer for workflow material that is still
-being explored, refined, or validated. Use this playbook repository as the
-canonical source only after that material has been proven reusable.
+being explored, refined, or supported with concrete evidence. Use this playbook
+repository as the canonical source only after that material has been proven
+reusable.
 
 This split keeps early capture lightweight without turning the playbook into a
 scratch space.
@@ -15,6 +16,20 @@ scratch space.
   the cross-repo rule or pattern.
 - A notes repository is not a second canonical source once promotion has
   happened.
+
+## Terms
+
+- `canonical`: the source that owns reusable workflow guidance after promotion.
+- `staging`: provisional notes, experiments, and local observations that may
+  inform later work but do not govern repositories.
+- `evidence-supported`: backed by concrete evidence such as real use, review,
+  repeated successful application, or merged repo work.
+- `validated`: reserved for repository validation commands and their results,
+  such as `make check`.
+- `promotion`: moving only the durable reusable lesson into the playbook after
+  evidence supports it.
+- `bounded`: scoped tightly enough to become one focused repo issue, PR, or
+  short arc.
 
 ## What Belongs In Notes
 
@@ -36,10 +51,10 @@ separate:
   ready to guide action yet
 - Deferred ideas: notes worth revisiting later, but still too broad,
   speculative, duplicated, or blocked to become repo work now
-- Bounded repo issues: action-ready work for a specific repository with a clear
-  scope, value, and acceptance shape
-- Playbook candidates: validated lessons that may later become reusable
-  cross-repo guidance after repo work proves the pattern
+- Bounded repo issues or PRs: action-ready work for a specific repository with
+  a clear scope, value, and acceptance shape
+- Playbook candidates: evidence-supported lessons that may later become
+  reusable cross-repo guidance after repo work proves the pattern
 
 Do not treat these states as a conveyor belt where every note must advance.
 Many notes should stay raw, many ideas should stay deferred, and only a narrow
@@ -52,7 +67,8 @@ following is true:
 
 - the same friction, gap, or cleanup need shows up repeatedly
 - the value is clear enough that repo-local action is justified now
-- the work is ready to be scoped, assigned, and validated in a specific repo
+- the work is ready to be scoped, assigned, implemented, and checked in a
+  specific repo
 
 Keep the item as a deferred idea when it is still mostly brainstorming,
 duplicate with existing backlog items, blocked on outside decisions, or too
@@ -77,12 +93,14 @@ Promote notes into the playbook when the guidance is:
 - reusable across multiple projects or workflow arcs
 - specific enough to tell people how to act, not just what was observed
 - stable enough that the core rule is unlikely to churn immediately
-- validated by real use, review, or repeated successful application
+- supported by concrete evidence from real use, review, repeated successful
+  application, or merged repo work
 - scoped so the playbook receives the rule, pattern, or checklist rather than
   project-specific residue
 
 If the content is still mostly retrospective detail, raw examples, or local
-context, keep refining it in notes instead of promoting it early.
+context, keep refining it in notes instead of promoting it early. The promotion
+packet should cite the evidence that supports the lesson.
 
 ## Promotion Flow
 
@@ -90,8 +108,10 @@ Use this general sequence:
 
 1. Capture the emerging pattern in notes while the work is fresh.
 2. Defer, group, or trim ideas that are not ready for action yet.
-3. Promote only action-ready, repo-local work into bounded repository issues.
-4. Tighten validated reusable guidance until it is ready for the playbook.
+3. Promote only action-ready, repo-local work into bounded repository issues or
+   PRs.
+4. Complete bounded repo work and capture the evidence-supported reusable
+   lesson.
 5. Promote the reusable rule into the playbook as the canonical version.
 6. Update or trim the notes so they no longer compete with the promoted source.
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -29,7 +29,7 @@ tooling.
 
 ## Context Refresh Primitive
 
-Canonical guidance for the validated org context refresh pattern lives in
+Canonical guidance for the verified org context refresh pattern lives in
 [`docs/context-refresh.md`](context-refresh.md). Use that page for when to run
 it, required verification inputs, failure handling, and the self-contained
 prompt block.
@@ -125,43 +125,23 @@ Constraints:
 External State Verification:
 - Verify live external state, such as GitHub repository or pull request state,
   before relying on it.
-- When available, fetch current repo or PR metadata before making decisions that
-  depend on it.
-- When asked to review, check, assess, approve, or comment on a PR, inspect the
-  PR directly unless explicitly asked for summary-only discussion.
-- Treat user-provided PR summaries as navigation and context only, not review
-  evidence.
-- If direct PR access is unavailable for a PR review, stop the review, state the
-  access blocker, and do not provide a merge or readiness recommendation.
-- If live state cannot be verified, explicitly state that limitation.
-- Do not infer PR status, CI status, or branch protection from summaries or
-  local files.
-- When code, tests, docs, risks, or user-facing claims depend on external public
-  API behavior, establish the current behavior from official docs, API
-  references, SDK docs, provider changelogs, or official release notes before
-  making the change.
-- Do not rely on memory or inference where official docs are available.
-- If official docs cannot confirm the behavior, state that uncertainty and avoid
-  encoding a false guarantee or limitation.
+- Follow the direct PR inspection rule in `docs/review-packet.md` when a task
+  asks for PR review, readiness, approval, or merge advice.
+- Follow the public API baseline in `docs/engineering-baseline.md` when code,
+  tests, docs, risks, or user-facing claims depend on external public API
+  behavior.
+- If live state cannot be verified, explicitly state that limitation and do not
+  infer PR status, CI status, or branch protection from summaries or local
+  files.
 
 Parallel Execution Plan:
-- Prefer parallel task execution when work can be separated cleanly by
-  repository, file area, or risk surface.
-- Before launching parallel runs, classify each task by lane: docs/governance,
-  isolated code path, shared API/client behavior, mutation/safety-critical path,
-  or release/checking.
-- Do not parallelize changes that share mutation paths, release state, schema
-  contracts, or fragile overlapping files unless a clear merge order exists.
-- Define merge order up front for parallel runs. Prefer docs/governance before
-  dependent docs, reusable infrastructure before repo adoption, shared
-  client/API behavior before callers, and safety/mutation changes after
-  dependent semantics are clear.
-- If two PRs overlap unexpectedly, pause, update or rebase in order, rerun the
-  repository's canonical validation, inspect the PRs directly, and do not merge
-  based only on local cleanliness.
-- Parallelism must preserve one-repo/one-branch/one-PR scope integrity,
-  workspace isolation, canonical validation, direct PR inspection, and
-  authoritative source requirements.
+- Follow the parallel execution and merge-order rules in
+  `docs/engineering-baseline.md`.
+- Before parallel work begins, classify each task by lane and define merge order
+  or state why merge order is flexible.
+- Preserve one-repo/one-branch/one-PR scope integrity, workspace isolation,
+  canonical validation, direct PR inspection, and authoritative source
+  requirements.
 
 Tasks:
 1. Inspect the existing structure and related docs or code.
@@ -169,25 +149,18 @@ Tasks:
 3. Update nearby docs or tests only when they are part of the same change.
 
 Validation:
-- Run the repository's canonical validation command, for example `make check`,
-  before opening or updating a PR when it exists and can run locally.
-- Do not treat CI as a substitute for available local canonical validation.
-- Do not add or rely on alternate validation tools unless they are explicitly
-  part of the repository-defined workflow.
+- Follow the validation rules in `docs/repo-readiness.md` and repo-local
+  `AGENTS.md`.
+- Run the repository's canonical validation command, such as `make check`, when
+  it exists and can run locally.
 - Report the actual result of validation; do not assume success.
 - If validation fails, include the failure details.
-- If a local tool needed by the canonical command is unavailable, do not
-  substitute another tool; report the limitation and rely on CI for enforcement
-  of checks that cannot be run locally.
 - If validation cannot be run, explain why.
 
 Deliverable:
-- Create a new focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
-- Do not default to `codex/...` in product or implementation repositories.
-- If an isolated workspace is needed, follow the Codex adapter workspace
-  isolation rule: use `git worktree` under the repo's `.worktrees/` directory,
-  and stop for explicit approval before using any sibling worktree, full copy,
-  or clone.
+- Follow the branch, workspace, and PR delivery rules in
+  `docs/feature-lifecycle.md`, `docs/repo-readiness.md`, and
+  `docs/tool-adapters/codex.md`.
 - Stage only relevant changes.
 - Commit and push only the intended changes.
 - Open a non-draft PR against `main` unless explicitly instructed otherwise.
@@ -317,8 +290,8 @@ Use this prompt for workflow shape and readiness, not for deep code review.
 
 ### Playbook Update Use When
 
-Use this prompt when a validated workflow lesson from one or more repositories should
-be promoted into the shared playbook as reusable guidance.
+Use this prompt when an evidence-supported workflow lesson from one or more
+repositories should be promoted into the shared playbook as reusable guidance.
 
 ### Playbook Update Required Inputs
 
@@ -337,7 +310,7 @@ be promoted into the shared playbook as reusable guidance.
 
 ```text
 Task:
-Promote validated workflow rules into the playbook for <repository>.
+Promote evidence-supported workflow rules into the playbook for <repository>.
 
 Inputs:
 - Source repository: <repository>
@@ -347,27 +320,34 @@ Inputs:
 
 Instructions:
 - Review the existing playbook reference and the source repository context.
-- Identify workflow rules or patterns that have already been validated in practice and are reusable across repositories.
+- Identify workflow rules or patterns that have concrete evidence from real use,
+  review, repeated successful application, or merged repo work and are reusable
+  across repositories.
 - Update the playbook only where the lesson is durable, generic, and better captured centrally than locally.
 - Prefer tightening or extending existing playbook guidance over adding fragmented one-off notes.
 
 Constraints:
 - Treat <playbook_reference> as the canonical source for cross-repo workflow rules.
 - Do not copy project-specific implementation details, repo names, or local exceptions into the playbook.
-- Do not promote rules that are still speculative, unvalidated, or narrowly tied to one repository.
+- Do not promote rules that are still speculative, unsupported by concrete
+  evidence, or narrowly tied to one repository.
 - Keep the change scoped to one logical documentation update.
 
 Validation:
-- Verify that each promoted rule is reusable across at least two plausible repository contexts.
+- Verify that each promoted rule is backed by concrete cited evidence, not only
+  plausible reuse.
 - Verify that any repo-local rule remains outside the shared playbook.
 - Verify that updated wording does not conflict with existing core playbook documents.
 - Verify that the resulting file placement matches the playbook structure.
+- Verify that the update includes a notes cleanup follow-up or explicitly says
+  no notes cleanup is needed.
 
 Output format:
 1. Proposed playbook changes: brief summary paragraph.
 2. Rules promoted: short bullets with rationale.
 3. Files to update: list of target files and why.
-4. Validation notes: short bullets covering reuse, scope, and conflict checks.
+4. Validation notes: short bullets covering evidence, reuse, scope, conflict
+   checks, and notes cleanup.
 5. Open questions: only if a rule boundary is still unclear.
 ```
 
@@ -463,8 +443,8 @@ backlog work.
 - The source material stays a staging layer, not a commitment queue.
 - Target repositories own actionable issues only when the work is ready for a
   bounded repo change.
-- Cross-repo workflow lessons should remain playbook candidates until validated
-  by repo work; do not skip straight from raw notes to playbook updates.
+- Cross-repo workflow lessons should remain playbook candidates until supported
+  by repo evidence; do not skip straight from raw notes to playbook updates.
 
 ### Deferred Notes Issue Promotion Prompt
 
@@ -499,7 +479,7 @@ Instructions:
   a coherent sequence, but do not force arc structure when standalone issues are
   clearer.
 - Identify playbook candidates separately when the note points to a possible
-  reusable rule that still needs repo validation before promotion.
+  reusable rule that still needs concrete repo evidence before promotion.
 
 Constraints:
 - Do not create issues for every interesting idea.
@@ -525,7 +505,7 @@ Output format:
    acceptance criteria, and duplicate-check result.
 4. Optional arcs: short bullets only when grouping adds real clarity.
 5. Playbook candidates: optional bullets for reusable lessons that should wait
-   for repo validation.
+   for repo evidence.
 ```
 
 ### Deferred Notes Issue Promotion Notes
@@ -678,11 +658,11 @@ they are also expected to make and deliver repo changes.
 
 ```text
 Delivery:
-- Create a focused branch using the repository-appropriate branch naming convention from the Codex adapter guidance.
-- Do not default to `codex/...` in product or implementation repositories.
-- If isolated workspace setup is needed, use `git worktree` under the repo's
-  `.worktrees/` directory as required by the Codex adapter guidance; do not
-  create a sibling worktree, full copy, or clone without explicit approval.
+- Follow the branch, PR readiness, and workspace rules in
+  `docs/feature-lifecycle.md`, `docs/repo-readiness.md`, and
+  `docs/tool-adapters/codex.md`.
+- Fetch current `origin/main` at task start, anchor implementation to that
+  fetched baseline, and verify current mergeability before PR.
 - Stage only the relevant changes.
 - Commit with a clear message.
 - Push the branch.
@@ -776,7 +756,8 @@ Inputs:
 Instructions:
 - Inspect the current git state, existing diff, and branch context.
 - Confirm that the intended changes form one logical PR and identify any unrelated files or accidental scope.
-- If needed, create a fresh branch from current main, keep only the intended diff, and prepare a clear commit and PR description.
+- If needed, create a fresh branch from current `origin/main`, keep only the
+  intended diff, and prepare a clear commit and PR description.
 - Summarize the change in a way that supports quick human review and accurate merge decisions.
 
 Constraints:
@@ -787,7 +768,8 @@ Constraints:
 
 Validation:
 - Verify that the diff contains only the intended files and changes.
-- Verify that the branch is suitable for review and based on an appropriate mainline state.
+- Verify that the branch is suitable for review, anchored to the intended
+  mainline state, and checked for current mergeability before PR.
 - Verify that the reported validation matches what was actually run or observed.
 - Verify that the PR summary explains user-facing, workflow, or documentation impact as appropriate for the repo type.
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -163,7 +163,8 @@ Deliverable:
   `docs/tool-adapters/codex.md`.
 - Stage only relevant changes.
 - Commit and push only the intended changes.
-- Open a non-draft PR against `main` unless explicitly instructed otherwise.
+- Open a PR in the appropriate readiness state against the intended base
+  branch, usually `main`.
 - Ensure the PR contains only intended changes.
 - Include a summary, validation results, and any residual risks.
 ```
@@ -198,8 +199,8 @@ Validation:
 - Report the actual result, including failure details if it fails.
 
 Deliverable:
-- Open a non-draft PR against `main` with summary, validation results, and
-  residual risks.
+- Open a PR in the appropriate readiness state against `main` with summary,
+  validation results, and residual risks.
 ```
 
 ### Model Selection And Cost Guidance
@@ -666,7 +667,8 @@ Delivery:
 - Stage only the relevant changes.
 - Commit with a clear message.
 - Push the branch.
-- Open a non-draft PR against the intended base branch, usually `main`, unless a draft PR is explicitly requested.
+- Open a PR in the appropriate readiness state against the intended base branch,
+  usually `main`.
 - Report the PR link, files changed, and validation results.
 ```
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -29,7 +29,12 @@ Open a pull request as ready for review when all of the following are true:
 - overlap and coordination risk are low
 - issue lifecycle should not affect pull request readiness; using `Closes #<issue>` follows standard GitHub behavior and should not delay marking a pull request as ready
 
-Before opening or updating a pull request, fetch current `origin/main`. If the branch is not based on current `origin/main`, update it onto current `origin/main`, resolve conflicts within the original task scope only, rerun the repository validation target, avoid unrelated cleanup, then push.
+Before opening or updating a pull request, fetch current `origin/main` and
+verify whether the branch is mergeable against current `main`. Update or rebase
+only for conflicts, overlapping upstream changes, repo policy, or explicit
+human request. Keep any conflict resolution within the original task scope,
+avoid unrelated cleanup, rerun the canonical validation entrypoint after the
+update, then push.
 
 Open a pull request as draft when any of the following are true:
 
@@ -38,7 +43,8 @@ Open a pull request as draft when any of the following are true:
 - reconciliation with other pending work is likely
 - the branch is intentionally staged for later promotion
 
-Docs-only changes should default to ready for review when they are validated and isolated.
+Docs-only changes should default to ready for review when canonical validation
+passes and the diff is isolated.
 
 When working in a multi-repo workspace, treat each repository as an independent unit of change. Even if multiple repositories are visible, commits, branches, and PRs must be created and managed per repository. Do not create cross-repo commits or PRs.
 
@@ -49,7 +55,8 @@ Before opening a PR, ensure that all staged changes belong to a single repositor
 Treat the following as the default branch protection baseline for `main`:
 
 - pull requests are required for changes to `main`
-- the repository validation check is required, typically `make check` or an equivalent single entrypoint
+- the repository validation check is required, typically `make check`; if a
+  repository uses a different single entrypoint, that repo's `AGENTS.md` owns it
 - admins follow the same merge rules
 - required approvals are not part of the default baseline unless a repository defines stricter repo-specific rules
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -21,10 +21,16 @@
 ## Notes vs Playbook
 
 - `cross-repo-threads` is a staging layer for ideas and experiments.
-- It is not canonical; treat repository code, tests, and docs as the source of truth and verify against playbook guidance.
+- It is not canonical and is not a direct path into playbook guidance.
+- Durable workflow guidance follows this order: idea -> notes staging ->
+  bounded repo issue or PR -> evidence-supported reusable lesson -> playbook
+  promotion -> notes cleanup.
+- Treat repository code, tests, docs, reviews, and merged PRs as the evidence
+  source for reusable lessons before promoting them into the playbook.
 
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
-- Validate with the repo's Makefile.
+- Run repository validation through the repo's Makefile when it provides the
+  canonical entrypoint.
 - Open PRs ready for review by default unless explicitly instructed otherwise.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -18,14 +18,18 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 - when multiple Codex projects, worktrees, or isolated directories are active, treat repository identity and execution-container identity as separate checks: confirm that the active execution container belongs to the repository named in the task before making changes; do not treat directory naming or a clean checkout alone as proof; if the active project or worktree does not match the intended repository, pause and switch before proceeding
 - keep this lightweight for normal same-repo work; a quick sanity check is enough
 - at the start of repo-scoped work, inspect the current git state
-- for every new repo-scoped arc, fetch `origin/main` once at the start and treat that fetched tip as the canonical base for the run
+- for every new repo-scoped arc, fetch current `origin/main` at task start and
+  anchor implementation to that fetched baseline
 - only remain on or reuse the current branch when the task explicitly says to continue that branch or PR
 - otherwise, create a new branch for the arc
 - if the active worktree or directory is not on up-to-date `main`, switch or recreate the branch from current `origin/main` before making changes
 - for medium or large arcs, verify the working branch is based on current `origin/main` before meaningful edits begin
-- after the run, check whether the resulting branch or PR is still mergeable against current `main`; if upstream moved in the meantime, treat that as a final-state mergeability check rather than a reason to restart or rebase mid-run by default
+- before opening or updating the PR, verify whether the resulting branch is
+  mergeable against current `main`
 - distinguish local execution state from remote PR state: a clean local branch means the run completed cleanly against its anchored base, while GitHub mergeability reflects the current remote state after newer `main` movement, required checks, and review requirements
-- make exceptions only when the task explicitly requires rebasing or when a real conflict or blocker appears that prevents finishing the requested work cleanly
+- update or rebase only when there is a conflict, overlapping upstream change,
+  repo policy requirement, or explicit human request; rerun canonical validation
+  after any update or rebase
 - do not treat transient GitHub `BLOCKED` or pending states as mid-run failures by default; inspect whether the cause is pending checks, pending review requirements, dependency ordering, or a true merge conflict, then wait or act accordingly
 - if normalization is unsafe or the state is unclear, pause and report rather than forcing cleanup
 
@@ -195,7 +199,7 @@ Codex should pause and ask for human input when:
   cleanliness alone
 - when refining an active PR within the same arc, update the existing branch and PR rather than opening a new PR; open a new PR only when the work changes phase, scope, or review surface
 - avoid bundling unrelated cleanup into the same PR
-- before calling the work complete, verify the PR diff contains only the intended arc; if `main` moved underneath the branch and overlap occurred, sync with current `main`, resolve conflicts, and rerun validation; if the branch carries unrelated history, rebuild the work onto a clean branch from current `main`
+- before calling the work complete, verify the PR diff contains only the intended arc; if `main` moved underneath the branch and overlap occurred, sync with current `main`, resolve conflicts, and rerun validation; if the branch carries unrelated history, rebuild the work onto a clean branch from current `origin/main`
 
 When behavior or supported capability changes, quickly check the existing docs for that area and update any statements that would become inaccurate before calling the work complete.
 

--- a/docs/trust-topology.md
+++ b/docs/trust-topology.md
@@ -4,9 +4,9 @@ Use this optional model when a workflow pattern needs a lightweight way to
 describe how much trust it has earned and what evidence supports that trust.
 
 The goal is to make promotion and cleanup decisions easier without adding a new
-required workflow step. If a pattern is already clearly validated, keep moving.
-If confidence is unclear, use this model to name the current trust level and the
-evidence behind it.
+required workflow step. If a pattern is already clearly evidence-supported, keep
+moving. If confidence is unclear, use this model to name the current trust level
+and the evidence behind it.
 
 This document adapts trust topology ideas into a practical workflow model for
 AI-assisted development systems.
@@ -24,8 +24,8 @@ Use it for playbook guidance, staging notes, prompt patterns, review workflows,
 or tool-adapter behavior that may later become canonical.
 
 Do not use it to create required metadata fields, a second tracking system, or a
-reason to promote speculative ideas. The playbook remains reusable, validated,
-and non-speculative.
+reason to promote speculative ideas. The playbook remains reusable,
+evidence-supported, and non-speculative.
 
 ## Trust Levels
 
@@ -101,7 +101,8 @@ Weak evidence includes:
 
 - a single anecdote without a merged result
 - a pattern that sounds right but has not been tried
-- copied guidance from another context that has not been validated locally
+- copied guidance from another context that has not been supported by local
+  evidence
 - broad claims without examples
 
 Evidence does not need a formal schema. A short note, PR link, review packet, or
@@ -136,19 +137,19 @@ Examples:
 
 When a dependency changes, revisit the dependent pattern before promoting it.
 
-### Validated By
+### Confirmed By
 
-Use `validated-by` when a check, review, or real usage confirms that a pattern
+Use `confirmed-by` when a check, review, or real usage confirms that a pattern
 worked in practice.
 
 Examples:
 
-- a docs change validated by `make check`
-- a workflow rule validated by a ready-for-review PR using it end to end
-- a prompt pattern validated by review feedback that found the output useful
+- a docs change confirmed by `make check`
+- a workflow rule confirmed by a ready-for-review PR using it end to end
+- a prompt pattern confirmed by review feedback that found the output useful
 
-Validation can be local, CI-based, manual, or reviewer-based. Be explicit about
-which kind was used.
+Confirmation can be local, CI-based, manual, or reviewer-based. Be explicit
+about which kind was used.
 
 ## Promotion Guidance
 
@@ -161,8 +162,8 @@ Use this progression as a guide:
 2. Move to `emerging` after repeated use shows the pattern is useful.
 3. Move to `strong` after it works across boundaries such as repos, phases, or
    reviewers.
-4. Move to `canonical` only when it is reusable, validated, non-speculative, and
-   clear enough to guide action.
+4. Move to `canonical` only when it is reusable, evidence-supported,
+   non-speculative, and clear enough to guide action.
 
 Promotion should be small and operational. When moving a pattern into the
 playbook:
@@ -204,7 +205,7 @@ Edges:
 
 - review feedback `supports` the packet shape
 - the packet format `depends-on` the feature lifecycle release phase
-- successful PR reviews are `validated-by` human inspection and CI results
+- successful PR reviews are `confirmed-by` human inspection and CI results
 
 ### Notes Cleanup Rule
 
@@ -217,7 +218,7 @@ Edges:
 
 - cleanup PRs `support` the rule
 - the rule `depends-on` the notes-versus-playbook boundary
-- markdown checks and reviewer confirmation `validated-by` the cleanup result
+- markdown checks and reviewer confirmation `confirmed-by` the cleanup result
 
 ### Tool Adapter Behavior
 
@@ -230,7 +231,7 @@ Edges:
 
 - repeated adapter usage `supports` the pattern
 - adapter guidance `depends-on` the core model
-- successful task completion `validated-by` the repo's normal checks and review
+- successful task completion `confirmed-by` the repo's normal checks and review
 
 ## Background and Further Reading
 


### PR DESCRIPTION
## Summary

This PR resolves the highest-risk playbook drift found by the audits by tightening source-of-truth language without broad rewriting.

Contradictions resolved:
- Normalizes the durable lifecycle to: idea -> notes staging -> bounded repo issue/PR -> evidence-supported reusable lesson -> playbook promotion -> notes cleanup.
- Aligns task-start and PR-readiness wording around fetching current `origin/main`, anchoring implementation to that fetched baseline, verifying mergeability before PR, and updating/rebasing only for conflicts, overlapping upstream changes, repo policy, or explicit request.
- Separates repository validation language from evidence-supported playbook promotion language.
- Removes soft "plausible reuse" promotion criteria and requires concrete cited evidence from real use, review, repeated successful application, or merged repo work.
- Reduces prompt template drift by pointing branch, validation, public API, PR inspection, workspace, and parallel execution behavior back to canonical owning docs.
- Marks maintenance automation inventory as non-canonical reference material, with runtime state owned by local automation configs.

## Files Changed

- `README.md`
- `docs/start-here.md`
- `docs/feature-lifecycle.md`
- `docs/engineering-baseline.md`
- `docs/repo-readiness.md`
- `docs/notes-repositories.md`
- `docs/prompts.md`
- `docs/trust-topology.md`
- `docs/maintenance-automations.md`
- `docs/context-refresh.md`
- `docs/tool-adapters/codex.md`

## Validation

- `make check` passed.
- Fetched current `origin/main` before PR preparation.
- Verified `origin/main` is an ancestor of this branch.
- Verified synthetic merge tree against current `origin/main` completed without conflicts.

## Residual Risks / Deferred Findings

- This PR intentionally does not move local automation configs or notes files between repositories.
- This PR does not implement scanner or workflow tooling.
- Broader glossary work is deferred; only terms needed to resolve this drift were added locally in `docs/notes-repositories.md`.