### PR TITLE
Clarify direct git and gh execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,9 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Follow the command-form preflight rule in `docs/repo-readiness.md`: use direct
   `git ...`, `gh ...`, `make ...`, `python ...`, repo-local scripts, and tool
   commands for ordinary repository operations.
+- For standard `git` and `gh` work, preserve direct CLI execution at both the
+  command-selection and execution-tool layers; disable implicit shell or
+  login-shell behavior where the environment supports that.
 - Before using `zsh`, `bash`, `sh`, `zsh -lc`, `bash -lc`, `sh -c`, aliases, or
   equivalent wrapper shells, confirm shell semantics are genuinely required;
   otherwise rewrite the operation into direct argv form.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -648,6 +648,10 @@ Validation:
   shell-wrapped commands are used only when shell semantics are required, and
   ordinary repository commands are rewritten to direct argv form before
   execution.
+- Verify that `git` and `gh` guidance preserves both layers of directness:
+  standard CLI flows use `git` and `gh` rather than alternate APIs or helper
+  tools, and execution settings disable implicit shell or login-shell behavior
+  where the environment supports that.
 - Verify that the updated AGENTS file does not introduce conflicting guidance relative to the playbook.
 - Verify that the document still works as a practical execution layer for this repo type.
 
@@ -778,8 +782,10 @@ Required startup:
 4. Identify the canonical source for reusable workflow rules.
 5. Confirm command form for ordinary repo commands.
 6. Confirm the dedicated repo-local worktree for implementation changes.
-7. Identify the canonical validation path.
-8. Act only after these checks are clear, or report the blocker.
+7. For `git` and `gh`, confirm execution settings avoid implicit shell or
+   login-shell wrapping where supported.
+8. Identify the canonical validation path.
+9. Act only after these checks are clear, or report the blocker.
 
 Interaction mode:
 - [implementation, review/audit, or orchestration/prompt-authoring]
@@ -807,6 +813,15 @@ Constraints:
   source.
 - Use direct command execution for ordinary `git`, `gh`, `make`, `python`,
   repo-local script, and tool commands from inside the target worktree.
+- For standard Git and GitHub CLI work, use `git` and `gh` directly rather than
+  alternate APIs, helper tools, wrapper scripts, or connector substitutions
+  unless the task requires non-CLI capability or direct CLI access is blocked.
+- Prefer native argv-style execution such as `["git", "status"]`,
+  `["git", "commit"]`, and `["gh", "pr", "create"]` where supported.
+- If the execution tool defaults to shell or login-shell behavior, explicitly
+  disable it for `git` and `gh` commands where supported, using options such as
+  `shell=false`, `login=false`, `use_shell=false`, or the platform-native
+  equivalent.
 - Do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent shell wrappers for
   ordinary repo commands.
 - Use shell wrappers only when shell syntax is genuinely required.
@@ -869,6 +884,11 @@ Delivery:
 - Run ordinary `git`, `gh`, `make`, `python`, repo-local script, and tool
   commands directly from the target worktree; reserve shell wrapping for
   commands that genuinely require shell syntax.
+- For standard `git` and `gh` work, use the CLI directly rather than alternate
+  APIs, helper scripts, or connector substitutions; where supported, use native
+  argv-style execution and disable implicit shell or login-shell defaults with
+  settings such as `shell=false`, `login=false`, `use_shell=false`, or the
+  platform-native equivalent.
 - Before executing a shell-wrapped command, perform the command-form preflight
   from `docs/repo-readiness.md`; when shell semantics are unnecessary, rewrite
   the operation into direct argv form before execution.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -201,6 +201,19 @@ aliases, or equivalent wrapper shells only for convenience. In particular,
 `zsh -lc`, `bash -lc`, `sh -c`, or equivalent forms are not normal wrappers for
 ordinary repo commands.
 
+For standard Git or GitHub CLI work, choose the `git` or `gh` command directly
+instead of substituting alternate APIs, helper tools, wrapper scripts, or
+connector-specific operations. Use alternate APIs or tools only when the task
+explicitly calls for capabilities the CLI cannot provide or when direct CLI
+access is unavailable and the fallback is reported clearly.
+
+Preserve that directness at the execution layer too. Prefer native argv-style
+execution, such as `["git", "status"]` or `["gh", "pr", "create"]`, when the
+environment supports it. If an execution tool defaults to a shell, login shell,
+or shell-like command string, explicitly disable that behavior for `git` and
+`gh` where supported, using settings such as `shell=false`, `login=false`,
+`use_shell=false`, or the platform's equivalent direct-exec option.
+
 This keeps operational intent visible in logs, prompts, review notes, and local
 approval surfaces. It also lets permission or approval systems reason about the
 specific operation being requested, instead of treating a simple repository
@@ -227,10 +240,12 @@ Examples:
 
 - incorrect: `zsh -lc 'git status'`
 - correct: `git status`
+- preferred native argv form where supported: `["git", "status"]`
 - incorrect: `bash -lc 'make check'`
 - correct: `make check`
 - incorrect: `sh -c 'gh pr view 145'`
 - correct: `gh pr view 145`
+- preferred native argv form where supported: `["gh", "pr", "view", "145"]`
 
 Avoid inflating simple commands into larger execution forms only for habit or
 convenience. The goal is not to forbid shells; it is to preserve clarity,

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -35,7 +35,8 @@ Before acting on repository or software work:
 3. Select the interaction mode before acting: implementation, review/audit, or
    orchestration/prompt-authoring.
 4. Identify the canonical source for the rule, behavior, or context being used.
-5. Confirm the command form for planned repository commands.
+5. Confirm the command form and execution settings for planned repository
+   commands, especially direct `git` and `gh` usage.
 6. Identify the repository's canonical validation path.
 7. Act only after those checks are clear, or report the blocker,
    uncertainty, or missing context.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -115,6 +115,16 @@ change.
 - prefer clear direct invocations for normal repository operations, such as
   `git status`, `git merge --ff-only origin/main`, `gh repo view`,
   `gh pr view`, `make check`, `python ...`, and repo-local scripts
+- for standard Git and GitHub CLI flows, use `git` and `gh` directly rather
+  than alternate APIs, helper scripts, connectors, or tool substitutions unless
+  the task requires a non-CLI capability or direct CLI access is blocked and
+  the fallback is reported
+- when the execution tool supports native argv arrays, prefer direct argv forms
+  such as `["git", "status"]` or `["gh", "pr", "view", "145"]`
+- if the execution surface defaults to shell or login-shell behavior, disable
+  that behavior for `git` and `gh` where supported, using options such as
+  `shell=false`, `login=false`, `use_shell=false`, or the platform-native
+  equivalent
 - do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent wrapper forms for
   ordinary repo commands
 - before executing a shell-wrapped command, perform a command-form preflight:


### PR DESCRIPTION
## Summary
- clarify the playbook command-form baseline so standard Git/GitHub CLI work uses direct `git` and `gh` rather than helper scripts, connectors, or alternate APIs
- add execution-layer guidance to prefer native argv forms and disable implicit shell/login-shell defaults where supported
- sync the Codex adapter, startup checklist, prompt snippets, and repo-local playbook AGENTS guidance with the clarified rule

## Validation
- `make check`

## Residual risks
- exact direct-exec option names vary by runtime, so the guidance names common settings and requires platform-native equivalents rather than one universal flag
