### PR TITLE
[codex] Clarify drop-in prompt artifact outputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Implementation agents make explicit repo changes and carry them through
   validation, commit, push, and PR delivery.
 - Review/audit agents inspect and report findings without mutating the repo.
-- Orchestration/prompt-authoring agents produce complete, self-contained
-  handoffs or prompts unless explicitly asked to implement.
+- Orchestration/prompt-authoring agents produce complete, self-contained,
+  drop-in handoffs or prompts unless explicitly asked to implement.
 
 ## Repo Scope
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ Repo-local rules take precedence only for repo-specific behavior.
 - Implementation agents make explicit repo changes and carry them through
   validation, commit, push, and PR delivery.
 - Review/audit agents inspect and report findings without mutating the repo.
-- Orchestration/prompt-authoring agents produce complete, self-contained,
-  drop-in handoffs or prompts unless explicitly asked to implement.
+- Orchestration/prompt-authoring agents produce complete, self-contained
+  handoffs or prompts unless explicitly asked to implement.
 
 ## Repo Scope
 

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -43,6 +43,10 @@ execution paths.
   reports, and follow-up.
 - Automation prompts that touch repositories should state the interaction mode
   from [`repo-readiness.md`](repo-readiness.md#interaction-mode-preflight).
+- Automation prompts intended for another agent or tool should be complete,
+  self-contained, and ready to paste by default. If an automation prompt update
+  asks to add or incorporate new guidance, provide the full updated prompt
+  unless the human explicitly asks for a delta, patch, diff, or targeted edit.
 - Report-only is the default for audits and validation checks.
 - Mutating automations must be bounded, conservative, and skip on uncertainty.
 - Skipped work should be reported with reasons, not hidden as a clean pass.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -58,14 +58,20 @@ authoritative scope.
 
 ## Prompt Output Contract
 
-Prompt and orchestration deliverables must be complete, self-contained, and
-directly usable by default. A downstream agent should not need to reconstruct
-the task from conversation history, hidden assumptions, earlier partial output,
-or unstated repository context.
+Prompt, spec, plan, implementation brief, review brief, automation prompt, agent
+instruction, and orchestration deliverables must be complete, self-contained,
+and directly usable by default. A downstream agent should not need to
+reconstruct the task from conversation history, hidden assumptions, earlier
+partial output, or unstated repository context.
 
-When prompt text is the deliverable, provide one contiguous copyable block. Do
-not split the prompt across multiple fragments, follow-up messages, or
-continuation blocks unless the human explicitly requests an incremental draft.
+When prompt or instruction text is the deliverable, provide the full drop-in
+version in one contiguous copyable block. If the human asks how to "add",
+"incorporate", "fold in", or otherwise update something in an existing prompt,
+spec, instruction, or task envelope, still return the full updated artifact by
+default. Do not assume the human will manually stitch prior context or earlier
+snippets into the final artifact. Do not split the artifact across multiple
+fragments, follow-up messages, or continuation blocks unless the human
+explicitly requests an incremental draft.
 
 Avoid these forms unless explicitly requested:
 
@@ -74,8 +80,14 @@ Avoid these forms unless explicitly requested:
 - "change X to Y" pseudo-prompts
 - diffs
 - partial edits
+- delta-only responses
+- targeted edits without the full updated artifact
 - instructions that require the receiver to infer missing context from earlier
   discussion
+
+Prefer copy/paste-safe output over terse conversational deltas for
+agent-facing prompts. Preserve brevity only when it does not risk omitting
+required context.
 
 When a prompt is intended for implementation, include enough context for the
 receiver to start safely: repository, working directory, canonical source,
@@ -807,8 +819,11 @@ Delivery:
 
 Deliverable:
 - [complete expected final output]
+- Provide the full drop-in artifact by default, even when the task asks to add,
+  incorporate, or fold new material into existing prompt or instruction text.
 - Do not provide partial prompts, continuation fragments, diffs, partial edits,
-  or "change X to Y" pseudo-prompts unless explicitly requested.
+  delta-only responses, targeted edits without the full updated artifact, or
+  "change X to Y" pseudo-prompts unless explicitly requested.
 ```
 
 ## Implementation Delivery Footer

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -68,6 +68,15 @@ Do not produce partial prompts, continuation fragments, diffs, partial edits,
 or "change X to Y" pseudo-prompts unless the human explicitly requested that
 form.
 
+When the requested artifact is a prompt, spec, plan, implementation brief,
+review brief, automation prompt, or agent instruction, provide the full
+drop-in version by default. This remains true when the human asks how to "add",
+"incorporate", "fold in", or otherwise update something in an existing
+artifact. Do not assume the human will manually stitch prior context,
+conversation history, or earlier snippets into the final artifact. Use a delta,
+patch, diff, targeted edit, or terse "change X to Y" response only when the
+human explicitly asks for that form.
+
 Keep this policy in the shared playbook. Repo-local `AGENTS.md` files should
 reference or rely on it rather than duplicate it, except where a repository
 truly requires different behavior.


### PR DESCRIPTION
## Summary

- Strengthens the playbook output contract for prompts, specs, plans, implementation briefs, review briefs, automation prompts, and agent instructions.
- Clarifies that add/incorporate requests still default to a complete drop-in artifact, not a delta-only response.
- Adds automation-specific wording while leaving AGENTS.md untouched under the refreshed playbook guidance that AGENTS edits require explicit authorization.

## Validation

- make check passed after refreshing the branch onto current origin/main.

## Residual Risks

- This PR updates canonical guidance only. Copied or repo-local instruction surfaces outside this playbook may still need separate, explicitly authorized AGENTS/update alignment where their repo workflow calls for it.