### PR TITLE
[codex] docs: promote reusable bootstrap guidance

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -141,6 +141,28 @@ sources before making the change.
 This requirement does not apply to trivial changes or internal-only refactors
 that do not depend on external API semantics.
 
+### External Dependency Boundaries
+
+For repositories that depend on external providers, specs, CLIs, SDKs, or
+hosted platforms, keep the boundary between documented behavior and local
+assumption visible:
+
+- Treat official provider or specification docs as authoritative for behavior
+  claims.
+- Distinguish documented guarantees from observed behavior in code comments,
+  docs, tests, risks, and PR notes.
+- Record the checked date when the behavior is operationally important,
+  time-sensitive, or likely to change.
+- Prefer conservative workflows when docs are incomplete, ambiguous, or silent.
+- Do not turn unverified assumptions into architecture, public guarantees, or
+  destructive default behavior.
+- Keep credentials in the environment or approved secret stores; do not encode
+  account-specific state, private topology, or local paths into reusable docs.
+
+Provider-specific API semantics belong in the repository that uses that
+provider, backed by direct official sources. The playbook should define the
+verification posture, not repeat external documentation.
+
 ### Reusable Advisory Check
 
 Repositories can call the canonical advisory scanner from this playbook instead

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -145,7 +145,8 @@ that do not depend on external API semantics.
 
 For repositories that depend on external providers, specs, CLIs, SDKs, or
 hosted platforms, keep the boundary between documented behavior and local
-assumption visible:
+assumption visible. This boundary is part of the repository's safety posture,
+not just a citation habit:
 
 - Treat official provider or specification docs as authoritative for behavior
   claims.

--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -14,6 +14,26 @@ Use this pattern when bootstrapping a brand-new repository from a fresh project 
 
 This keeps the actual bootstrap reviewable while avoiding ambiguity about where the repository starts.
 
+## Bootstrap Content Checklist
+
+Include only the durable repo-shaping decisions needed before normal feature
+work begins:
+
+- purpose and audience
+- public or private posture
+- license selection for public repositories
+- non-affiliation language when the repository could be mistaken for an
+  official, vendor-owned, or endorsed project
+- scope boundaries and explicit non-goals
+- safety model for mutation-capable workflows
+- credential handling expectations
+- validation entrypoint or current validation gap
+- ecosystem registration needs after bootstrap
+
+Keep these decisions short and operational. Repo-specific examples,
+implementation details, provider behavior, and legal analysis belong outside
+the reusable playbook.
+
 ## Lessons
 
 ### Base Branch First
@@ -27,6 +47,46 @@ If the bootstrap work is complete, the PR should be ready for review by default.
 ### Relative Links From The Start
 
 Repo docs should use relative links from the start. Absolute local filesystem paths are not portable and can leak machine-specific context into the repository.
+
+### Positioning Before Features
+
+Establish the repository's public posture before feature growth. A public
+infrastructure-adjacent repository should state what it is, who owns it, and
+what it is not. If readers could confuse it with an official provider,
+upstream, customer, or employer project, include a brief non-affiliation
+statement in repo-local docs.
+
+Do not turn positioning into legal policy. The reusable requirement is clarity:
+avoid implied endorsement, hidden ownership assumptions, or ambiguous safety
+claims.
+
+### Scope And Non-Goals
+
+Define the first working boundary before adding implementation weight:
+
+- what workflows the repository intentionally supports
+- what workflows it intentionally excludes
+- what live-service, production, destructive, or credentialed behavior is out
+  of scope by default
+- what assumptions must remain explicit until verified
+
+Use non-goals to prevent accidental expansion, not to document every possible
+future idea.
+
+### Public-Safe Operating Posture
+
+For public repositories near infrastructure, automation, credentials, or
+mutable external systems, default to conservative safety boundaries:
+
+- dry-run or inspect-first behavior before mutation
+- deterministic manifests or reports for reviewable output
+- environment-only credential handling
+- no committed secrets, local paths, account identifiers, or private topology
+- explicit confirmation for destructive or irreversible operations
+- clear separation between observed behavior and documented guarantees
+
+The playbook guidance is the posture, not a mandate for a specific
+architecture.
 
 ### Validation In A Docs-First Repo
 
@@ -43,6 +103,22 @@ Keep the bootstrap workflow tool-aware but practical:
 - repo and PR metadata may be easier to inspect through a connector when available
 - repo creation, branch publishing, or current-branch PR actions may still need `gh`
 - if a connector mutation misbehaves, use the simplest working CLI fallback and verify the resulting state
+
+### Ecosystem Registration After Bootstrap
+
+A repository is not fully integrated when the first bootstrap PR merges. After
+bootstrap, check that surrounding workflow systems recognize the repository
+consistently:
+
+- repo inventories or org briefs
+- automation inventories or scheduled maintenance lists
+- cross-repo prompts or context refresh inputs
+- sibling-repo references, when they intentionally name the repository
+- validation or advisory workflow adoption, when applicable
+
+Keep this lightweight. The reusable lesson is to distinguish intentionally
+excluded repositories from accidentally invisible ones, then update only the
+systems that should know about the repo.
 
 ## Reuse
 

--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -14,10 +14,12 @@ Use this pattern when bootstrapping a brand-new repository from a fresh project 
 
 This keeps the actual bootstrap reviewable while avoiding ambiguity about where the repository starts.
 
-## Bootstrap Content Checklist
+## Bootstrap Posture Checklist
 
-Include only the durable repo-shaping decisions needed before normal feature
-work begins:
+For public, infrastructure-adjacent, or externally dependent repositories,
+bootstrap should connect public positioning, operational posture, and technical
+shape before feature work begins. Include only the durable repo-shaping
+decisions needed to make that posture clear:
 
 - purpose and audience
 - public or private posture
@@ -25,10 +27,13 @@ work begins:
 - non-affiliation language when the repository could be mistaken for an
   official, vendor-owned, or endorsed project
 - scope boundaries and explicit non-goals
-- safety model for mutation-capable workflows
+- safety model and mutation boundaries
+- reviewable artifacts, such as deterministic manifests or reports, when the
+  repository produces operational output
 - credential handling expectations
+- authoritative external documentation boundaries
 - validation entrypoint or current validation gap
-- ecosystem registration needs after bootstrap
+- lightweight ecosystem registration needs after bootstrap
 
 Keep these decisions short and operational. Repo-specific examples,
 implementation details, provider behavior, and legal analysis belong outside
@@ -48,13 +53,13 @@ If the bootstrap work is complete, the PR should be ready for review by default.
 
 Repo docs should use relative links from the start. Absolute local filesystem paths are not portable and can leak machine-specific context into the repository.
 
-### Positioning Before Features
+### Positioning, Scope, And Architecture
 
-Establish the repository's public posture before feature growth. A public
-infrastructure-adjacent repository should state what it is, who owns it, and
-what it is not. If readers could confuse it with an official provider,
-upstream, customer, or employer project, include a brief non-affiliation
-statement in repo-local docs.
+Establish one coherent posture before feature growth. A repository should state
+what it is, what it is not, and how its technical choices reinforce that
+boundary. If readers could confuse it with an official provider, upstream,
+customer, or employer project, include a brief non-affiliation statement in
+repo-local docs.
 
 Do not turn positioning into legal policy. The reusable requirement is clarity:
 avoid implied endorsement, hidden ownership assumptions, or ambiguous safety
@@ -70,15 +75,19 @@ Define the first working boundary before adding implementation weight:
   of scope by default
 - what assumptions must remain explicit until verified
 
-Use non-goals to prevent accidental expansion, not to document every possible
-future idea.
+Use non-goals to prevent accidental expansion, especially platform gravity
+toward orchestration systems, desired-state platforms, automation frameworks,
+or generalized control planes. Include that evolution only when it is an
+explicit repository goal.
 
 ### Public-Safe Operating Posture
 
 For public repositories near infrastructure, automation, credentials, or
-mutable external systems, default to conservative safety boundaries:
+mutable external systems, default to conservative safety boundaries. The
+architecture should match the stated posture:
 
 - dry-run or inspect-first behavior before mutation
+- explicit mutation boundaries
 - deterministic manifests or reports for reviewable output
 - environment-only credential handling
 - no committed secrets, local paths, account identifiers, or private topology
@@ -86,7 +95,8 @@ mutable external systems, default to conservative safety boundaries:
 - clear separation between observed behavior and documented guarantees
 
 The playbook guidance is the posture, not a mandate for a specific
-architecture.
+architecture. Avoid hidden destructive behavior and do not let implementation
+convenience contradict the public scope or safety claim.
 
 ### Validation In A Docs-First Repo
 
@@ -104,21 +114,24 @@ Keep the bootstrap workflow tool-aware but practical:
 - repo creation, branch publishing, or current-branch PR actions may still need `gh`
 - if a connector mutation misbehaves, use the simplest working CLI fallback and verify the resulting state
 
-### Ecosystem Registration After Bootstrap
+### Lightweight Ecosystem Registration
 
 A repository is not fully integrated when the first bootstrap PR merges. After
-bootstrap, check that surrounding workflow systems recognize the repository
-consistently:
+bootstrap, check that surrounding workflow systems know the repository exists
+where that awareness matters:
 
 - repo inventories or org briefs
-- automation inventories or scheduled maintenance lists
+- automation inventories or scheduled maintenance lists, when the repo is
+  intentionally covered
 - cross-repo prompts or context refresh inputs
 - sibling-repo references, when they intentionally name the repository
 - validation or advisory workflow adoption, when applicable
 
-Keep this lightweight. The reusable lesson is to distinguish intentionally
-excluded repositories from accidentally invisible ones, then update only the
-systems that should know about the repo.
+Keep this lightweight. Registration means inventories, audits, and context
+systems can classify the repo correctly. It does not imply mature automation
+support, operational ownership, or service guarantees. Distinguish
+intentionally excluded repositories from accidentally invisible ones, then
+update only the systems that should know about the repo.
 
 ## Reuse
 


### PR DESCRIPTION
## Summary

- Reframe the promoted bootstrap guidance as a cohesive bootstrap posture for public, infrastructure-adjacent, or externally dependent repositories.
- Connect public positioning, scope/non-goals, safety posture, and architecture choices so dry-run-first workflows, explicit mutation boundaries, deterministic outputs, and env-only credentials reinforce the stated repo boundary.
- Add concise platform-gravity guidance and tighten lightweight ecosystem registration so inventories and context systems can recognize a repo without implying automation ownership or operational guarantees.
- Add external dependency boundary guidance to the engineering baseline, emphasizing official provider/spec documentation, documented-vs-observed behavior, checked dates when relevant, and conservative handling of ambiguity.

## Rationale

The same operational patterns have now appeared across multiple public, infrastructure-adjacent repositories. This promotes only the durable abstraction into the playbook so future repositories can reuse the posture without copying repo-specific language or provider implementation details.

## Validation

- `make check` passed locally.
- GitHub checks passed: `markdownlint` and `authoritative-source-check`.
- Changed-file scan found no repository- or provider-specific names in the new guidance.
- Reviewed for duplicate bootstrap guidance; additions extend `docs/new-repo-bootstrap.md` instead of creating a new fragmented doc.

## Deferred

- Provider-specific behavior, repo-specific disclaimers, provider API semantics, automation implementation, orchestration patterns, legal-policy material, and contributor-license-policy design remain intentionally out of scope.