### PR TITLE
Add command intent visibility guidance

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -76,6 +76,28 @@ shared locations unless the task explicitly requires broader coordination. When
 broader coordination is required, state where the shared state lives and why
 repo-local state is insufficient.
 
+## Command Form And Intent Visibility
+
+Prefer the structurally minimal command form that still expresses the intended
+operation clearly. Normal repository operations should usually be invoked as
+the command itself, rather than hidden inside an extra shell layer.
+
+This keeps operational intent visible in logs, prompts, review notes, and local
+approval surfaces. It also lets permission or approval systems reason about the
+specific operation being requested, instead of treating a simple repository
+action as a broad shell execution.
+
+Use a shell wrapper when the operation genuinely needs shell semantics, such as
+pipes, redirects, globbing, chaining, shell builtins, inline environment
+assignment, or other composition that the command cannot express directly.
+When shell semantics are needed, keep the wrapped command narrow enough that
+the operational intent remains inspectable.
+
+Avoid inflating simple commands into larger execution forms only for habit or
+convenience. The goal is not to forbid shells; it is to preserve clarity,
+reviewability, and policy precision around what work is actually being
+performed.
+
 ## Branch Protection
 
 Treat the following as the default branch protection baseline for `main`:

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -92,14 +92,16 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
 
 - before repo- or PR-dependent work, verify GitHub access instead of relying on
   cached context, summaries, or local branch state
-- prefer direct `git ...` and `gh ...` invocations for normal repository
+- apply the command-form guidance in
+  [`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility):
+  keep normal repository operations in their structurally minimal form, and
+  reserve shell wrapping for operations that need shell semantics
+- prefer clear `git ...` and `gh ...` invocations for normal repository
   operations, such as `git status`, `git merge --ff-only origin/main`,
   `gh repo view`, and `gh pr view`
-- do not shell-wrap `git` or `gh` commands unless shell behavior is required,
-  such as pipes, redirects, globbing, command substitution, or compound
-  conditionals
-- expect shell-wrapped `git` and `gh` commands to prompt when local approval
-  rules allow only the direct command form
+- when a `git` or `gh` operation needs shell composition, keep the wrapped
+  command narrow enough that the requested operation remains visible to local
+  approval and review surfaces
 - use `gh repo view` to confirm the target repository is reachable
 - when PR state matters, use `gh pr view` to fetch current PR metadata before
   making decisions


### PR DESCRIPTION
Summary
- Adds reusable repo-readiness guidance for structurally minimal command forms and operational intent visibility.
- Aligns the Codex adapter to reference the shared command-form principle while keeping tool-specific GitHub preflight examples local to the adapter.

Validation
- make check

Rationale
- docs/repo-readiness.md owns target-repository execution, repo-local workflow state, validation expectations, and AGENTS responsibilities, so it is the best canonical home for the reusable principle.
- Incubator local-policy artifacts and implementation-specific allow rules remain outside the playbook.