### PR TITLE
Add AGENTS review duplication caution

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -563,6 +563,7 @@ Constraints:
 Validation:
 - Verify that AGENTS points readers to the relevant playbook documents instead of restating them.
 - Verify that repo-local rules are specific to this repository's files, validation path, and workflow shape.
+- Verify repeated AGENTS wording by authority ownership and operational effect before trimming or promoting it; preserve necessary repo-local execution constraints, and remove broad playbook restatements.
 - Verify that the updated AGENTS file does not introduce conflicting guidance relative to the playbook.
 - Verify that the document still works as a practical execution layer for this repo type.
 


### PR DESCRIPTION
Summary
- Adds one AGENTS Update validation reminder to classify repeated AGENTS wording by authority ownership and operational effect before trimming or promoting it.
- Preserves the existing playbook/local split by keeping repo-local execution constraints in AGENTS and broad workflow restatements out.

Validation
- make check

Notes
- This update intentionally remains small and advisory.