### PR TITLE
[codex] docs: clarify validation check taxonomy

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -64,8 +64,9 @@ branch and PR. Simple one-step tasks do not need this much structure.
 - `Constraints`: guardrails that prevent overengineering, unrelated cleanup, and
   behavior drift.
 - `Tasks`: ordered work items when the path matters.
-- `Validation`: concrete repo commands or checks, such as `make check`, plus any
-  manual review expected.
+- `Validation`: the canonical repo command, such as `make check`, when
+  available, plus any explicitly advisory, CI-only, release-only, or manual
+  review expectations.
 - `Deliverable`: branch, commit, PR, review packet, or handoff expectations.
 
 Keep prompts concise but complete. The goal is to remove ambiguity that would

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -57,6 +57,8 @@ Treat the following as the default branch protection baseline for `main`:
 - pull requests are required for changes to `main`
 - the repository validation check is required, typically `make check`; if a
   repository uses a different single entrypoint, that repo's `AGENTS.md` owns it
+- additional CI-only checks block merge only when branch protection or
+  repo-local guidance explicitly makes them required
 - admins follow the same merge rules
 - required approvals are not part of the default baseline unless a repository defines stricter repo-specific rules
 
@@ -70,7 +72,8 @@ This document defines expectations, not exact GitHub settings.
 - the canonical validation entrypoint, typically `make check`
 - what the canonical validation entrypoint includes
 - justified exclusions from local validation
-- CI-only or advisory checks that are not part of the local blocking path
+- CI-only, advisory, smoke, chaos, or release-only checks that are not part of
+  the local blocking path, including whether they block merge or release
 - branch or commit conventions that are specific to the repository
 - repo-specific constraints, boundaries, or file placement rules
 
@@ -93,6 +96,35 @@ Reusable workflow rules belong in the playbook, not duplicated into each reposit
   environment.
 - CI is the enforcement layer.
 - Local validation should match CI behavior as closely as practical.
+
+### Check Taxonomy And Gates
+
+Use one clear role for each check:
+
+- Canonical local validation is the repo-owned local command, typically
+  `make check`. When it exists and can run locally, it blocks local readiness
+  and PR completion until it passes.
+- CI-only checks run remotely because they have no practical local canonical
+  path, require hosted infrastructure, depend on credentials, or are too slow or
+  disruptive for normal local work. They block merge only when branch protection
+  or repo-local guidance explicitly requires them.
+- Advisory checks surface risk or missing evidence. They do not block local
+  readiness, merge, or release unless the repository deliberately promotes them
+  into a documented required check.
+- Smoke checks are narrow confidence checks. Their gate depends on placement:
+  inside `make check` they block local readiness, as required CI they block
+  merge, and otherwise they remain advisory.
+- Chaos checks exercise resilience, stress, failure modes, or long-running
+  scenarios. Default them to advisory, scheduled, or release-only unless the
+  repository explicitly documents a stricter merge or release gate.
+- Release-only checks run for release preparation or publish decisions. They
+  block release when documented, but they do not block ordinary PR readiness or
+  merge unless repo-local guidance says so.
+
+Do not create hidden validation gates. If a check is expected to block local
+readiness, merge, or release, document the check name, when it runs, what it
+blocks, and what to report when it is unavailable. Otherwise report the result
+as informational or advisory evidence, not as an unstated requirement.
 
 ### Minimum `make check` Coverage By Repo Type
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -219,6 +219,8 @@ When behavior or supported capability changes, quickly check the existing docs f
 - treat checks as CI-only only when the repository does not expose a local
   canonical path for them or the local canonical path cannot run in the current
   environment
+- do not infer merge or release gates from check names alone; use the
+  repository's documented validation taxonomy and required CI status
 - report clearly when no local validation path exists
 - until a formal validation path exists, report that gap and keep any review to
   scope and consistency notes rather than presenting it as substitute


### PR DESCRIPTION
## Summary

Clarifies the relationship between canonical local validation and additional check types without adding new process layers.

Terminology decisions:
- Canonical local validation is the repo-owned local command, typically `make check`, and blocks local readiness when available.
- CI-only checks block merge only when branch protection or repo-local guidance explicitly makes them required.
- Advisory checks remain informational unless deliberately promoted into a documented required check.
- Smoke checks inherit their gate from placement: `make check`, required CI, or advisory.
- Chaos checks default to advisory, scheduled, or release-only unless a repo documents a stricter gate.
- Release-only checks block release when documented, but do not automatically block ordinary PR readiness or merge.
- Hidden validation gates are explicitly discouraged; blocking checks need their name, timing, blocking scope, and unavailable-state reporting documented.

## Affected Docs

- `docs/repo-readiness.md`: adds the taxonomy and gate boundaries, plus AGENTS/branch-protection wording for extra checks.
- `docs/tool-adapters/codex.md`: tells Codex not to infer merge or release gates from check names alone.
- `docs/prompts.md`: tightens the validation field wording around canonical, advisory, CI-only, release-only, and manual review expectations.

## Validation

- `make check` passed.
- Reviewed the updated wording against this repo's `AGENTS.md`; it preserves `make check` as the canonical local validation path and keeps advisory source scanning non-blocking unless a caller configures stricter behavior.
- Reviewed for reuse across docs, code, API/provider-facing, and mixed repositories through the existing repo-readiness coverage model.

## Remaining Ambiguity / Follow-Up

- Repositories still need to document their own specific check names and branch-protection settings in repo-local guidance when they choose stricter gates.
- This PR does not define release-management automation or repo-specific CI implementations.

Closes #108