### PR TITLE
Require worktrees for implementation changes

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -15,10 +15,11 @@ Define shared engineering expectations across repositories. This baseline forms 
   - Do not add or substitute alternate local validation tools outside the
     repo-defined workflow.
 - Command intent stays visible
-  - Run ordinary repo commands directly from the target repository, following
-    the command-form rules in `docs/repo-readiness.md`.
+  - Run ordinary repo commands directly from the target repository worktree,
+    following the command-form rules in `docs/repo-readiness.md`.
 - Repository isolation
   - One repository per PR.
+  - One dedicated worktree per implementation change.
   - No cross-repo commits.
 - Deterministic behavior
   - Prefer explicit, predictable outputs.
@@ -131,8 +132,8 @@ If two PRs overlap unexpectedly, pause and re-establish the order before merging
 
 Parallelism must not weaken:
 
-- one repository, one branch, one PR scope integrity
-- repo-local `.worktrees/` isolation when worktrees are used
+- one repository, one branch, one worktree, one PR scope integrity
+- required repo-local `.worktrees/` isolation for implementation changes
 - canonical validation
 - direct PR inspection
 - authoritative source requirements

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -125,11 +125,13 @@ made it. AI-agent branches should use concise, non-tool-branded names such as
 broad tool-name prefixes such as `codex/`, `claude/`, or `copilot/` should be
 avoided unless a repository intentionally requires them.
 
-For same-repo parallel work, prefer isolated Git worktrees over multiple arcs
-sharing one checkout. Keep the main checkout clean and on `main`, fetch before
-creating task worktrees so `origin/main` is current, create one worktree per
-issue or task from that current `origin/main`, and do the issue work only
-inside its worktree.
+Every implementation change must happen in a dedicated Git worktree: one
+repository, one branch, one worktree, and one PR per change. Keep the main
+checkout clean and on `main`, fetch before creating task worktrees so
+`origin/main` is current, create one worktree per issue or task from that
+current `origin/main`, and do the issue work only inside its worktree. The only
+exceptions are read-only inspection or explicit human instruction not to modify
+files.
 
 Before starting a same-repo worktree run, inspect existing worktree metadata and
 clear stale entries so an old attempt does not distort the new setup. Reuse an

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -183,9 +183,15 @@ External State Verification:
   review/audit or orchestration/prompt-authoring.
 - Verify live external state, such as GitHub repository or pull request state,
   before relying on it.
-- Run commands directly from the target repository and follow the command-form
-  rule in `docs/repo-readiness.md`; do not wrap ordinary repo commands in
-  `zsh`, `bash`, `sh`, or equivalent shell forms.
+- Run commands directly from inside the target repository worktree and follow
+  the command-form rule in `docs/repo-readiness.md`; do not wrap ordinary repo
+  commands in `zsh`, `bash`, `sh`, or equivalent shell forms.
+- For implementation changes, use a dedicated repo-local git worktree: one
+  repository, one branch, one worktree, and one PR per change. Run commands
+  from inside that target worktree and keep temporary or scratch state
+  repo-local.
+- The only worktree exceptions are read-only inspection or explicit human
+  instruction not to modify files.
 - Follow the direct PR inspection rule in `docs/review-packet.md` when a task
   asks for PR review, readiness, approval, or merge advice.
 - Follow the public API baseline in `docs/engineering-baseline.md` when code,
@@ -200,8 +206,8 @@ Parallel Execution Plan:
   `docs/engineering-baseline.md`.
 - Before parallel work begins, classify each task by lane and define merge order
   or state why merge order is flexible.
-- Preserve one-repo/one-branch/one-PR scope integrity, workspace isolation,
-  canonical validation, direct PR inspection, and authoritative source
+- Preserve one-repo/one-branch/one-worktree/one-PR scope integrity, workspace
+  isolation, canonical validation, direct PR inspection, and authoritative source
   requirements.
 
 Tasks:
@@ -629,9 +635,9 @@ Constraints:
 - Explicitly distinguish shared playbook rules from repo-local rules.
 - Do not duplicate broad workflow guidance in AGENTS when the playbook already covers it.
 - Do not remove necessary repo-local instructions that the playbook cannot supply.
-- For global rollout, keep one repository, one branch, and one pull request per
-  target repository unless the target repository's documented process says
-  otherwise.
+- For global rollout and implementation changes, keep one repository, one
+  branch, one dedicated worktree, and one pull request per target repository
+  unless the target repository's documented process says otherwise.
 - Keep the document concise, operational, and easy to maintain.
 
 Validation:
@@ -771,8 +777,9 @@ Required startup:
 3. Select the interaction mode before acting.
 4. Identify the canonical source for reusable workflow rules.
 5. Confirm command form for ordinary repo commands.
-6. Identify the canonical validation path.
-7. Act only after these checks are clear, or report the blocker.
+6. Confirm the dedicated repo-local worktree for implementation changes.
+7. Identify the canonical validation path.
+8. Act only after these checks are clear, or report the blocker.
 
 Interaction mode:
 - [implementation, review/audit, or orchestration/prompt-authoring]
@@ -790,12 +797,16 @@ Scope:
 
 Constraints:
 - Keep changes minimal, scoped, and structurally local.
+- Use a dedicated repo-local git worktree for implementation changes: one
+  repository, one branch, one worktree, and one PR per change. Run commands
+  from inside the target worktree and keep temporary or scratch state
+  repo-local.
 - Do not include unrelated cleanup.
 - Do not rely on noncanonical staging, runtime, generated, or local instruction
   surfaces as policy unless the rule has been promoted into the canonical
   source.
 - Use direct command execution for ordinary `git`, `gh`, `make`, `python`,
-  repo-local script, and tool commands.
+  repo-local script, and tool commands from inside the target worktree.
 - Do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent shell wrappers for
   ordinary repo commands.
 - Use shell wrappers only when shell syntax is genuinely required.
@@ -851,8 +862,12 @@ Delivery:
 - Follow the branch, PR readiness, and workspace rules in
   `docs/feature-lifecycle.md`, `docs/repo-readiness.md`, and
   `docs/tool-adapters/codex.md`.
+- Use a dedicated repo-local git worktree for implementation changes: one
+  repository, one branch, one worktree, and one PR per change. Run commands
+  from inside the target worktree and keep temporary or scratch state
+  repo-local.
 - Run ordinary `git`, `gh`, `make`, `python`, repo-local script, and tool
-  commands directly from the target repository; reserve shell wrapping for
+  commands directly from the target worktree; reserve shell wrapping for
   commands that genuinely require shell syntax.
 - Before executing a shell-wrapped command, perform the command-form preflight
   from `docs/repo-readiness.md`; when shell semantics are unnecessary, rewrite
@@ -955,6 +970,9 @@ Inputs:
 Instructions:
 - Inspect the current git state, existing diff, and branch context.
 - Confirm that the intended changes form one logical PR and identify any unrelated files or accidental scope.
+- Confirm that the changes are in a dedicated repo-local worktree, or stop and
+  report the mismatch unless the human explicitly instructed no file
+  modification.
 - If needed, create a fresh branch from current `origin/main`, keep only the
   intended diff, and prepare a clear commit and PR description.
 - Summarize the change in a way that supports quick human review and accurate merge decisions.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -29,8 +29,8 @@ requests, or running implementation-oriented workflows.
 Use one of these modes:
 
 - Implementation mode: directly make repo changes, validate them, commit them,
-  push the branch, and open or update a pull request when repo guidance calls
-  for PR delivery.
+  push the branch, and open or update a pull request from a dedicated
+  repo-local worktree when repo guidance calls for PR delivery.
 - Review/audit mode: inspect the requested repository, pull request, issue, or
   file surface and report findings, evidence, risks, and recommendations
   without mutating the repository.
@@ -118,9 +118,19 @@ Open a pull request as draft when any of the following are true:
 Docs-only changes should default to ready for review when canonical validation
 passes and the diff is isolated.
 
-When working in a multi-repo workspace, treat each repository as an independent unit of change. Even if multiple repositories are visible, commits, branches, and PRs must be created and managed per repository. Do not create cross-repo commits or PRs.
+When working in a multi-repo workspace, treat each repository as an independent
+unit of change. Even if multiple repositories are visible, commits, branches,
+worktrees, and PRs must be created and managed per repository. Do not create
+cross-repo commits or PRs.
 
-Before opening a PR, ensure that all staged changes belong to a single repository. If changes span multiple repositories, split them into separate branches and PRs, one per repository.
+Before opening a PR, ensure that all staged changes belong to a single
+repository. If changes span multiple repositories, split them into separate
+branches, worktrees, and PRs, one per repository.
+
+Every implementation change must use a dedicated repo-local git worktree: one
+repository, one branch, one worktree, and one PR per change. The only
+exceptions are read-only inspection or explicit human instruction not to modify
+files.
 
 ## Workspace Boundary Discovery
 
@@ -143,8 +153,9 @@ workflow updates.
 
 ## Repo-Local Workflow State
 
-Run commands from the target repository working directory by default. Keep
-temporary workflow artifacts scoped to that repository whenever practical.
+For implementation changes, run commands from inside the target repository's
+dedicated worktree. Keep temporary workflow artifacts scoped to that repository
+whenever practical.
 Examples include local worktree directories, generated review artifacts,
 transient manifests, and task-specific scratch state.
 
@@ -181,7 +192,7 @@ Use the structurally minimal command form that still expresses the intended
 operation clearly. Normal repository operations must be invoked as the command
 itself, rather than hidden inside an extra shell layer.
 
-Run commands from the target repository working directory by default. For
+Run commands from inside the target repository worktree by default. For
 ordinary repository operations, use direct `git ...`, `gh ...`, `make ...`,
 `python ...`, repo-local scripts, and tool-specific commands. Before choosing a
 wrapper shell, check whether the command has a direct form and use that direct
@@ -263,9 +274,9 @@ Canonical playbook updates and `AGENTS.md` edits are separate work types:
   update, rollout, or enforcement.
 - Cross-repo `AGENTS.md` updates are rollout or enforcement work and should not
   be inferred from a playbook docs change.
-- Global rollout should use one repository, one branch, and one pull request per
-  target repository unless a target repository's documented process says
-  otherwise.
+- Global rollout and implementation changes must use one repository, one
+  branch, one dedicated worktree, and one pull request per target repository
+  unless a target repository's documented process says otherwise.
 - Reviews and delivery notes for workflow changes should state which category
   the change belongs to: canonical playbook guidance only or explicitly
   authorized `AGENTS.md` update/enforcement.
@@ -284,8 +295,8 @@ repositories for org profile content, community health files, templates,
 metadata, or GitHub-supported defaults.
 
 Org infrastructure repositories still follow the shared workflow rules where
-they apply: one repo, one branch, one pull request; current `origin/main` as the
-base; purpose-based branch names; small scoped diffs; human-readable review
+they apply: one repo, one branch, one dedicated worktree, one pull request;
+current `origin/main` as the base; purpose-based branch names; small scoped diffs; human-readable review
 summaries; no unrelated cleanup; and public artifact path hygiene.
 
 Normal project-repository expectations may not apply until the repository grows:

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -73,12 +73,13 @@ Before acting on repository or software work:
 - Prefer small, scoped changes.
 - Report whether a workflow change is canonical playbook guidance only or an
   explicitly authorized `AGENTS.md` update/enforcement task.
-- For global rollout, use one repository, one branch, and one pull request per
-  target repository unless that repository's documented process says otherwise.
+- For global rollout and implementation changes, use one repository, one
+  branch, one dedicated worktree, and one pull request per target repository
+  unless that repository's documented process says otherwise.
 - In ctrl-alt-keith workflows, default ambiguous repository tasks to
   review/audit or orchestration/prompt-authoring unless the human explicitly
   asks for direct implementation.
-- Run commands directly from the target repository; follow
+- Run commands directly from inside the target repository worktree; follow
   `docs/repo-readiness.md` for command form and shell-wrapping rules.
 - Run repository validation through the repo's Makefile when it provides the
   canonical entrypoint.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -54,11 +54,10 @@ change.
 
 - read-only exploration, audit, or review work may use the active checkout when
   no repo changes are required
-- for repo-changing implementation work that needs an isolated workspace, use
-  `git worktree` from the target repository and place every repo-changing
-  worktree under `<repo>/.worktrees/`; do not create sibling repo directories,
-  sibling worktree directories, or ad hoc full-copy repositories under the
-  project root
+- for repo-changing implementation work, always use `git worktree` from the
+  target repository and place every repo-changing worktree under
+  `<repo>/.worktrees/`; do not create sibling repo directories, sibling
+  worktree directories, or ad hoc full-copy repositories under the project root
 - before creating or reusing a repo-changing worktree, run `git worktree list`,
   select a repo-local `.worktrees/...` path, and report that selected path in
   setup or delivery notes


### PR DESCRIPTION
Summary:
- Require dedicated repo-local git worktrees for implementation changes across readiness, lifecycle, baseline, Codex adapter, and prompts.
- Preserve one repo/branch/worktree/PR per change and clarify exceptions for read-only inspection or explicit no-modification instruction.
- Direct commands and temporary state toward the target worktree and repo-local scratch paths.

Validation:
- make check