### PR TITLE
Add single-operator review posture

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -943,6 +943,13 @@ Instructions:
   a browser and not submitting a GitHub review.
 - Treat "review this PR" as inspect the PR and provide feedback in chat, unless
   the human explicitly asks to post the review to GitHub.
+- Apply the single-operator review posture from `docs/repo-readiness.md` when
+  the repository ecosystem is primarily operated by one maintainer with rapid
+  iteration and straightforward rollback. Bias toward actionable
+  experimentation, cohesive local improvements, and practical follow-on
+  recommendations while preserving normal rigor for security-sensitive,
+  destructive, irreversible, compatibility-sensitive, release, or
+  high-blast-radius behavior.
 - Treat user-provided summaries, pasted titles, local path snippets, and copied
   diff excerpts as navigation and context only, not review evidence, when a PR
   link or PR number is available.
@@ -968,7 +975,8 @@ Instructions:
 
 Output format:
 1. Review findings: severity-ordered findings with file or PR references where
-   possible.
+   possible. Distinguish blockers from non-blocking risks, implementation
+   opportunities, and practical follow-ons.
 2. Scope and evidence notes: concise notes on inspected PR surface, CI/checks,
    mergeability, and task fit.
 3. Recommendation: `ready to merge`, `needs decision`, or `blocked`, only when

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -81,6 +81,27 @@ Keep this policy in the shared playbook. Repo-local `AGENTS.md` files should
 reference or rely on it rather than duplicate it, except where a repository
 truly requires different behavior.
 
+## Single-Operator Review Posture
+
+For repository ecosystems primarily operated by one maintainer with rapid
+iteration, clear rollback paths, and low coordination overhead, reviews should
+bias toward actionable experimentation and cohesive improvement.
+
+Prefer cohesive, locally testable changes over artificial PR splitting when
+the blast radius is understood and rollback is straightforward. Reviewers
+should surface concrete implementation opportunities early, recommend
+practical follow-on improvements freely, and avoid deferring useful cleanup
+only because it is adjacent to the requested change.
+
+This posture does not weaken rigor for security-sensitive changes, data-loss
+risks, irreversible migrations, compatibility hazards, destructive automation,
+release behavior, or high-blast-radius operational changes. In those cases,
+reviewers should apply the normal conservative review posture.
+
+When using this posture, distinguish blocking issues from non-blocking
+experiments, risks, and follow-on opportunities. The goal is faster
+operational learning without hiding real safety or maintainability concerns.
+
 ## Makefile Discoverability
 
 Any repository with a Makefile should include a `make help` target. `make help`

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -77,6 +77,24 @@ say that connector access is unavailable. Do not provide a merge or readiness
 recommendation from secondhand text. Provide only clearly caveated feedback
 from information already present, or ask for connector access to be restored.
 
+## Single-Operator Review Posture
+
+When a repository ecosystem fits the single-operator posture in
+[`repo-readiness.md`](repo-readiness.md#single-operator-review-posture), review
+feedback should distinguish:
+
+- blocking issues that should stop merge
+- non-blocking risks that are acceptable to test operationally
+- implementation opportunities that would make the current change more
+  cohesive
+- practical follow-on improvements that are useful but not required before
+  merge
+
+Do not turn locally testable, reversible improvements into automatic deferrals
+only because they are adjacent to the original request. Also do not soften
+security-sensitive, destructive, irreversible, compatibility-sensitive, or
+high-blast-radius findings into experiments.
+
 ## Optional Trust Or Evidence Context
 
 When prior validation, repeated usage, or unresolved uncertainty affects review


### PR DESCRIPTION
## Summary

- Add canonical single-operator review posture guidance to repo readiness.
- Connect review packets to the posture so feedback separates blockers, acceptable experiments, implementation opportunities, and follow-ons.
- Update the reusable PR review prompt to apply the posture during reviews.

## Rationale

This moves the review posture out of local/thread instructions and into the shared playbook policy surface while preserving normal rigor for security-sensitive, destructive, irreversible, compatibility-sensitive, release, and high-blast-radius behavior.

## Validation

- `make check`
- `git diff --check`

## Review packet

- Interaction mode: implementation
- Source evidence: user request to promote the single-operator ecosystem review posture into policy
- Recommendation: ready to merge