### PR TITLE
[codex] Add public artifact path hygiene guidance

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -66,6 +66,21 @@ and one unsupported command for each new override.
 - Keep licensing guidance simple and reusable; put repository-specific
   exceptions in the repository's own setup notes.
 
+## Public Artifact Path Hygiene
+
+Public-facing workflow artifacts should avoid machine-local absolute filesystem
+paths. This includes public docs, reusable examples, manifests, validation
+notes, PR evidence, and reusable workflow guidance.
+
+Prefer relative paths, repo-root placeholders, lint-safe example placeholders,
+and temporary-directory abstractions instead. When an example needs a scratch
+location, show the pattern rather than a captured local path, such as a
+`mktemp`-style temporary directory or `[temporary-directory]/artifact`.
+
+Machine-local paths reduce portability and can leak unnecessary local context
+into public artifacts. Keep path examples reusable unless the artifact is
+explicitly private, local-only, and not intended for publication.
+
 ## Parallel Execution And Merge Ordering
 
 Prefer parallel task execution when work can be cleanly separated by repository,

--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -54,7 +54,10 @@ If the bootstrap work is complete, the PR should be ready for review by default.
 
 ### Relative Links From The Start
 
-Repo docs should use relative links from the start. Absolute local filesystem paths are not portable and can leak machine-specific context into the repository.
+Repo docs should use relative links from the start. For public bootstrap
+artifacts, apply the baseline path-hygiene rule: avoid machine-local absolute
+paths in docs, examples, manifests, validation notes, and reusable workflow
+guidance.
 
 ### Local Workflow Artifact Hygiene
 


### PR DESCRIPTION
## Summary

- Add a shared engineering-baseline rule for avoiding machine-local absolute filesystem paths in public-facing workflow artifacts.
- Align the new-repo bootstrap relative-link lesson with the broader path-hygiene baseline.

## Rationale

Machine-local paths reduce portability and can leak unnecessary local context into public docs, reusable examples, manifests, validation notes, PR evidence, and workflow guidance. The added guidance keeps the reusable lesson operational without expanding into workstation or filesystem policy.

## Validation

- `make check`