### PR TITLE
[codex] harden authoritative source adoption model

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -15,7 +15,7 @@ on:
         type: string
         default: changed
       official_domains:
-        description: Additional official documentation domain suffixes, separated by commas or spaces.
+        description: Additional narrow official documentation domain suffixes, separated by commas or spaces.
         required: false
         type: string
         default: ""

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -201,6 +201,54 @@ Markdown file instead of the pull request's changed Markdown files. Use
 authoritative for the caller repository but not built into the scanner. Use
 `playbook_ref` only when testing or pinning a non-`main` playbook ref.
 
+### Incremental Advisory Adoption
+
+Use the advisory check first in API-facing repositories where public API claims
+are common and the repository already has a clear canonical validation path.
+Google-facing and Atlassian-facing repositories are good candidates when their
+docs, tests, or PR notes regularly cite vendor API behavior.
+
+Adopt the check in this order:
+
+1. Inventory the changed surfaces that make public API claims, such as docs,
+   generated-client notes, schemas, examples, and PR descriptions.
+2. Identify the narrow official vendor documentation domains needed for that
+   repository's APIs. Prefer product API references, developer portals,
+   official schemas, SDK docs, release notes, and changelogs controlled by the
+   vendor.
+3. Add the reusable workflow in `scan_mode: changed` with only those narrow
+   `official_domains`. Keep it advisory and visible in PR checks.
+4. Triage the first findings in ordinary PR review. Replace community, blog, or
+   third-party links with official sources when official sources exist.
+5. Use a nearby source justification only when official docs are unavailable,
+   ambiguous, or insufficient for the specific edge case. Keep the claim
+   conservative.
+6. Expand to the next repository only after the current repository has a small,
+   understandable finding pattern and no broad domain suppressions.
+
+Keep rollout lightweight. Do not require every historical Markdown file to be
+clean before adoption. Use `scan_mode: all` only for an explicit audit PR, not
+as the default rollout posture. Do not make advisory warnings required merge
+gates unless the caller repository explicitly documents that stricter local
+policy.
+
+False-positive mitigation should stay local and narrow:
+
+- Prefer specific official documentation domains over broad corporate domains.
+- Do not add broad allowlists for mixed domains that also host community,
+  marketing, or blog content.
+- Keep third-party investigation links separate from authoritative API claims,
+  or add a nearby source justification when no official source exists.
+- Avoid mixed source dumps where one community link appears to support many API
+  claims.
+- Fix wording when the scanner reveals an unsupported guarantee rather than
+  suppressing the finding.
+
+Implementation details remain in the reusable workflow and scanner. Caller
+repositories should document only their chosen official documentation domains,
+any repo-local advisory status, and any intentional exclusions from local
+blocking validation.
+
 ### Reusable Workflow Pinning
 
 Reusable workflows consumed by other repositories should be treated as

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -121,6 +121,14 @@ sources before making the change.
   - official OpenAPI or schema definitions
   - official SDK documentation
   - official release notes or changelogs
+- Treat a source as authoritative only when it is controlled by the provider or
+  standards body responsible for the behavior and is specific enough to support
+  the claim being made. Product API references, developer portals, schema
+  definitions, SDK docs, and provider release notes are good evidence.
+- Do not treat generic corporate home pages, marketing pages, blogs, forums,
+  community answers, issue comments, StackOverflow answers, third-party
+  tutorials, AI-generated content, or search-result snippets as authoritative
+  evidence for public API behavior.
 - Check official sources for behavior such as resource lifecycle or status
   semantics, region or location availability, pagination, rate limits and
   retryability, auth or token error behavior, deletion and idempotency
@@ -200,6 +208,56 @@ Markdown file instead of the pull request's changed Markdown files. Use
 `official_domains` to add provider-controlled documentation domains that are
 authoritative for the caller repository but not built into the scanner. Use
 `playbook_ref` only when testing or pinning a non-`main` playbook ref.
+
+### Official Domain Classification
+
+Keep official-source classification narrow and explainable. Add documentation
+domains that are controlled by the provider and are used for API references,
+developer docs, SDK docs, official schemas, changelogs, release notes, or
+product support docs that directly describe the behavior in question.
+
+Do not add broad generic domains just because a vendor owns them. Avoid
+allowlisting mixed surfaces such as blogs, communities, marketplaces, marketing
+sites, support forums, or generic corporate roots when only a documentation
+subdomain or developer portal is authoritative.
+
+The scanner includes narrow Google and Atlassian documentation domains because
+they are common adoption targets:
+
+- Google: `cloud.google.com`, `developers.google.com`, and
+  `firebase.google.com`.
+- Atlassian: `developer.atlassian.com`, `docs.atlassian.com`, and
+  `support.atlassian.com`.
+
+These defaults do not imply that `google.com`, `atlassian.com`, `blog.google`,
+`community.atlassian.com`, or other mixed/community domains are authoritative.
+Caller repositories can still add more narrow `official_domains` when their
+public API surface depends on another provider-controlled documentation domain.
+
+Same-organization GitHub repository links are intentionally treated as project
+references for this playbook's repositories. They are useful for local project
+history, reusable workflow behavior, and issue or PR context owned by the same
+organization. They are not a substitute for provider documentation when the
+claim is about an external public API.
+
+### Source Justifications
+
+Suppressions must be visible, justified, and intentionally scoped. A
+non-authoritative source may remain only when official docs are unavailable,
+ambiguous, or insufficient for the specific edge case being discussed.
+
+Use a nearby justification marker with a reason, such as:
+
+```text
+Source justification: official docs do not cover this API edge case; this link is investigation context only.
+```
+
+The scanner recognizes `Source justification:`, `Source exception:`,
+`non-authoritative-source-ok:`, and `third-party-source-ok:` only when the
+marker includes text after the colon and appears near the URL. Bare markers or
+distant blanket exceptions are not suppressions. Keep the source claim
+conservative, prefer replacing the link with official docs when possible, and
+leave the exception visible in the reviewed Markdown or PR body.
 
 ### Incremental Advisory Adoption
 

--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -23,7 +23,17 @@ PUBLIC_API_CONTEXT_RE = re.compile(
     re.IGNORECASE,
 )
 
-DEFAULT_OFFICIAL_SUFFIXES = ("akamai.com", "linode.com", "python.org")
+DEFAULT_OFFICIAL_SUFFIXES = (
+    "akamai.com",
+    "linode.com",
+    "python.org",
+    "cloud.google.com",
+    "developers.google.com",
+    "firebase.google.com",
+    "developer.atlassian.com",
+    "docs.atlassian.com",
+    "support.atlassian.com",
+)
 OFFICIAL_GITHUB_DOMAINS = {"api.github.com", "docs.github.com"}
 OFFICIAL_GITHUB_PATH_MARKERS = (
     "/github/docs",
@@ -32,13 +42,12 @@ OFFICIAL_GITHUB_PATH_MARKERS = (
 )
 SAME_ORG_GITHUB_OWNERS = {"ctrl-alt-keith"}
 KNOWN_THIRD_PARTY_SUFFIXES = ("stackoverflow.com", "medium.com", "dev.to")
-JUSTIFICATION_MARKERS = (
-    "source justification:",
-    "source exception:",
-    "non-authoritative-source-ok",
-    "third-party-source-ok",
-    "official docs unavailable",
-    "authoritative docs unavailable",
+JUSTIFICATION_RE = re.compile(
+    r"\b("
+    r"source justification|source exception|"
+    r"non-authoritative-source-ok|third-party-source-ok"
+    r")\s*:\s*\S",
+    re.IGNORECASE,
 )
 
 
@@ -104,7 +113,7 @@ def reason_for(url: str) -> tuple[str, str]:
 
 def justified(lines: list[str], index: int) -> bool:
     nearby = " ".join(lines[max(0, index - 1) : min(len(lines), index + 2)]).lower()
-    return any(marker in nearby for marker in JUSTIFICATION_MARKERS)
+    return JUSTIFICATION_RE.search(nearby) is not None
 
 
 def public_api_context(lines: list[str], index: int) -> str | None:
@@ -218,7 +227,7 @@ def warning_line(finding: dict[str, object]) -> str:
         message += f" {finding['count']} URLs from this domain were detected."
     message += (
         f" Matched public API context: {finding['context']}. "
-        "Replace with official docs or add a source justification if official docs are unavailable."
+        "Replace with official docs or add a visible source justification if official docs are unavailable."
     )
     message = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -49,6 +49,71 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
 
         self.assertEqual(findings, [])
 
+    def test_google_official_doc_domains_are_allowed_by_default(self) -> None:
+        urls = [
+            "https://cloud.google.com/apis/docs/overview",
+            "https://developers.google.com/workspace/gmail/api/guides",
+            "https://firebase.google.com/docs/reference",
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                findings = scanner.scan_text(
+                    "docs/example.md",
+                    f"Google API source: {url}",
+                )
+
+                self.assertEqual(findings, [])
+
+    def test_atlassian_official_doc_domains_are_allowed_by_default(self) -> None:
+        urls = [
+            "https://developer.atlassian.com/cloud/jira/platform/rest/v3/",
+            "https://docs.atlassian.com/software/jira/docs/api/latest/",
+            "https://support.atlassian.com/jira-cloud-administration/docs/",
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                findings = scanner.scan_text(
+                    "docs/example.md",
+                    f"Atlassian API source: {url}",
+                )
+
+                self.assertEqual(findings, [])
+
+    def test_google_and_atlassian_community_domains_still_warn(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "\n".join(
+                [
+                    "Google API source: https://blog.google/products/workspace/example",
+                    "Atlassian API source: https://community.atlassian.com/t5/example/post",
+                ]
+            ),
+        )
+
+        self.assertEqual(
+            [finding["domain"] for finding in findings],
+            ["blog.google", "community.atlassian.com"],
+        )
+
+    def test_same_org_github_project_reference_is_intentionally_allowed(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "Project API behavior source: https://github.com/ctrl-alt-keith/example-repo/pull/1",
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_other_github_project_reference_still_warns(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "Project API behavior source: https://github.com/example/example-repo/pull/1",
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["domain"], "github.com")
+
     def test_configured_domains_accept_comma_and_space_separated_values(self) -> None:
         domains = scanner.configured_domains(
             ["https://docs.aws.amazon.com, cloud.google.com learn.microsoft.com"]
@@ -71,6 +136,19 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
         )
 
         self.assertEqual(findings, [])
+
+    def test_suppression_marker_without_reason_does_not_suppress_warning(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "\n".join(
+                [
+                    "non-authoritative-source-ok",
+                    "REST retry behavior source: https://medium.com/example/post",
+                ]
+            ),
+        )
+
+        self.assertEqual(len(findings), 1)
 
     def test_warning_line_describes_actionable_public_api_remediation(self) -> None:
         finding = scanner.scan_text(


### PR DESCRIPTION
## Summary

Hardens the reusable authoritative-source advisory model so Google- and Atlassian-facing repositories can adopt it with lower false-positive churn while keeping source enforcement visible and auditable.

## Scanner and guidance changes

- Adds narrow built-in official documentation domains for Google (`cloud.google.com`, `developers.google.com`, `firebase.google.com`) and Atlassian (`developer.atlassian.com`, `docs.atlassian.com`, `support.atlassian.com`).
- Keeps mixed/community surfaces warning-worthy, including `blog.google` and `community.atlassian.com`, instead of broad vendor-domain allowlisting.
- Tightens suppression recognition so `Source justification:`, `Source exception:`, `non-authoritative-source-ok:`, and `third-party-source-ok:` require visible reason text near the URL.
- Documents authoritative vs non-authoritative source classification, narrow `official_domains` expectations, same-org GitHub project-reference behavior, and incremental advisory adoption sequencing.
- Clarifies the reusable workflow input as additional narrow official documentation domains.

## Suppression-model decisions

Suppressions remain visible Markdown or PR-body annotations, not silent bypasses. Bare markers no longer suppress warnings; the marker must include a scoped reason after the colon and appear near the non-authoritative URL. The guidance keeps official docs first, allows third-party context only when official docs are unavailable, ambiguous, or insufficient, and tells callers to keep claims conservative.

## Google and Atlassian handling

The scanner now treats common provider-controlled documentation domains as official by default for Google and Atlassian adoption targets. It deliberately does not allow broad roots such as `google.com` or `atlassian.com`, nor community/blog surfaces, so adopters get fewer expected-doc false positives without turning vendor ownership into a generic allowlist.

## Validation

- `make check` passed.
- Verified the PR branch still contains current `origin/main` before pushing.

## Residual risks and future gaps

- Additional provider documentation domains should still be added repo-by-repo through narrow `official_domains` values when adoption exposes a legitimate official docs surface.
- This remains advisory unless a caller repository explicitly documents stricter enforcement.
- `scan_mode: all` remains appropriate only for explicit audit PRs, not initial rollout.

Closes #109
Closes #110