### PR TITLE
[codex] Update incubator references

### DIFF
--- a/docs/context-refresh.md
+++ b/docs/context-refresh.md
@@ -52,8 +52,8 @@ Working Context:
   - ka-destinations
   - linode-image-lab
   - linode-backup-lab
-- Local notes layer:
-  - cross-repo-threads
+- Private staging/incubation layer:
+  - ai-workflow-incubator
   - reference only
   - not authoritative
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -98,8 +98,8 @@ Context:
   replay comparison, but the reporting text needs to be clearer.
 - Additional context when helpful: This pattern was used in knowledge-adapters
   PR #248 and passed `make chaos-all`. Confidence is medium; behavior is stable
-  but not yet promoted to the playbook. Related staging notes mention chaos
-  replay fingerprints in ai-workflow-incubator.
+  but not yet promoted to the playbook. Related private staging notes mention
+  chaos replay fingerprints.
 ```
 
 ### Codex Task Prompt Template

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -98,8 +98,8 @@ Context:
   replay comparison, but the reporting text needs to be clearer.
 - Additional context when helpful: This pattern was used in knowledge-adapters
   PR #248 and passed `make chaos-all`. Confidence is medium; behavior is stable
-  but not yet promoted to the playbook. Related notes mention chaos replay
-  fingerprints in cross-repo-threads.
+  but not yet promoted to the playbook. Related staging notes mention chaos
+  replay fingerprints in ai-workflow-incubator.
 ```
 
 ### Codex Task Prompt Template

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -27,6 +27,9 @@
   promotion -> notes cleanup.
 - Treat repository code, tests, docs, reviews, and merged PRs as the evidence
   source for reusable lessons before promoting them into the playbook.
+- Canonical guidance should generally describe staging and incubation by role;
+  use concrete private repository names when operational paths, examples,
+  provenance, or ecosystem topology need them.
 
 ## Rule of Thumb
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -18,9 +18,9 @@
 - Treat `AGENTS.md` as the repo-local execution layer.
 - Repo-local rules take precedence only for repo-specific behavior.
 
-## Incubator vs Playbook
+## Staging vs Playbook
 
-- `ai-workflow-incubator` is the private staging/incubation repo for ideas and experiments.
+- The private staging/incubation layer is for ideas and experiments.
 - It is not canonical and is not a direct path into playbook guidance.
 - Durable workflow guidance follows this order: idea -> notes staging ->
   bounded repo issue or PR -> evidence-supported reusable lesson -> playbook

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -18,9 +18,9 @@
 - Treat `AGENTS.md` as the repo-local execution layer.
 - Repo-local rules take precedence only for repo-specific behavior.
 
-## Notes vs Playbook
+## Incubator vs Playbook
 
-- `cross-repo-threads` is a staging layer for ideas and experiments.
+- `ai-workflow-incubator` is the private staging/incubation repo for ideas and experiments.
 - It is not canonical and is not a direct path into playbook guidance.
 - Durable workflow guidance follows this order: idea -> notes staging ->
   bounded repo issue or PR -> evidence-supported reusable lesson -> playbook


### PR DESCRIPTION
## Summary
- replace active playbook references to cross-repo-threads with ai-workflow-incubator
- describe the staging surface as a private staging/incubation layer
- update the reusable prompt example to point at incubator staging notes

## Validation
- make check