### PR TITLE
docs: require command-form preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,10 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Run commands from this repository working directory by default.
 - Keep temporary workflow state repo-local, for example `.worktrees/`.
-- Follow the command-form rule in `docs/repo-readiness.md`: prefer direct
-  `git ...`, `gh ...`, `make ...`, `python ...`, and tool commands; reserve
-  wrapper shells for commands that genuinely require shell behavior.
+- Follow the command-form preflight rule in `docs/repo-readiness.md`: use direct
+  `git ...`, `gh ...`, `make ...`, `python ...`, and tool commands for ordinary
+  repository operations; before using a wrapper shell, confirm shell semantics
+  are genuinely required, otherwise rewrite the operation into direct argv form.
 
 ## Validation
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -567,6 +567,10 @@ Validation:
 - Verify that AGENTS points readers to the relevant playbook documents instead of restating them.
 - Verify that repo-local rules are specific to this repository's files, validation path, and workflow shape.
 - Verify repeated AGENTS wording by authority ownership and operational effect before trimming or promoting it; preserve necessary repo-local execution constraints, and remove broad playbook restatements.
+- Verify that command-form guidance preserves the playbook's preflight rule:
+  shell-wrapped commands are used only when shell semantics are required, and
+  ordinary repository commands are rewritten to direct argv form before
+  execution.
 - Verify that the updated AGENTS file does not introduce conflicting guidance relative to the playbook.
 - Verify that the document still works as a practical execution layer for this repo type.
 
@@ -669,6 +673,9 @@ Delivery:
   `docs/tool-adapters/codex.md`.
 - Run ordinary repo commands directly from the target repository; reserve
   shell wrapping for commands that genuinely require shell syntax.
+- Before executing a shell-wrapped command, perform the command-form preflight
+  from `docs/repo-readiness.md`; when shell semantics are unnecessary, rewrite
+  the operation into direct argv form before execution.
 - Fetch current `origin/main` at task start, anchor implementation to that
   fetched baseline, and verify current mergeability before PR.
 - Stage only the relevant changes.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -89,27 +89,47 @@ repo-local state is insufficient.
 
 ## Command Form And Intent Visibility
 
-Prefer the structurally minimal command form that still expresses the intended
-operation clearly. Normal repository operations should usually be invoked as
-the command itself, rather than hidden inside an extra shell layer.
+Use the structurally minimal command form that still expresses the intended
+operation clearly. Normal repository operations must be invoked as the command
+itself, rather than hidden inside an extra shell layer.
 
 Run commands from the target repository working directory by default. For
-ordinary repository operations, prefer direct `git ...`, `gh ...`, `make ...`,
+ordinary repository operations, use direct `git ...`, `gh ...`, `make ...`,
 `python ...`, and tool-specific commands. Do not wrap those commands in `zsh`,
 `bash`, `sh`, shell aliases, or equivalent wrapper shells only for convenience.
-In particular, avoid `zsh -lc`, `bash -lc`, `sh -c`, or equivalent forms for
-ordinary repo commands.
+In particular, `zsh -lc`, `bash -lc`, `sh -c`, or equivalent forms must not be
+used for ordinary repo commands.
 
 This keeps operational intent visible in logs, prompts, review notes, and local
 approval surfaces. It also lets permission or approval systems reason about the
 specific operation being requested, instead of treating a simple repository
 action as a broad shell execution.
 
+Before executing any shell-wrapped command, perform a command-form preflight:
+
+- determine whether the operation genuinely needs shell semantics, such as
+  pipes, redirects, glob expansion, command chaining, shell builtins, inline
+  environment assignment, compound shell conditionals, or other shell-only
+  composition
+- if shell semantics are not required, rewrite the command into direct argv
+  form before execution
+- if shell semantics are required, keep the wrapped command narrow enough that
+  the operational intent remains inspectable
+
 Use a shell wrapper when the operation genuinely needs shell semantics, such as
 pipes, redirection, glob expansion, command chaining, shell builtins, inline
 environment assignment, compound conditionals, or other composition that the
 command cannot express directly. When shell semantics are needed, keep the
 wrapped command narrow enough that the operational intent remains inspectable.
+
+Examples:
+
+- incorrect: `zsh -lc 'git status'`
+- correct: `git status`
+- incorrect: `bash -lc 'make check'`
+- correct: `make check`
+- incorrect: `sh -c 'gh pr view 145'`
+- correct: `gh pr view 145`
 
 Avoid inflating simple commands into larger execution forms only for habit or
 convenience. The goal is not to forbid shells; it is to preserve clarity,

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -101,9 +101,19 @@ Tasks that extend a clean documented seam are more likely to remain small. Tasks
   `gh pr view`, `make check`, and `python ...`
 - do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent wrapper forms for
   ordinary repo commands
+- before executing a shell-wrapped command, perform a command-form preflight:
+  decide whether shell semantics are genuinely required; if not, rewrite the
+  operation into direct argv form before execution
+- treat pipes, redirects, glob expansion, command chaining, shell builtins,
+  inline environment assignment, and compound shell conditionals as examples of
+  shell semantics that can justify a wrapper when no direct command form is
+  sufficient
 - when a `git` or `gh` operation needs shell composition, keep the wrapped
   command narrow enough that the requested operation remains visible to local
   approval and review surfaces
+- examples: use `git status`, not `zsh -lc 'git status'`; use `make check`, not
+  `bash -lc 'make check'`; use `gh pr view 145`, not
+  `sh -c 'gh pr view 145'`
 - use `gh repo view` to confirm the target repository is reachable
 - when PR state matters, use `gh pr view` to fetch current PR metadata before
   making decisions


### PR DESCRIPTION
## Summary
- make command-form preflight a normative requirement before any shell-wrapped command
- add direct argv rewrite examples for ordinary repo commands
- update Codex and prompt guidance so AGENTS drift checks can audit the stronger rule

## Validation
- make check