### PR TITLE
[codex] Document direct git and gh usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Prefer direct `gh ...` commands unless shell behavior is required.
+- Prefer direct `git ...` and `gh ...` commands unless shell behavior is required.
 
 ## Validation
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -92,11 +92,14 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 
 - before repo- or PR-dependent work, verify GitHub access instead of relying on
   cached context, summaries, or local branch state
-- prefer direct `gh ...` invocations for GitHub CLI operations; do not
-  shell-wrap `gh` commands unless shell behavior is required, such as pipes,
-  redirects, globbing, command substitution, or compound conditionals
-- expect shell-wrapped `gh` commands to prompt when local approval rules allow
-  only the direct command form
+- prefer direct `git ...` and `gh ...` invocations for normal repository
+  operations, such as `git status`, `git merge --ff-only origin/main`,
+  `gh repo view`, and `gh pr view`
+- do not shell-wrap `git` or `gh` commands unless shell behavior is required,
+  such as pipes, redirects, globbing, command substitution, or compound
+  conditionals
+- expect shell-wrapped `git` and `gh` commands to prompt when local approval
+  rules allow only the direct command form
 - use `gh repo view` to confirm the target repository is reachable
 - when PR state matters, use `gh pr view` to fetch current PR metadata before
   making decisions


### PR DESCRIPTION
Summary
- Generalize Codex/tool guidance from direct gh-only commands to direct git and gh repository commands.
- Keep shell wrapping reserved for commands that need shell behavior.

Validation
- make check