### PR TITLE
Separate playbook guidance from AGENTS rollout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - This repo contains reusable AI workflow and playbook guidance.
 - It does not contain implementation code or project-specific automation.
+- Playbook documentation changes do not imply permission to update `AGENTS.md`
+  files in other repositories.
+- Update this repo's `AGENTS.md` with playbook changes only when needed to keep
+  the local execution entrypoint consistent.
 
 ## File Placement
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,6 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - This repo contains reusable AI workflow and playbook guidance.
 - It does not contain implementation code or project-specific automation.
-- Playbook documentation changes do not imply permission to update `AGENTS.md`
-  files in other repositories.
-- Update this repo's `AGENTS.md` with playbook changes only when needed to keep
-  the local execution entrypoint consistent.
 
 ## File Placement
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -400,14 +400,14 @@ Validation:
   no notes cleanup is needed.
 
 Output format:
-1. Proposed playbook changes: brief summary paragraph.
-2. Rules promoted: short bullets with rationale.
-3. Files to update: list of target files and why.
-4. Change classification: canonical playbook guidance only, unless there is
-   explicit authorization for an `AGENTS.md` update/enforcement task.
-5. Validation notes: short bullets covering evidence, reuse, scope, conflict
-   checks, rollout boundary, and notes cleanup.
-6. Open questions: only if a rule boundary is still unclear.
+- Proposed playbook changes: brief summary paragraph.
+- Rules promoted: short bullets with rationale.
+- Files to update: list of target files and why.
+- Change classification: canonical playbook guidance only, unless there is
+  explicit authorization for an `AGENTS.md` update/enforcement task.
+- Validation notes: short bullets covering evidence, reuse, scope, conflict
+  checks, rollout boundary, and notes cleanup.
+- Open questions: only if a rule boundary is still unclear.
 ```
 
 ### Playbook Update Notes

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -382,11 +382,10 @@ Constraints:
 - Do not copy project-specific implementation details, repo names, or local exceptions into the playbook.
 - Do not promote rules that are still speculative, unsupported by concrete
   evidence, or narrowly tied to one repository.
-- Do not update `AGENTS.md` files in other repositories as part of this
-  playbook update. Cross-repo `AGENTS.md` rollout or enforcement requires a
-  separate explicit rollout task.
-- If the target is the playbook repository itself, update its local `AGENTS.md`
-  only when needed to keep the playbook repo's local entrypoint consistent.
+- Do not update `AGENTS.md` files as part of this playbook update, including
+  the playbook repository's own `AGENTS.md`, unless the user explicitly
+  authorizes that edit or the task's primary purpose is `AGENTS.md` update,
+  rollout, or enforcement.
 - Keep the change scoped to one logical documentation update.
 
 Validation:
@@ -394,7 +393,7 @@ Validation:
   plausible reuse.
 - Verify that any repo-local rule remains outside the shared playbook.
 - Verify that the change does not treat canonical playbook updates as implicit
-  cross-repo `AGENTS.md` rollout.
+  `AGENTS.md` update or rollout.
 - Verify that updated wording does not conflict with existing core playbook documents.
 - Verify that the resulting file placement matches the playbook structure.
 - Verify that the update includes a notes cleanup follow-up or explicitly says
@@ -404,8 +403,8 @@ Output format:
 1. Proposed playbook changes: brief summary paragraph.
 2. Rules promoted: short bullets with rationale.
 3. Files to update: list of target files and why.
-4. Change classification: one of canonical playbook guidance only, playbook repo
-   local `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+4. Change classification: canonical playbook guidance only, unless there is
+   explicit authorization for an `AGENTS.md` update/enforcement task.
 5. Validation notes: short bullets covering evidence, reuse, scope, conflict
    checks, rollout boundary, and notes cleanup.
 6. Open questions: only if a rule boundary is still unclear.
@@ -637,8 +636,8 @@ Validation:
 Output format:
 1. AGENTS change summary: short paragraph.
 2. Shared-vs-local split: bullets showing what belongs in the playbook and what stays local.
-3. Change classification: canonical playbook guidance only, playbook repo local
-   `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+3. Change classification: explicitly authorized `AGENTS.md` update/enforcement
+   for the named repository.
 4. Files updated: list of touched files.
 5. Validation notes: short bullets.
 6. Residual gaps: optional bullets only if something still needs a human decision.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -375,18 +375,26 @@ Instructions:
   across repositories.
 - Update the playbook only where the lesson is durable, generic, and better captured centrally than locally.
 - Prefer tightening or extending existing playbook guidance over adding fragmented one-off notes.
+- Treat playbook updates and `AGENTS.md` rollout as separate work types.
 
 Constraints:
 - Treat <playbook_reference> as the canonical source for cross-repo workflow rules.
 - Do not copy project-specific implementation details, repo names, or local exceptions into the playbook.
 - Do not promote rules that are still speculative, unsupported by concrete
   evidence, or narrowly tied to one repository.
+- Do not update `AGENTS.md` files in other repositories as part of this
+  playbook update. Cross-repo `AGENTS.md` rollout or enforcement requires a
+  separate explicit rollout task.
+- If the target is the playbook repository itself, update its local `AGENTS.md`
+  only when needed to keep the playbook repo's local entrypoint consistent.
 - Keep the change scoped to one logical documentation update.
 
 Validation:
 - Verify that each promoted rule is backed by concrete cited evidence, not only
   plausible reuse.
 - Verify that any repo-local rule remains outside the shared playbook.
+- Verify that the change does not treat canonical playbook updates as implicit
+  cross-repo `AGENTS.md` rollout.
 - Verify that updated wording does not conflict with existing core playbook documents.
 - Verify that the resulting file placement matches the playbook structure.
 - Verify that the update includes a notes cleanup follow-up or explicitly says
@@ -396,9 +404,11 @@ Output format:
 1. Proposed playbook changes: brief summary paragraph.
 2. Rules promoted: short bullets with rationale.
 3. Files to update: list of target files and why.
-4. Validation notes: short bullets covering evidence, reuse, scope, conflict
-   checks, and notes cleanup.
-5. Open questions: only if a rule boundary is still unclear.
+4. Change classification: one of canonical playbook guidance only, playbook repo
+   local `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+5. Validation notes: short bullets covering evidence, reuse, scope, conflict
+   checks, rollout boundary, and notes cleanup.
+6. Open questions: only if a rule boundary is still unclear.
 ```
 
 ### Playbook Update Notes
@@ -600,12 +610,17 @@ Instructions:
 - Keep playbook-level rules in the playbook and repo-local execution rules in AGENTS.
 - Update AGENTS so it clearly acts as the thin repo-local execution layer on top of the shared playbook.
 - Preserve useful repo-specific instructions such as validation commands, file placement rules, and local workflow constraints.
+- Treat this as explicit rollout or enforcement work for the named repository,
+  not as a side effect of a generic playbook update.
 
 Constraints:
 - Treat <playbook_reference> as the canonical source for cross-repo workflow rules.
 - Explicitly distinguish shared playbook rules from repo-local rules.
 - Do not duplicate broad workflow guidance in AGENTS when the playbook already covers it.
 - Do not remove necessary repo-local instructions that the playbook cannot supply.
+- For global rollout, keep one repository, one branch, and one pull request per
+  target repository unless the target repository's documented process says
+  otherwise.
 - Keep the document concise, operational, and easy to maintain.
 
 Validation:
@@ -622,9 +637,11 @@ Validation:
 Output format:
 1. AGENTS change summary: short paragraph.
 2. Shared-vs-local split: bullets showing what belongs in the playbook and what stays local.
-3. Files updated: list of touched files.
-4. Validation notes: short bullets.
-5. Residual gaps: optional bullets only if something still needs a human decision.
+3. Change classification: canonical playbook guidance only, playbook repo local
+   `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+4. Files updated: list of touched files.
+5. Validation notes: short bullets.
+6. Residual gaps: optional bullets only if something still needs a human decision.
 ```
 
 ### AGENTS Update Notes

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -238,6 +238,21 @@ This document defines expectations, not exact GitHub settings.
 
 Reusable workflow rules belong in the playbook, not duplicated into each repository's `AGENTS.md`.
 
+Canonical playbook updates and `AGENTS.md` rollout are separate work types:
+
+- Playbook guidance changes update reusable workflow policy in this repository.
+- Playbook repository local `AGENTS.md` sync is allowed only when needed to keep
+  this repo's local entrypoint aligned with changed playbook behavior.
+- Cross-repo `AGENTS.md` updates are rollout or enforcement work. They require
+  an explicit rollout task and should not be inferred from a playbook docs
+  change.
+- Global rollout should use one repository, one branch, and one pull request per
+  target repository unless a target repository's documented process says
+  otherwise.
+- Reviews and delivery notes for workflow changes should state which category
+  the change belongs to: canonical playbook guidance only, playbook repo local
+  `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+
 ## Repository Categories
 
 Most repositories fit one or more broad surfaces: docs or workflow guidance,

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -238,20 +238,20 @@ This document defines expectations, not exact GitHub settings.
 
 Reusable workflow rules belong in the playbook, not duplicated into each repository's `AGENTS.md`.
 
-Canonical playbook updates and `AGENTS.md` rollout are separate work types:
+Canonical playbook updates and `AGENTS.md` edits are separate work types:
 
 - Playbook guidance changes update reusable workflow policy in this repository.
-- Playbook repository local `AGENTS.md` sync is allowed only when needed to keep
-  this repo's local entrypoint aligned with changed playbook behavior.
-- Cross-repo `AGENTS.md` updates are rollout or enforcement work. They require
-  an explicit rollout task and should not be inferred from a playbook docs
-  change.
+- `AGENTS.md` edits, including in `ai-workflow-playbook` itself, require
+  explicit user authorization or a task whose primary purpose is `AGENTS.md`
+  update, rollout, or enforcement.
+- Cross-repo `AGENTS.md` updates are rollout or enforcement work and should not
+  be inferred from a playbook docs change.
 - Global rollout should use one repository, one branch, and one pull request per
   target repository unless a target repository's documented process says
   otherwise.
 - Reviews and delivery notes for workflow changes should state which category
-  the change belongs to: canonical playbook guidance only, playbook repo local
-  `AGENTS.md` sync, or cross-repo `AGENTS.md` rollout/enforcement.
+  the change belongs to: canonical playbook guidance only or explicitly
+  authorized `AGENTS.md` update/enforcement.
 
 ## Repository Categories
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -17,6 +17,13 @@
 - Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
 - Treat `AGENTS.md` as the repo-local execution layer.
 - Repo-local rules take precedence only for repo-specific behavior.
+- Treat canonical playbook changes and `AGENTS.md` rollout as separate work
+  types. Updating the playbook does not implicitly authorize updates to
+  `AGENTS.md` files in other repositories.
+- A playbook documentation change may update this repository's own `AGENTS.md`
+  only when needed to keep the playbook repo's local entrypoint consistent.
+- Updating `AGENTS.md` in other repositories is cross-repo rollout or
+  enforcement work and requires an explicit rollout task.
 - Before acting on repository or software work, determine the interaction mode
   using `docs/repo-readiness.md`: implementation, review/audit, or
   orchestration/prompt-authoring.
@@ -40,6 +47,8 @@ Before acting on repository or software work:
 - `ai-workflow-playbook` is the canonical source for reusable workflow policy.
 - Repo-local `AGENTS.md` files are repo-local execution guidance layered on top
   of the playbook.
+- Cross-repo `AGENTS.md` alignment is enforcement or rollout work, not a side
+  effect of changing canonical playbook guidance.
 - Incubation, staging, and evidence repositories, including
   `ai-workflow-incubator`, are noncanonical unless a durable rule is explicitly
   promoted into the playbook.
@@ -64,6 +73,11 @@ Before acting on repository or software work:
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
+- Report whether a workflow change is canonical playbook guidance only,
+  playbook repo local `AGENTS.md` sync, or cross-repo `AGENTS.md`
+  rollout/enforcement.
+- For global rollout, use one repository, one branch, and one pull request per
+  target repository unless that repository's documented process says otherwise.
 - In ctrl-alt-keith workflows, default ambiguous repository tasks to
   review/audit or orchestration/prompt-authoring unless the human explicitly
   asks for direct implementation.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -17,13 +17,11 @@
 - Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
 - Treat `AGENTS.md` as the repo-local execution layer.
 - Repo-local rules take precedence only for repo-specific behavior.
-- Treat canonical playbook changes and `AGENTS.md` rollout as separate work
-  types. Updating the playbook does not implicitly authorize updates to
-  `AGENTS.md` files in other repositories.
-- A playbook documentation change may update this repository's own `AGENTS.md`
-  only when needed to keep the playbook repo's local entrypoint consistent.
-- Updating `AGENTS.md` in other repositories is cross-repo rollout or
-  enforcement work and requires an explicit rollout task.
+- Treat canonical playbook changes and `AGENTS.md` edits as separate work
+  types. Updating the playbook does not implicitly authorize any `AGENTS.md`
+  edit, including in `ai-workflow-playbook` itself.
+- Edit `AGENTS.md` only with explicit user authorization or when the task's
+  primary purpose is `AGENTS.md` update, rollout, or enforcement.
 - Before acting on repository or software work, determine the interaction mode
   using `docs/repo-readiness.md`: implementation, review/audit, or
   orchestration/prompt-authoring.
@@ -47,7 +45,7 @@ Before acting on repository or software work:
 - `ai-workflow-playbook` is the canonical source for reusable workflow policy.
 - Repo-local `AGENTS.md` files are repo-local execution guidance layered on top
   of the playbook.
-- Cross-repo `AGENTS.md` alignment is enforcement or rollout work, not a side
+- `AGENTS.md` alignment is update, enforcement, or rollout work, not a side
   effect of changing canonical playbook guidance.
 - Incubation, staging, and evidence repositories, including
   `ai-workflow-incubator`, are noncanonical unless a durable rule is explicitly
@@ -73,9 +71,8 @@ Before acting on repository or software work:
 ## Rule of Thumb
 
 - Prefer small, scoped changes.
-- Report whether a workflow change is canonical playbook guidance only,
-  playbook repo local `AGENTS.md` sync, or cross-repo `AGENTS.md`
-  rollout/enforcement.
+- Report whether a workflow change is canonical playbook guidance only or an
+  explicitly authorized `AGENTS.md` update/enforcement task.
 - For global rollout, use one repository, one branch, and one pull request per
   target repository unless that repository's documented process says otherwise.
 - In ctrl-alt-keith workflows, default ambiguous repository tasks to


### PR DESCRIPTION
Summary: Clarifies that canonical playbook changes and AGENTS.md update/enforcement are separate work types. Updates the playbook startup/readiness docs and prompt templates so generic playbook updates do not imply any AGENTS.md edit, including in ai-workflow-playbook itself. Documents that AGENTS.md edits require explicit user authorization or a task whose primary purpose is AGENTS update, rollout, or enforcement. Validation: make check passed. Change classification: canonical playbook guidance only; no AGENTS.md files are changed in the final PR diff and no local AGENTS sync is performed.