### PR TITLE
[codex] Document workspace boundary discovery

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -50,6 +50,12 @@ named files, define the intended dataset boundary before traversal begins.
 - If the boundary is unclear, tighten the prompt or ask for clarification rather
   than widening the scan.
 
+For multi-repo audits or workspace-wide operations, define workspace scope from
+authoritative inventory sources before filesystem traversal. Reconcile
+organization-level repository enumeration with explicit workspace manifests such
+as `config/workspace-repos.txt`, and do not treat raw local checkout layout as
+authoritative scope.
+
 ## Prompt Output Contract
 
 Prompt and orchestration deliverables must be complete, self-contained, and

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -113,6 +113,25 @@ When working in a multi-repo workspace, treat each repository as an independent 
 
 Before opening a PR, ensure that all staged changes belong to a single repository. If changes span multiple repositories, split them into separate branches and PRs, one per repository.
 
+## Workspace Boundary Discovery
+
+When work spans multiple repositories, determine the active managed workspace
+set from authoritative repository inventory sources before broad scans or
+updates begin.
+
+Prefer organization-level repository enumeration and explicit workspace
+manifests such as `config/workspace-repos.txt`. Reconcile those sources before
+treating local checkouts as part of the active workspace scope.
+
+Do not treat raw local filesystem layout as authoritative workspace scope.
+Local checkout trees may contain stale repositories, archived repositories,
+detached worktrees, experiments, incomplete clones, temporary operational
+state, or local-only scratch repositories.
+
+Reconcile local workspace state against the canonical workspace inventory
+before cross-repo audits, `AGENTS.md` alignment, enforcement scans, or broad
+workflow updates.
+
 ## Repo-Local Workflow State
 
 Run commands from the target repository working directory by default. Keep


### PR DESCRIPTION
## Summary

- Adds canonical workspace-boundary discovery guidance to `docs/repo-readiness.md` for multi-repo audits and workspace-wide operations.
- Directs broad operations to reconcile organization-level repository inventory with explicit manifests such as `config/workspace-repos.txt` before trusting local checkout state.
- Adds a concise prompt-template reference in `docs/prompts.md` so filesystem-scoped audits preserve the authoritative-inventory rule.

## Validation

- `make check` passed.

## Source evidence

- `../ai-workflow-incubator/workflow-patterns/operational-evidence/2026-05-08-workflow-policy-transmission-drift.md`
- Related merged PR: #149, "Promote canonical workflow output rules"

## Residual risks / follow-ups

- This PR only canonicalizes the playbook guidance; any later enforcement, AGENTS alignment, or automation updates should use the new inventory-first boundary rule.