### PR TITLE
docs: clarify repo-local workflow state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Put tool-specific guidance in `docs/tool-adapters/`.
 - Do not add project-specific logic or implementation examples.
 
+## Local Execution
+
+- Run commands from this repository working directory by default.
+- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Prefer direct `gh ...` commands unless shell behavior is required.
+
 ## Validation
 
 - Use `make check` as the canonical local validation entrypoint.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Local Execution
 
 - Run commands from this repository working directory by default.
-- Keep temporary workflow state repo-local, including `.worktrees/`.
+- Keep temporary workflow state repo-local, for example `.worktrees/`.
 - Prefer direct `gh ...` commands unless shell behavior is required.
 
 ## Validation

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -50,6 +50,18 @@ When working in a multi-repo workspace, treat each repository as an independent 
 
 Before opening a PR, ensure that all staged changes belong to a single repository. If changes span multiple repositories, split them into separate branches and PRs, one per repository.
 
+## Repo-Local Workflow State
+
+Run commands from the target repository working directory by default. Keep
+temporary workflow artifacts scoped to that repository whenever practical.
+Examples include local worktree directories, generated review artifacts,
+transient manifests, and task-specific scratch state.
+
+Avoid spreading workflow state across sibling repositories, home-directory
+scratch areas, or ad hoc shared locations unless the task explicitly requires
+broader coordination. When broader coordination is required, state where the
+shared state lives and why repo-local state is insufficient.
+
 ## Branch Protection
 
 Treat the following as the default branch protection baseline for `main`:

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -92,6 +92,11 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 
 - before repo- or PR-dependent work, verify GitHub access instead of relying on
   cached context, summaries, or local branch state
+- prefer direct `gh ...` invocations for GitHub CLI operations; do not
+  shell-wrap `gh` commands unless shell behavior is required, such as pipes,
+  redirects, globbing, command substitution, or compound conditionals
+- expect shell-wrapped `gh` commands to prompt when local approval rules allow
+  only the direct command form
 - use `gh repo view` to confirm the target repository is reachable
 - when PR state matters, use `gh pr view` to fetch current PR metadata before
   making decisions


### PR DESCRIPTION
Summary
- Add reusable repo-local workflow state guidance to the repo readiness baseline.
- Document direct GitHub CLI invocation expectations in the Codex adapter.
- Add a thin repo-local execution section to this repository's AGENTS.md.

Files changed
- AGENTS.md
- docs/repo-readiness.md
- docs/tool-adapters/codex.md

Validation
- make check

Residual risks or open questions
- git worktree target-path enforcement still depends on workflow guidance because the local Codex rules file only supports literal prefix rules.
