### PR TITLE
docs: standardize branch naming guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 ## Branches
 
-- Use `codex/<short-name>` for automation-driven playbook or documentation work.
-- Use concise descriptive branch names for human-driven work, such as
+- Follow the branch naming guidance in `docs/feature-lifecycle.md`.
+- For playbook documentation work, use concise descriptive branch names such as
   `docs/<short-name>` or `chore/<short-name>`.
 
 ## Pull Requests

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -117,10 +117,9 @@ branch, validation, and PR flow before calling them complete.
 Use purpose-based branch prefixes that describe the change, not the tool that
 made it. AI-agent branches should use concise, non-tool-branded names such as
 `docs/<short-topic>`, `fix/<short-topic>`, `chore/<short-topic>`, or
-`feature/<short-topic>`. Repo-local guidance may narrow the allowed prefixes,
-such as using `feat/` instead of `feature/`, but broad tool-name prefixes such
-as `codex/`, `claude/`, or `copilot/` should be avoided unless a repository
-intentionally requires them.
+`feat/<short-topic>`. Repo-local guidance may narrow the allowed prefixes, but
+broad tool-name prefixes such as `codex/`, `claude/`, or `copilot/` should be
+avoided unless a repository intentionally requires them.
 
 For same-repo parallel work, prefer isolated Git worktrees over multiple arcs
 sharing one checkout. Keep the main checkout clean and on `main`, fetch before

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -114,14 +114,13 @@ stop after the findings or recommendations unless the request also asks for
 shipped changes. If those tasks do produce repo changes, follow the same
 branch, validation, and PR flow before calling them complete.
 
-For mixed-purpose repos that contain code, docs, tests, and release or
-workflow content, keep purpose-based branch prefixes such as `feat/`, `fix/`,
-`docs/`, `chore/`, `refactor/`, and `test/`. Reserve broad tool-oriented
-prefixes such as `codex/` for doc-only repos, scratch experiments, or repos
-whose branch convention explicitly allows them. Branch names should describe
-the change, not the tool that made it; for example
-`feat/minimal-cli-baseline`, `docs/project-map`, `chore/release-v0.7.0`, and
-`fix/run-ctrl-c-skip`.
+Use purpose-based branch prefixes that describe the change, not the tool that
+made it. AI-agent branches should use concise, non-tool-branded names such as
+`docs/<short-topic>`, `fix/<short-topic>`, `chore/<short-topic>`, or
+`feature/<short-topic>`. Repo-local guidance may narrow the allowed prefixes,
+such as using `feat/` instead of `feature/`, but broad tool-name prefixes such
+as `codex/`, `claude/`, or `copilot/` should be avoided unless a repository
+intentionally requires them.
 
 For same-repo parallel work, prefer isolated Git worktrees over multiple arcs
 sharing one checkout. Keep the main checkout clean and on `main`, fetch before

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -232,7 +232,10 @@ When behavior or supported capability changes, quickly check the existing docs f
 
 - use a fresh branch for each lifecycle phase after merge
 - keep commit messages and PR titles clear and phase-oriented
-- adapt branch, commit, and PR naming to repo context: in playbook or workflow repos, use Codex-explicit naming such as `codex/<topic>` and `[codex] docs: ...` to make automation-driven changes obvious; in product or implementation repos, follow standard development naming such as `feat/<topic>`, `fix/<topic>`, `feat: ...`, and `fix: ...`
+- adapt branch, commit, and PR naming to repo context: use purpose-based
+  branch names such as `docs/<topic>`, `fix/<topic>`, `chore/<topic>`, or
+  repo-local equivalents, and avoid Codex-branded branch or PR-title prefixes
+  unless a repository intentionally requires them
 - preserve a clean review narrative rather than one long-running branch
 - open a new PR when the work changes phase or review surface
 - for same-repo worktree batches, prefer opening PRs serially unless parallel


### PR DESCRIPTION
## Summary
- Add canonical playbook guidance for descriptive, non-tool-branded AI-agent branch names.
- Replace Codex-branded playbook and adapter examples with purpose-based branch naming guidance.

## Validation
- `make check`