### PR TITLE
docs: require connector PR review inspection

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -912,11 +912,13 @@ Inputs:
 - Summary-only requested: [summary_only]
 
 Instructions:
-- When a PR link or PR number is available, you must open the PR through the
-  GitHub connector before giving any review, approval, readiness, or merge
-  recommendation.
+- When a PR link or PR number is available, you must use connector inspection
+  and must open the PR through the GitHub connector before giving any review,
+  approval, readiness, or merge recommendation.
 - Stay in review/audit mode. Do not implement changes while performing the PR
   review unless the human explicitly changes the task to implementation.
+- Local checkouts, `git diff`, and `gh` commands may be used as supplemental
+  evidence for PR review, but they must not replace connector inspection.
 - Treat "open the PR" as read-only connector inspection, not opening the PR in
   a browser and not submitting a GitHub review.
 - Treat "review this PR" as inspect the PR and provide feedback in chat, unless

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -183,6 +183,9 @@ External State Verification:
   review/audit or orchestration/prompt-authoring.
 - Verify live external state, such as GitHub repository or pull request state,
   before relying on it.
+- When the human posts a GitHub PR link, provides a PR number, or asks to
+  review a PR, follow the GitHub connector-first PR review rule in
+  `docs/review-packet.md`.
 - Run commands directly from inside the target repository worktree and follow
   the command-form rule in `docs/repo-readiness.md`; do not wrap ordinary repo
   commands in `zsh`, `bash`, `sh`, or equivalent shell forms.
@@ -909,22 +912,37 @@ Inputs:
 - Summary-only requested: [summary_only]
 
 Instructions:
-- Unless Summary-only requested is `yes`, inspect the PR directly before giving
-  any review, approval, readiness, or merge recommendation.
+- When a PR link or PR number is available, you must open the PR through the
+  GitHub connector before giving any review, approval, readiness, or merge
+  recommendation.
 - Stay in review/audit mode. Do not implement changes while performing the PR
   review unless the human explicitly changes the task to implementation.
-- Treat user-provided summaries as navigation and context only, not review
-  evidence.
-- Inspect the PR title and body, changed files, relevant diffs, CI and check
+- Treat "open the PR" as read-only connector inspection, not opening the PR in
+  a browser and not submitting a GitHub review.
+- Treat "review this PR" as inspect the PR and provide feedback in chat, unless
+  the human explicitly asks to post the review to GitHub.
+- Treat user-provided summaries, pasted titles, local path snippets, and copied
+  diff excerpts as navigation and context only, not review evidence, when a PR
+  link or PR number is available.
+- You must inspect the actual PR metadata, title and body, changed files,
+  relevant diffs, comments and unresolved review discussion, CI and check
   status, mergeability, and scope against the task or issue where those inputs
   are available.
-- If direct PR access is unavailable and Summary-only requested is not `yes`,
-  stop the PR review, state that direct PR access is unavailable, and ask for
-  access to be restored or for the PR and files to be made available.
+- You must not mutate the PR: do not submit, approve, request changes, comment
+  on, label, merge, close, or otherwise change the PR unless the human
+  explicitly asks for that GitHub action.
+- If GitHub connector access is unavailable or declined and Summary-only
+  requested is not `yes`, stop the PR review, state that connector access is
+  unavailable, and provide only clearly caveated feedback from the information
+  already present.
 - Do not claim the PR is safe to merge, ready to merge, or approved without
-  direct evidence from the PR itself.
-- If Summary-only requested is `yes`, state that the response is based only on
-  the supplied summary and does not establish merge readiness.
+  direct evidence from the PR itself through the connector.
+- If Summary-only requested is `yes` but a PR link or PR number is available,
+  state that summary-only material is not the review source of truth and still
+  perform connector inspection before review feedback.
+- If Summary-only requested is `yes` and no PR link or PR number is available,
+  state that the response is based only on the supplied summary and does not
+  establish merge readiness.
 
 Output format:
 1. Review findings: severity-ordered findings with file or PR references where

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -36,27 +36,42 @@ When relevant, say explicitly whether validation was mocked, contract-level, or 
 
 ## Direct PR Inspection
 
-When asked to review, check, assess, approve, or comment on a PR, inspect the PR
-directly unless the human explicitly asks for summary-only discussion.
+When the human posts a GitHub PR link, provides a PR number, or asks to review,
+check, assess, approve, or comment on a PR, the reviewer must open the PR
+through the GitHub connector before giving review feedback.
 
-User-provided PR summaries are useful navigation and context, but they are not
-review evidence. A PR review must be grounded in the actual PR surface,
-including, where available:
+Treat "open the PR" as read-only connector inspection. It does not mean opening
+the PR in a browser, and it does not mean submitting a GitHub review.
+
+User-provided PR summaries, pasted titles, local path snippets, and copied
+diff excerpts are useful navigation and context, but they are not the review
+source of truth when a PR link or PR number is available. A PR review must be
+grounded in the actual PR surface from the connector. The reviewer must inspect,
+where available:
 
 - PR title and body
 - changed files
 - relevant diffs
+- comments and unresolved review discussion
 - CI and check status
 - mergeability
 - scope against the task, issue, or stated goal
 
-Do not claim a PR is safe to merge, ready to merge, or approved without direct
-evidence from the PR itself.
+Return review feedback in chat by default. The reviewer must not mutate the PR:
+do not submit, approve, request changes, comment on, label, merge, close, or
+otherwise change the PR unless the human explicitly asks for that GitHub action.
 
-If direct PR access is unavailable, stop the PR review and say that direct PR
-access is unavailable. Do not provide a merge or readiness recommendation from
-secondhand text. Ask for access to be restored or for the PR and files to be
-made available for direct inspection.
+Treat "review this PR" as inspect the PR and provide feedback in chat. Do not
+post the review to GitHub unless the human explicitly asks to post the review
+to GitHub.
+
+Do not claim a PR is safe to merge, ready to merge, or approved without direct
+evidence from the PR itself through the connector.
+
+If GitHub connector access is unavailable or declined, stop the PR review and
+say that connector access is unavailable. Do not provide a merge or readiness
+recommendation from secondhand text. Provide only clearly caveated feedback
+from information already present, or ask for connector access to be restored.
 
 ## Optional Trust Or Evidence Context
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -37,8 +37,12 @@ When relevant, say explicitly whether validation was mocked, contract-level, or 
 ## Direct PR Inspection
 
 When the human posts a GitHub PR link, provides a PR number, or asks to review,
-check, assess, approve, or comment on a PR, the reviewer must open the PR
-through the GitHub connector before giving review feedback.
+check, assess, approve, or comment on a PR, the reviewer must use connector
+inspection and must open the PR through the GitHub connector before giving
+review feedback.
+
+Local checkouts, `git diff`, and `gh` commands may be used as supplemental
+evidence for PR review, but they must not replace connector inspection.
 
 Treat "open the PR" as read-only connector inspection. It does not mean opening
 the PR in a browser, and it does not mean submitting a GitHub review.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -130,11 +130,12 @@ change.
 - examples: use `git status`, not `zsh -lc 'git status'`; use `make check`, not
   `bash -lc 'make check'`; use `gh pr view 145`, not
   `sh -c 'gh pr view 145'`
-- use `gh repo view` to confirm the target repository is reachable when
-  connector inspection is not the required path
 - when the human posts a GitHub PR link, provides a PR number, or asks to
-  review, check, assess, approve, or comment on a PR, Codex must open the PR
-  through the GitHub connector before giving review feedback
+  review, check, assess, approve, or comment on a PR, Codex must use connector
+  inspection and must open the PR through the GitHub connector before giving
+  review feedback
+- local checkouts, `git diff`, and `gh` commands may be used as supplemental
+  evidence for PR review, but they must not replace connector inspection
 - treat "open the PR" as read-only connector inspection, not opening the PR in
   a browser and not submitting a GitHub review
 - treat "review this PR" as inspect the PR and provide feedback in chat, unless

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -130,21 +130,30 @@ change.
 - examples: use `git status`, not `zsh -lc 'git status'`; use `make check`, not
   `bash -lc 'make check'`; use `gh pr view 145`, not
   `sh -c 'gh pr view 145'`
-- use `gh repo view` to confirm the target repository is reachable
-- when PR state matters, use `gh pr view` to fetch current PR metadata before
-  making decisions
-- when asked to review, check, assess, approve, or comment on a PR, inspect the
-  PR directly unless the human explicitly asks for summary-only discussion
-- treat user-provided PR summaries as navigation and context only, not review
-  evidence
-- direct PR inspection should include the PR title and body, changed files,
-  relevant diffs, CI and check status, mergeability, and scope against the task
-  or issue where those inputs are available
-- if the required `gh` commands fail, stop and report the access or state
-  blocker instead of inferring remote state
-- if direct PR access is unavailable for a PR review, stop the review, state
-  that direct PR access is unavailable, and ask for access to be restored or for
-  the PR and files to be made available
+- use `gh repo view` to confirm the target repository is reachable when
+  connector inspection is not the required path
+- when the human posts a GitHub PR link, provides a PR number, or asks to
+  review, check, assess, approve, or comment on a PR, Codex must open the PR
+  through the GitHub connector before giving review feedback
+- treat "open the PR" as read-only connector inspection, not opening the PR in
+  a browser and not submitting a GitHub review
+- treat "review this PR" as inspect the PR and provide feedback in chat, unless
+  the human explicitly asks to post the review to GitHub
+- Codex must inspect the actual PR metadata, title and body, changed files,
+  relevant diffs, comments and unresolved review discussion, CI and check
+  status, mergeability, and scope against the task or issue where those inputs
+  are available
+- treat user-provided PR summaries, pasted titles, local path snippets, and
+  copied diff excerpts as navigation and context only, not review evidence,
+  when a PR link or PR number is available
+- Codex must not mutate the PR: do not submit, approve, request changes,
+  comment on, label, merge, close, or otherwise change the PR unless the human
+  explicitly asks for that GitHub action
+- if GitHub connector access is unavailable or declined for a PR review, stop
+  the review, state that connector access is unavailable, and provide only
+  clearly caveated feedback from the information already present
+- if the required `gh` commands fail on a non-review PR task, stop and report
+  the access or state blocker instead of inferring remote state
 - do not assume mergeability, checks, or branch protection without verification
 
 ## Public API Baseline Check


### PR DESCRIPTION
Summary:
- Require GitHub PR links and available PR numbers to be opened through the GitHub connector before review feedback.
- Clarify read-only inspection versus GitHub write actions, including that reviewers must not mutate PRs unless explicitly asked.
- Update the reusable PR review prompt and Codex adapter guidance to keep feedback in chat by default.

Validation:
- make check