### PR TITLE
chore: ignore Python bytecode artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,9 @@
 # Local worktrees
 .worktrees/
 
+# Python bytecode
+__pycache__/
+*.pyc
+
 # Generated convenience bundles
 dist/


### PR DESCRIPTION
## Summary
- Ignore Python bytecode caches generated by helper scripts and tests.
- Keep local execution residue out of normal git status output.

## Validation
- make check
- git check-ignore --verbose scripts/__pycache__ scripts/example.pyc