### PR TITLE
docs: require direct command execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Prefer direct `git ...` and `gh ...` commands unless shell behavior is required.
+- Follow the command-form rule in `docs/repo-readiness.md`: prefer direct
+  `git ...`, `gh ...`, `make ...`, `python ...`, and tool commands; reserve
+  wrapper shells for commands that genuinely require shell behavior.
 
 ## Validation
 

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -14,6 +14,9 @@ Define shared engineering expectations across repositories. This baseline forms 
     do not treat CI as a substitute for that local step.
   - Do not add or substitute alternate local validation tools outside the
     repo-defined workflow.
+- Command intent stays visible
+  - Run ordinary repo commands directly from the target repository, following
+    the command-form rules in `docs/repo-readiness.md`.
 - Repository isolation
   - One repository per PR.
   - No cross-repo commits.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -126,6 +126,9 @@ Constraints:
 External State Verification:
 - Verify live external state, such as GitHub repository or pull request state,
   before relying on it.
+- Run commands directly from the target repository and follow the command-form
+  rule in `docs/repo-readiness.md`; do not wrap ordinary repo commands in
+  `zsh`, `bash`, `sh`, or equivalent shell forms.
 - Follow the direct PR inspection rule in `docs/review-packet.md` when a task
   asks for PR review, readiness, approval, or merge advice.
 - Follow the public API baseline in `docs/engineering-baseline.md` when code,
@@ -664,6 +667,8 @@ Delivery:
 - Follow the branch, PR readiness, and workspace rules in
   `docs/feature-lifecycle.md`, `docs/repo-readiness.md`, and
   `docs/tool-adapters/codex.md`.
+- Run ordinary repo commands directly from the target repository; reserve
+  shell wrapping for commands that genuinely require shell syntax.
 - Fetch current `origin/main` at task start, anchor implementation to that
   fetched baseline, and verify current mergeability before PR.
 - Stage only the relevant changes.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -82,16 +82,23 @@ Prefer the structurally minimal command form that still expresses the intended
 operation clearly. Normal repository operations should usually be invoked as
 the command itself, rather than hidden inside an extra shell layer.
 
+Run commands from the target repository working directory by default. For
+ordinary repository operations, prefer direct `git ...`, `gh ...`, `make ...`,
+`python ...`, and tool-specific commands. Do not wrap those commands in `zsh`,
+`bash`, `sh`, shell aliases, or equivalent wrapper shells only for convenience.
+In particular, avoid `zsh -lc`, `bash -lc`, `sh -c`, or equivalent forms for
+ordinary repo commands.
+
 This keeps operational intent visible in logs, prompts, review notes, and local
 approval surfaces. It also lets permission or approval systems reason about the
 specific operation being requested, instead of treating a simple repository
 action as a broad shell execution.
 
 Use a shell wrapper when the operation genuinely needs shell semantics, such as
-pipes, redirects, globbing, chaining, shell builtins, inline environment
-assignment, or other composition that the command cannot express directly.
-When shell semantics are needed, keep the wrapped command narrow enough that
-the operational intent remains inspectable.
+pipes, redirection, glob expansion, command chaining, shell builtins, inline
+environment assignment, compound conditionals, or other composition that the
+command cannot express directly. When shell semantics are needed, keep the
+wrapped command narrow enough that the operational intent remains inspectable.
 
 Avoid inflating simple commands into larger execution forms only for habit or
 convenience. The goal is not to forbid shells; it is to preserve clarity,

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -34,6 +34,8 @@
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
+- Run commands directly from the target repository; follow
+  `docs/repo-readiness.md` for command form and shell-wrapping rules.
 - Run repository validation through the repo's Makefile when it provides the
   canonical entrypoint.
 - Open PRs ready for review by default unless explicitly instructed otherwise.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -96,9 +96,11 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   [`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility):
   keep normal repository operations in their structurally minimal form, and
   reserve shell wrapping for operations that need shell semantics
-- prefer clear `git ...` and `gh ...` invocations for normal repository
-  operations, such as `git status`, `git merge --ff-only origin/main`,
-  `gh repo view`, and `gh pr view`
+- prefer clear direct invocations for normal repository operations, such as
+  `git status`, `git merge --ff-only origin/main`, `gh repo view`,
+  `gh pr view`, `make check`, and `python ...`
+- do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent wrapper forms for
+  ordinary repo commands
 - when a `git` or `gh` operation needs shell composition, keep the wrapped
   command narrow enough that the requested operation remains visible to local
   approval and review surfaces


### PR DESCRIPTION
Summary:
- Strengthen the canonical command-form rule in docs/repo-readiness.md.
- Reinforce direct command execution in Codex guidance, prompts, start-here, engineering baseline, and repo-local AGENTS.md.

Validation:
- make check