### PR TITLE
Clarify orchestration prompt authority context

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -785,10 +785,10 @@ Working directory:
 Repository:
 [repository]
 
-Canonical sources:
-- Shared workflow policy: [canonical_source]
+Required context:
+- Canonical reusable workflow policy: [canonical_source]
 - Repo-local execution guidance: [repo-local AGENTS.md or equivalent]
-- Source evidence: [source_evidence]
+- Reference evidence: [source_evidence]
 
 Required startup:
 1. Read the shared playbook startup guidance first.


### PR DESCRIPTION
## Summary
- Replace the orchestration handoff template heading "Canonical sources" with "Required context".
- Clarify that shared workflow policy is canonical while repo-local guidance and source evidence are contextual/reference inputs.

## Validation
- make check

Closes #164
Linear: CAK-6