### PR TITLE
[codex] reduce context refresh snapshot churn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ workspace-bootstrap: ## Generate fresh-thread and project-source bootstrap conte
 	mv "$$tmp" "$$out"; \
 	echo "Generated $$out"
 
-context-refresh: ## Generate current-state brief for fresh-thread handoff.
+context-refresh: ## Generate repository orientation brief for fresh-thread handoff.
 	python3 scripts/generate_context_refresh.py --repo-manifest $(WORKSPACE_REPOS_MANIFEST) --output dist/context-refresh.md
 
 github-context: ## Generate GitHub connector repo hydration snippet.

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Reusable pattern:
 
 Run `make workspace-bootstrap` to generate `dist/workspace-bootstrap.md`, a non-canonical hydration bundle for fresh-thread and project-source context loading. Canonical guidance remains in the source docs and repo-local `AGENTS.md`; the generated bundle is only a convenience snapshot and should be regenerated instead of edited directly.
 
-Run `make context-refresh` to generate `dist/context-refresh.md`, a non-canonical current-state brief for fresh-thread handoff and repo-state refresh.
+Run `make context-refresh` to generate `dist/context-refresh.md`, a non-canonical repository orientation brief for fresh-thread handoff and repo orientation refresh. Dynamic PR and issue state is intentionally omitted; inspect GitHub directly before acting.
 
 Run `make github-context` to generate `dist/github-context.md`, a paste-ready `@GitHub` repo list for connector rehydration in fresh threads. The artifact is non-canonical and generated from `config/workspace-repos.txt`.
 
 These generated artifacts are complementary:
 
 - `workspace-bootstrap` hydrates stable operating guidance.
-- `context-refresh` captures current repo state.
+- `context-refresh` captures durable repo orientation state.
 - `github-context` rehydrates GitHub connector repo scope.
 
 Repository code, issues, pull requests, docs, and repo-local `AGENTS.md` files remain the source of truth.
@@ -80,7 +80,7 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md): Codex-specific adapter notes
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
-- [`docs/context-refresh.md`](docs/context-refresh.md): verified context refresh primitive for baseline briefs plus verified repo state
+- [`docs/context-refresh.md`](docs/context-refresh.md): verified context refresh primitive for durable repository orientation briefs
 - [`docs/maintenance-automations.md`](docs/maintenance-automations.md): reusable operating rules plus reference inventory notes for recurring Codex maintenance automation
 - [`docs/prompts.md`](docs/prompts.md): reusable prompt templates, including the standard Codex task prompt format
 

--- a/docs/context-refresh.md
+++ b/docs/context-refresh.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-Context refresh rebuilds current repository-state context for fresh-thread
+Context refresh rebuilds durable repository orientation context for fresh-thread
 handoff, lost context, or meaningful repo drift. For new threads, start with the
 [Thread Initialization](thread-init.md) pattern, then refresh context when
-verified current state matters.
+verified repository identity and branch context matter.
 
 ## Primary Workflow
 
@@ -15,8 +15,9 @@ Run the executable target from the repository root:
 make context-refresh
 ```
 
-Use `dist/context-refresh.md` as the generated current-state snapshot. It is a
-convenience artifact for handoff and orientation, not a canonical document.
+Use `dist/context-refresh.md` as the generated repository orientation snapshot.
+It is a convenience artifact for handoff and orientation, not a canonical
+document.
 
 ## Source of Truth
 
@@ -26,13 +27,17 @@ and the local repository state outrank generated snapshots and prior briefs.
 Do not edit generated snapshots to make them true. Regenerate them after repo
 state changes or before using an old snapshot to guide action.
 
+Dynamic pull request and issue state is intentionally omitted from generated
+context refresh output. Inspect GitHub directly before acting on current PR or
+issue state.
+
 ## Interpretation
 
 - `blocked` or `unavailable` repo entries mean inspection failed. Do not guess
   the missing state from prior context, summaries, or expectations.
 - Stale snapshots should be regenerated before acting on their conclusions.
-- Generated output can summarize verified state, but it does not replace direct
-  inspection when decisions require current evidence.
+- Generated output can summarize durable orientation state, but it does not
+  replace direct inspection when decisions require current evidence.
 
 ## Boundaries
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -33,8 +33,8 @@ tooling.
 
 Canonical guidance for the verified org context refresh pattern lives in
 [`docs/context-refresh.md`](context-refresh.md). Use that page for when to run
-it, how to generate the current-state snapshot, and how to interpret blocked,
-unavailable, or stale output.
+it, how to generate the repository orientation snapshot, and how to interpret
+blocked, unavailable, or stale output.
 
 ## Filesystem-Scoped Audit Boundaries
 

--- a/scripts/generate_context_refresh.py
+++ b/scripts/generate_context_refresh.py
@@ -17,62 +17,12 @@ from workspace_repos import (
 )
 
 DEFAULT_MANIFEST = Path("config/workspace-repos.txt")
-OPEN_ITEM_LIMIT = 100
-MERGED_PR_LIMIT = 5
 
 REPO_CONTEXT_QUERY = """
 query RepoContext($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
-    nameWithOwner
     defaultBranchRef {
       name
-    }
-    openPullRequests: pullRequests(
-      states: OPEN
-      first: 100
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      totalCount
-      nodes {
-        number
-        title
-        url
-        updatedAt
-        author {
-          login
-        }
-      }
-    }
-    openIssues: issues(
-      states: OPEN
-      first: 100
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      totalCount
-      nodes {
-        number
-        title
-        url
-        updatedAt
-        author {
-          login
-        }
-      }
-    }
-    recentMergedPullRequests: pullRequests(
-      states: MERGED
-      first: 5
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      nodes {
-        number
-        title
-        url
-        mergedAt
-        author {
-          login
-        }
-      }
     }
   }
 }
@@ -83,9 +33,6 @@ query RepoContext($owner: String!, $name: String!) {
 class RepoReport:
     name: str
     default_branch: str | None
-    open_prs: dict[str, Any]
-    open_issues: dict[str, Any]
-    recent_merged_prs: list[dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -96,7 +43,7 @@ class UnavailableRepo:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Generate a non-canonical current-state context refresh."
+        description="Generate a non-canonical repository orientation refresh."
     )
     parser.add_argument(
         "--output",
@@ -167,9 +114,6 @@ def collect_repo(repo: str) -> RepoReport:
     return RepoReport(
         name=repo,
         default_branch=default_branch.get("name"),
-        open_prs=repository["openPullRequests"],
-        open_issues=repository["openIssues"],
-        recent_merged_prs=repository["recentMergedPullRequests"]["nodes"],
     )
 
 
@@ -197,7 +141,7 @@ def render_report(
         "Status: generated snapshot",
         "Canonical: false",
         "",
-        "This file is a generated current-state brief for fresh-thread handoff.",
+        "This file is a generated repository orientation brief for fresh-thread handoff.",
         "",
         "Repository code, issues, pull requests, and docs remain the source of truth.",
         "",
@@ -209,6 +153,7 @@ def render_report(
         "",
         "This report is a point-in-time snapshot, not canonical guidance.",
         "Use GitHub and repository state as the source of truth before acting.",
+        "Dynamic PR/issue state intentionally omitted; inspect GitHub directly before acting.",
         "",
         "## Tracked Repositories",
         "",
@@ -224,22 +169,20 @@ def render_report(
         lines.extend(render_repo(report))
         lines.append("")
 
-    lines.extend(["## Blocked Or Unavailable", ""])
     if unavailable:
+        lines.extend(["## Blocked Or Unavailable", ""])
         lines.extend(
             f"- `{repo.name}`: {repo.reason}"
             for repo in unavailable
         )
-    else:
-        lines.append("- None.")
+        lines.append("")
 
     lines.extend(
         [
-            "",
             "## Reminder",
             "",
             "This file is a generated convenience artifact.",
-            "It is useful for fresh-thread handoff and repo-state refresh,",
+            "It is useful for fresh-thread handoff and repo orientation refresh,",
             "but it does not replace repository docs, issues, pull requests,",
             "or current GitHub state.",
             "",
@@ -253,57 +196,9 @@ def render_repo(report: RepoReport) -> list[str]:
         f"### `{report.name}`",
         "",
         f"- Default branch: `{report.default_branch or 'unknown'}`",
-        f"- Open PRs: {report.open_prs['totalCount']}",
-        f"- Open issues: {report.open_issues['totalCount']}",
-        "",
-        "#### Open PRs",
-        "",
+        "- Dynamic PR/issue state intentionally omitted; inspect GitHub directly before acting.",
     ]
-    lines.extend(render_items(report.open_prs, "PR", "updatedAt"))
-    lines.extend(["", "#### Open Issues", ""])
-    lines.extend(render_items(report.open_issues, "Issue", "updatedAt"))
-    lines.extend(
-        [
-            "",
-            f"#### Recent Merged PRs (latest {MERGED_PR_LIMIT})",
-            "",
-        ]
-    )
-    lines.extend(render_node_list(report.recent_merged_prs, "PR", "mergedAt"))
     return lines
-
-
-def render_items(items: dict[str, Any], kind: str, date_field: str) -> list[str]:
-    nodes = items["nodes"]
-    total_count = items["totalCount"]
-    lines = render_node_list(nodes, kind, date_field)
-    if total_count > len(nodes):
-        lines.append(
-            f"- Showing {len(nodes)} of {total_count}; rerun with direct GitHub"
-            " inspection for the complete list."
-        )
-    return lines
-
-
-def render_node_list(
-    nodes: list[dict[str, Any]],
-    kind: str,
-    date_field: str,
-) -> list[str]:
-    if not nodes:
-        return ["- None."]
-    return [render_node(node, kind, date_field) for node in nodes]
-
-
-def render_node(node: dict[str, Any], kind: str, date_field: str) -> str:
-    author = (node.get("author") or {}).get("login") or "unknown"
-    date_value = node.get(date_field) or "unknown date"
-    title = one_line(node.get("title") or "untitled")
-    url = node.get("url") or "unknown url"
-    return (
-        f"- {kind} #{node['number']}: {title} "
-        f"({date_field}: {date_value}; author: {author}) {url}"
-    )
 
 
 def one_line(value: str) -> str:

--- a/tests/test_generate_context_refresh.py
+++ b/tests/test_generate_context_refresh.py
@@ -40,8 +40,8 @@ class ContextRefreshGeneratorTest(unittest.TestCase):
                         "Canonical: false",
                         "",
                         (
-                            "This file is a generated current-state brief for "
-                            "fresh-thread handoff."
+                            "This file is a generated repository orientation "
+                            "brief for fresh-thread handoff."
                         ),
                         "",
                         (
@@ -76,6 +76,33 @@ class ContextRefreshGeneratorTest(unittest.TestCase):
             "- `ctrl-alt-keith/example`: repository was not returned by GitHub",
             report,
         )
+
+    def test_repo_state_omits_dynamic_pr_issue_details(self) -> None:
+        report = generator.render_report(
+            reports=[
+                generator.RepoReport(
+                    "ctrl-alt-keith/example",
+                    "main",
+                )
+            ],
+            unavailable=[],
+            generated_at=datetime(2026, 5, 8, 12, 0, tzinfo=timezone.utc),
+            repos=("ctrl-alt-keith/example",),
+        )
+
+        self.assertIn("- Default branch: `main`", report)
+        self.assertIn(
+            (
+                "- Dynamic PR/issue state intentionally omitted; inspect "
+                "GitHub directly before acting."
+            ),
+            report,
+        )
+        self.assertNotIn("Open PRs", report)
+        self.assertNotIn("Open Issues", report)
+        self.assertNotIn("Recent Merged PRs", report)
+        self.assertNotIn("author:", report)
+        self.assertNotIn("updatedAt", report)
 
     def test_one_line_normalizes_whitespace(self) -> None:
         self.assertEqual(generator.one_line("hello\n  there"), "hello there")


### PR DESCRIPTION
## Summary

- Narrow `make context-refresh` output to durable repository orientation: tracked repo identifiers, default branch, generation metadata, canonicality warnings, and regeneration instructions.
- Remove generated open PR/issue counts and lists, recent merged PR sections, author metadata, activity timestamps, and empty-state boilerplate from the context refresh generator.
- Update docs and tests so downstream AI hydration treats the artifact as stable orientation context and inspects GitHub directly for dynamic PR/issue state.

## Rationale

The previous context refresh artifact looked like a pseudo-live GitHub status report. That created unnecessary churn and risked accidental authority inflation when agents treated stale generated snapshots as fresher than source systems. The new output keeps stable orientation context while explicitly omitting dynamic PR/issue state.

## Validation

- Regenerated dist artifacts with `make dist`; `dist/context-refresh.md` now renders as a 78-line orientation snapshot with no PR/issue lists, recent merged PRs, author metadata, activity timestamps, or empty-state `None` blocks.
- `make check`
- `git diff --check`