### PR TITLE
Add repo interaction mode preflight

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -90,6 +90,10 @@ feature branch unless intentionally continuing that PR.
 
 ### Repo Change Completion
 
+After the interaction mode preflight in
+[`repo-readiness.md`](repo-readiness.md#interaction-mode-preflight) selects
+implementation mode, repo-changing work follows the normal delivery path.
+
 For repo changes, "done" means all of the following are complete:
 
 - change implemented

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -40,6 +40,8 @@ execution paths.
 
 - Name recurring automations by purpose so their intent is clear in schedules,
   reports, and follow-up.
+- Automation prompts that touch repositories should state the interaction mode
+  from [`repo-readiness.md`](repo-readiness.md#interaction-mode-preflight).
 - Report-only is the default for audits and validation checks.
 - Mutating automations must be bounded, conservative, and skip on uncertainty.
 - Skipped work should be reported with reasons, not hidden as a clean pass.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -54,6 +54,14 @@ Use this format for non-trivial Codex implementation tasks: work that changes an
 existing system, has meaningful constraints, needs validation, or should end in a
 branch and PR. Simple one-step tasks do not need this much structure.
 
+Before writing or using a Codex task prompt, apply the interaction mode
+preflight in [`docs/repo-readiness.md`](repo-readiness.md#interaction-mode-preflight).
+Use this implementation prompt format only when the intended mode is direct
+implementation. For review/audit work, use the review or audit templates. For
+orchestration or prompt-authoring work, inspect enough context to produce a
+complete self-contained downstream prompt instead of appending implementation
+delivery instructions by habit.
+
 ### Codex Task Prompt Format Sections
 
 - `Context`: repository, current situation, relevant background, and any known
@@ -124,6 +132,9 @@ Constraints:
 - Do not silently skip required steps; report any blockers or incomplete work.
 
 External State Verification:
+- Determine the interaction mode before repo work begins. Implementation mode
+  requires explicit user intent; ambiguous ctrl-alt-keith repo tasks default to
+  review/audit or orchestration/prompt-authoring.
 - Verify live external state, such as GitHub repository or pull request state,
   before relying on it.
 - Run commands directly from the target repository and follow the command-form
@@ -659,10 +670,15 @@ Append this footer to implementation prompts when the task is expected to make
 repo changes and deliver them through the normal branch, commit, push, and PR
 flow.
 
+Use this footer only after the interaction mode is clearly implementation mode.
+
 ### Implementation Delivery Footer Do Not Use When
 
 Do not append this footer for exploration, design, or review-only tasks unless
 they are also expected to make and deliver repo changes.
+
+Do not append this footer for orchestration or prompt-authoring tasks whose
+deliverable is a complete downstream prompt rather than repo mutation.
 
 ### Implementation Delivery Footer Snippet
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -20,6 +20,46 @@ Define the smallest reusable baseline a repository should have before normal AI-
 - Repositories with a Makefile include `make help` for local target discovery.
 - Defaults should favor safe, explicit behavior over implied shortcuts.
 
+## Interaction Mode Preflight
+
+Before acting on any repository or software task, determine the interaction
+mode. Do this before editing files, creating branches, committing, opening pull
+requests, or running implementation-oriented workflows.
+
+Use one of these modes:
+
+- Implementation mode: directly make repo changes, validate them, commit them,
+  push the branch, and open or update a pull request when repo guidance calls
+  for PR delivery.
+- Review/audit mode: inspect the requested repository, pull request, issue, or
+  file surface and report findings, evidence, risks, and recommendations
+  without mutating the repository.
+- Orchestration/prompt-authoring mode: inspect enough issue, repository, pull
+  request, and workflow context to decide the right course of action, then
+  produce a complete, self-contained prompt or handoff for another agent or
+  tool.
+
+Do not infer implementation mode from vague wording such as "fix this",
+"handle this", or "let's fix the bug" when the surrounding context suggests
+advisory review, audit, orchestration, or prompt generation.
+
+For ctrl-alt-keith workflows, default ambiguous repository tasks to
+review/audit mode or orchestration/prompt-authoring mode unless the human
+explicitly asks for direct implementation. Implementation mode requires clear
+user intent, such as "make the change", "implement it", "open the PR",
+"commit this", or equivalent wording.
+
+In orchestration/prompt-authoring mode, do enough direct inspection to make the
+handoff usable without hidden assumptions. A prompt that asks another agent to
+act should include the repository, goal, relevant context, constraints,
+validation path, deliverable expectations, and any known blockers or
+uncertainty. Do not produce partial prompts that leave the downstream agent to
+rediscover essential context.
+
+Keep this policy in the shared playbook. Repo-local `AGENTS.md` files should
+reference or rely on it rather than duplicate it, except where a repository
+truly requires different behavior.
+
 ## Makefile Discoverability
 
 Any repository with a Makefile should include a `make help` target. `make help`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -17,6 +17,9 @@
 - Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
 - Treat `AGENTS.md` as the repo-local execution layer.
 - Repo-local rules take precedence only for repo-specific behavior.
+- Before acting on repository or software work, determine the interaction mode
+  using `docs/repo-readiness.md`: implementation, review/audit, or
+  orchestration/prompt-authoring.
 
 ## Staging vs Playbook
 
@@ -34,6 +37,9 @@
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
+- In ctrl-alt-keith workflows, default ambiguous repository tasks to
+  advisory/orchestration unless the human explicitly asks for direct
+  implementation.
 - Run commands directly from the target repository; follow
   `docs/repo-readiness.md` for command form and shell-wrapping rules.
 - Run repository validation through the repo's Makefile when it provides the

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -38,8 +38,8 @@
 
 - Prefer small, scoped changes.
 - In ctrl-alt-keith workflows, default ambiguous repository tasks to
-  advisory/orchestration unless the human explicitly asks for direct
-  implementation.
+  review/audit or orchestration/prompt-authoring unless the human explicitly
+  asks for direct implementation.
 - Run commands directly from the target repository; follow
   `docs/repo-readiness.md` for command form and shell-wrapping rules.
 - Run repository validation through the repo's Makefile when it provides the

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -11,6 +11,23 @@ This document explains how Codex maps onto the core playbook. It is adapter-spec
 
 Tasks that extend a clean documented seam are more likely to remain small. Tasks that must create or reshape seams tend to expand and should be treated that way during estimation.
 
+## Interaction Mode Selection
+
+Before repo-scoped work, apply the interaction mode preflight in
+[`repo-readiness.md`](../repo-readiness.md#interaction-mode-preflight).
+
+Codex should not treat vague repair language as permission to mutate a repo
+when the surrounding context indicates advisory review, audit, orchestration,
+or prompt authoring. In ctrl-alt-keith workflows, ambiguous repo tasks default
+to read-only review/audit or orchestration/prompt-authoring unless the human
+explicitly asks Codex to implement, commit, push, or open the PR.
+
+When acting in orchestration/prompt-authoring mode, Codex should still inspect
+enough live repository, issue, pull request, and documentation context to write
+a complete downstream prompt. The deliverable is the prompt or handoff itself,
+not a branch or PR, unless the human separately asks Codex to implement the
+change.
+
 ## Project-Context Check
 
 - before making changes, confirm the current Codex project or working context matches the intended task target


### PR DESCRIPTION
Summary
- Adds a canonical interaction mode preflight for implementation, review/audit, and orchestration/prompt-authoring before repo work begins.
- Clarifies that ambiguous ctrl-alt-keith repo tasks default to review/audit or orchestration unless the user explicitly asks for direct implementation.
- Points Codex adapter, prompt templates, lifecycle completion, start-here, and maintenance automation guidance back to the canonical policy.

Validation
- make check passed.

Notes
- Repo-local AGENTS.md files should not duplicate this policy unless they are intentionally overriding behavior for a repository-specific reason.
- The local-only workspace file ~/src/ctrl-alt-keith/AGENTS.md is outside this repository and should consume this canonical policy separately.