### PR TITLE
Document Codex sandbox temp root diagnostics

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -153,6 +153,14 @@ artifacts that may need later inspection. Use disposable OS temp locations only
 for short-lived process-local files whose path and contents do not matter after
 the command finishes.
 
+For Codex specifically, configured
+`[sandbox_workspace_write].writable_roots` may not be the full effective
+writable root set. The active project root and platform temp directories can be
+implicit writable roots unless local config excludes them. When stricter
+isolation matters, inspect the effective policy with
+`codex debug prompt-input effective-sandbox-check` and use the Codex adapter's
+sandbox guidance for temp-root exclusions.
+
 Avoid spreading workflow state across sibling repositories or other ad hoc
 shared locations unless the task explicitly requires broader coordination. When
 broader coordination is required, state where the shared state lives and why

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -173,6 +173,44 @@ Worktree cleanup can require elevated permission even when the visible worktree
 paths sit inside the repository, because Git also updates internal worktree
 metadata outside the leaf directories being removed.
 
+### Sandbox Writable Roots
+
+In `workspace-write` mode, do not assume
+`[sandbox_workspace_write].writable_roots` is the complete effective writable
+root list. Codex may also have implicit writable roots from the active project
+root and platform temp locations such as `/tmp` or `$TMPDIR`; on macOS, `/tmp`
+may appear in diagnostics as `/private/tmp`.
+
+Inspect the effective policy when sandbox boundaries matter:
+
+```sh
+codex debug prompt-input effective-sandbox-check
+```
+
+For stricter isolation, local Codex config can explicitly exclude the implicit
+temp roots:
+
+```toml
+[sandbox_workspace_write]
+exclude_slash_tmp = true
+exclude_tmpdir_env_var = true
+```
+
+Then verify the empty-explicit-roots case so temp roots do not silently
+reappear:
+
+```sh
+codex debug prompt-input -c 'sandbox_workspace_write.writable_roots=[]' effective-sandbox-check
+```
+
+Use repo-local scratch paths for workflow artifacts that need review later.
+Excluding temp roots can break tools that require writable temp directories, so
+redirect those tools to repo-local temp state when stricter isolation is
+required.
+
+The detailed runtime note lives in
+`ai-workflow-incubator/runtime-artifacts/codex-local-policy/sandbox-writable-roots.md`.
+
 ## Autonomous Lane
 
 Codex should continue executing without pausing for human input when:


### PR DESCRIPTION
Summary:
- Add concise Codex adapter guidance for inspecting effective writable roots.
- Clarify in repo readiness guidance that configured writable_roots may not be the full effective writable root set.
- Point detailed runtime behavior to the incubator runtime-artifacts note.

Why:
- Operators should not assume writable_roots excludes implicit project or temp roots.
- Stricter isolation requires exclude_slash_tmp, exclude_tmpdir_env_var, and effective-policy verification.

Validation:
- make check