### PR TITLE
Clarify noncanonical runtime references

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -229,6 +229,9 @@ required.
 
 The detailed runtime note lives in
 `ai-workflow-incubator/runtime-artifacts/codex-local-policy/sandbox-writable-roots.md`.
+That runtime artifact is operational reference material for this adapter. It is
+not canonical reusable policy unless the guidance is explicitly promoted into
+the playbook.
 
 ## Autonomous Lane
 


### PR DESCRIPTION
## Summary

- Clarifies that the linked runtime artifact is operational reference material for the Codex adapter.
- States that the runtime artifact is not canonical reusable policy unless promoted into the playbook.

## Issue / Planning

- Closes #165
- Linear: CAK-8

## Validation

- make check

## Risks

- Docs-only change scoped to docs/tool-adapters/codex.md.