### PR TITLE
Add issue coordination guidance

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -145,11 +145,11 @@ for GitHub issue closure. Do not manually close the GitHub issue as a separate
 coordination step unless the repository workflow or human explicitly asks for
 it.
 
-Keep planning tickets open while the implementation PR is still open unless the
-planning system's local workflow says otherwise. Usually mark the planning
-ticket complete only after the PR has merged and the linked GitHub issue
-closure has been confirmed. During the PR-open state, planning status should
-reflect implementation in progress or in review, not merge-complete.
+Planning tickets will usually remain open while the implementation PR is still
+open unless the planning system's local workflow says otherwise. Usually mark
+the planning ticket complete only after the PR has merged and the linked GitHub
+issue closure has been confirmed. During the PR-open state, planning status
+should reflect implementation in progress or in review, not merge-complete.
 
 For multi-issue work, keep the mapping explicit: list every GitHub issue the PR
 intends to close and every planning ticket it coordinates with. If one PR

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -118,6 +118,49 @@ stop after the findings or recommendations unless the request also asks for
 shipped changes. If those tasks do produce repo changes, follow the same
 branch, validation, and PR flow before calling them complete.
 
+### Issue And Planning Coordination
+
+For repository implementation work, GitHub remains the implementation and
+closure source of truth unless repo-local guidance explicitly defines a
+different system of record. GitHub issues, pull requests, closing keywords, CI,
+review state, and merge state determine whether repo work is complete.
+
+Planning systems such as Linear are coordination layers by default. Use them to
+track planning intent, status, assignment, sequencing, or stakeholder context,
+but do not treat them as authoritative over repository implementation state
+unless the target repository explicitly says so. The same rule applies to
+similar planning mirrors or boards.
+
+When both GitHub and planning identifiers exist, implementation PRs should
+reference both. Keep the GitHub closing keyword tied to the GitHub issue and
+include the planning identifier as coordination context, for example:
+
+```text
+Closes #163
+Linear: CAK-5
+```
+
+Use GitHub closing keywords such as `Closes #163` as the preferred mechanism
+for GitHub issue closure. Do not manually close the GitHub issue as a separate
+coordination step unless the repository workflow or human explicitly asks for
+it.
+
+Keep planning tickets open while the implementation PR is still open unless the
+planning system's local workflow says otherwise. Usually mark the planning
+ticket complete only after the PR has merged and the linked GitHub issue
+closure has been confirmed. During the PR-open state, planning status should
+reflect implementation in progress or in review, not merge-complete.
+
+For multi-issue work, keep the mapping explicit: list every GitHub issue the PR
+intends to close and every planning ticket it coordinates with. If one PR
+resolves only part of a larger planning ticket, say that directly and leave the
+remaining planning item or follow-up open.
+
+Residual risks and follow-ups belong in the review packet and PR notes. Create
+or keep separate follow-up issues or planning tickets only when work remains
+after merge; do not hide unfinished required work behind a completed planning
+status.
+
 Use purpose-based branch prefixes that describe the change, not the tool that
 made it. AI-agent branches should use concise, non-tool-branded names such as
 `docs/<short-topic>`, `fix/<short-topic>`, `chore/<short-topic>`, or

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -112,6 +112,8 @@ template instead of appending implementation delivery instructions by habit.
 
 - `Context`: repository, current situation, relevant background, and any known
   boundaries.
+- `Coordination`: optional GitHub issue IDs, planning ticket IDs such as Linear
+  IDs, PR linkage expectations, and post-merge coordination notes.
 - `Goal`: the desired outcome in one or two clear sentences.
 - `Scope`: optional when the goal is already precise; useful for naming included
   and excluded work.
@@ -162,6 +164,12 @@ Context:
 Context:
 - Repository: [repository]
 - Relevant background: [short context]
+
+Coordination:
+- GitHub issues: [none, or issues such as #163]
+- Planning tickets: [none, or IDs such as Linear CAK-5]
+- PR linkage: [closing keywords and planning references expected in the PR]
+- Post-merge notes: [none, or planning/status updates to verify after merge]
 
 Goal:
 - [desired outcome]
@@ -235,6 +243,10 @@ Deliverable:
 - Commit and push only the intended changes.
 - Open a PR in the appropriate readiness state against the intended base
   branch, usually `main`.
+- When GitHub issues and planning tickets are both provided, reference both in
+  the PR. Use GitHub closing keywords such as `Closes #163` for GitHub issue
+  closure and include planning identifiers such as `Linear: CAK-5` as
+  coordination context.
 - Ensure the PR contains only intended changes.
 - Include a summary, validation results, and any residual risks.
 ```
@@ -799,6 +811,8 @@ Goal:
 Context:
 - [relevant facts discovered by the orchestrator]
 - [issue, PR, evidence note, or prior-art context the receiver needs]
+- [GitHub issue IDs, planning-ticket IDs, PR linkage expectations, and
+  post-merge coordination notes, when relevant]
 
 Scope:
 - In scope: [files, behavior, docs, or workflow area]
@@ -845,6 +859,10 @@ Delivery:
 - [branch, commit, push, PR, review packet, or report expectation]
 - Include summary, validation, source evidence, and residual risks or
   follow-ups.
+- When both GitHub issues and planning tickets are in scope, include both in
+  the PR or handoff. Use GitHub closing keywords for GitHub issue closure and
+  treat planning tickets as coordination state unless repo-local guidance says
+  otherwise.
 
 Deliverable:
 - [complete expected final output]
@@ -902,6 +920,8 @@ Delivery:
 - Push the branch.
 - Open a PR in the appropriate readiness state against the intended base branch,
   usually `main`.
+- Include expected GitHub issue closing keywords and planning-ticket references
+  in the PR body when those identifiers are provided.
 - Report the PR link, files changed, and validation results.
 ```
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -121,6 +121,8 @@ Open a pull request as ready for review when all of the following are true:
 - no known follow-up work is required before merge
 - overlap and coordination risk are low
 - issue lifecycle should not affect pull request readiness; using `Closes #<issue>` follows standard GitHub behavior and should not delay marking a pull request as ready
+- planning-ticket status should not delay a completed implementation PR unless
+  it reflects real sequencing, overlap, or completion risk
 
 Before opening or updating a pull request, fetch current `origin/main` and
 verify whether the branch is mergeable against current `main`. Update or rebase

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -14,6 +14,8 @@ The packet should include:
   orchestration/prompt-authoring
 - Source evidence: issue, PR, evidence note, docs, or review input that shaped
   the work
+- Coordination links: GitHub issue IDs, planning ticket IDs such as Linear IDs,
+  and expected PR linkage when relevant
 - Validation: what was run and what the results were
 - Risks: remaining concerns, edge cases, follow-up work, or any important gap between mocked or contract-level validation and real-world validation
 - Recommendation: `ready to merge`, `needs decision`, or `blocked`
@@ -134,6 +136,9 @@ During review:
 - confirm no unrelated changes are included
 - confirm the diff aligns with the intended arc
 - confirm issue linkage (if present) is accurate
+- confirm planning-ticket linkage (if present) is accurate and does not replace
+  GitHub as the repository closure source of truth unless repo-local guidance
+  says otherwise
 
 Quick check:
 
@@ -146,3 +151,7 @@ Before merge:
 
 - the PR diff must contain only the intended arc
 - issue-driven PRs must include `Closes #[issue number]`
+- when a planning ticket such as Linear is linked, the PR should reference it
+  for coordination, and post-merge notes should say whether planning status
+  needs to remain open or can be marked complete after GitHub closure is
+  confirmed

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -281,6 +281,10 @@ Codex should pause and ask for human input when:
   and local validation; finish the delivery path by using a focused branch,
   staging only the relevant changes, creating a clear commit, pushing, and
   opening or updating the PR against the intended base branch, usually `main`
+- when the task provides GitHub issue IDs and planning-ticket IDs such as
+  Linear IDs, include both in the PR body; use GitHub closing keywords for repo
+  issue closure and treat planning-ticket status as coordination state unless
+  repo-local guidance says otherwise
 - when reporting completion for implementation tasks, include the PR link,
   files changed, and validation results
 - for exploration, design, audit, or review-only tasks, do not force a PR when


### PR DESCRIPTION
## Summary
- Add canonical lifecycle guidance for GitHub issue, planning-ticket, PR, and completion-state coordination.
- Surface coordination IDs and post-merge notes in implementation prompts, review packets, and Codex PR expectations.
- Keep PR readiness tied to implementation state rather than planning-ticket status unless real coordination risk remains.

## Placement rationale
- Feature lifecycle owns the canonical source-of-truth and closure behavior because it defines repo change completion.
- Repo readiness gets only the PR-readiness consequence.
- Prompts and review packets get lightweight fields so agents carry GitHub and planning IDs without making Linear mandatory.

## Deferred complexity
- No required Linear workflow, status taxonomy, automation, labels, or sync protocol was added.
- Repo-local guidance can still override the default when a repository uses a different system of record.

## Validation
- make check