### PR TITLE
Tighten AGENTS worktree and validation wording

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,10 @@ Repo-local rules take precedence only for repo-specific behavior.
 ## Local Execution
 
 - Run commands from this repository working directory by default.
-- Keep temporary workflow state repo-local, for example `.worktrees/`.
+- For implementation changes, use one repository, one branch, one dedicated
+  repo-local worktree under `.worktrees/`, and one pull request per change; see
+  `docs/repo-readiness.md#pr-readiness`.
+- Keep temporary workflow state repo-local.
 - Follow the command-form preflight rule in `docs/repo-readiness.md`: use direct
   `git ...`, `gh ...`, `make ...`, `python ...`, repo-local scripts, and tool
   commands for ordinary repository operations.
@@ -44,12 +47,15 @@ Repo-local rules take precedence only for repo-specific behavior.
 
 - Use `make check` as the canonical local validation entrypoint.
 - Run `make check` before opening or updating a PR.
-- `make check` runs Markdown lint and scanner unit tests.
+- `make check` runs Markdown lint, scanner unit tests, and generated dist
+  artifact drift checks.
 - Treat direct validation tool calls as implementation details of the Makefile
   target.
-- Authoritative-source scanning is advisory and non-blocking unless a caller
-  configures that workflow to be stricter.
-- CI remains the enforcing authority if local tooling is unavailable.
+- `make authoritative-source-check` runs advisory authoritative-source scanning;
+  it is separate from `make check` and non-blocking unless a caller configures
+  that workflow to be stricter.
+- CI is the enforcement layer for required remote checks and for checks that
+  local tooling cannot run.
 
 ## Branches
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -141,6 +141,14 @@ Open a pull request as draft when any of the following are true:
 Docs-only changes should default to ready for review when canonical validation
 passes and the diff is isolated.
 
+Implementation agents may open or update ready-for-review pull requests by
+default when repository guidance calls for PR delivery. Ready-for-review status
+does not authorize merge. Do not merge pull requests or enable auto-merge
+unless the human explicitly instructs that action for the specific pull request
+or workflow step. Sequential workflows that depend on merges must pause for
+explicit human confirmation before merge and before continuing to downstream
+steps.
+
 When working in a multi-repo workspace, treat each repository as an independent
 unit of change. Even if multiple repositories are visible, commits, branches,
 worktrees, and PRs must be created and managed per repository. Do not create


### PR DESCRIPTION
## Summary

- Tighten the repo-local AGENTS.md worktree mandate and link it to canonical PR readiness guidance.
- Correct the AGENTS.md description of make check and separate advisory authoritative-source scanning.
- Clarify in the canonical PR readiness section that ready-for-review PRs do not authorize merge or auto-merge, and sequential workflows must pause for explicit human confirmation before merge-dependent downstream work.

## Recent merge review

- Reviewed recently merged PRs #180, #181, #182, #183, and #184 for wording overlap.
- #181 added adjacent planning-ticket readiness language in docs/repo-readiness.md; this PR extends the same readiness boundary without conflicting with it.
- No wording conflicts found with the recent Codex adapter, orchestration prompt, runtime-reference, or dist-check changes.

## Follow-up issues

- No additional follow-up issues appear warranted from this scope.

## Validation

- make check
- Generated dist artifacts were not present, so no regeneration was required.

Closes #166
Closes #167
Closes #168