### PR TITLE
Consolidate duplicated workflow guidance

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -168,27 +168,18 @@ made it. AI-agent branches should use concise, non-tool-branded names such as
 broad tool-name prefixes such as `codex/`, `claude/`, or `copilot/` should be
 avoided unless a repository intentionally requires them.
 
-Every implementation change must happen in a dedicated Git worktree: one
-repository, one branch, one worktree, and one PR per change. Keep the main
-checkout clean and on `main`, fetch before creating task worktrees so
-`origin/main` is current, create one worktree per issue or task from that
-current `origin/main`, and do the issue work only inside its worktree. The only
-exceptions are read-only inspection or explicit human instruction not to modify
-files.
+Use the canonical implementation-isolation rule in
+[`repo-readiness.md`](repo-readiness.md#pr-readiness): one repository, one
+branch, one dedicated repo-local worktree, and one PR per change. Keep the main
+checkout clean, fetch before creating task worktrees so `origin/main` is
+current, and do issue work only inside the task worktree unless the work is
+read-only or the human explicitly says not to modify files.
 
-Before starting a same-repo worktree run, inspect existing worktree metadata and
-clear stale entries so an old attempt does not distort the new setup. Reuse an
-existing same-repo worktree only when it is clearly the same active issue, PR,
-or arc and its state is still clean and intelligible; otherwise recreate from
-current `origin/main`, especially when the worktree belongs to a different arc,
-the state is stale or unclear, or cleanup and recovery would be more confusing
-than starting fresh. Bias toward clarity over clever reuse.
-
-After merge, cleanup succeeds when the experiment or task worktrees created for
-that run are removed or clearly accounted for. Do not treat unrelated
-pre-existing worktrees as cleanup failures. If removal is blocked or deferred,
-report that clearly, avoid deleting unrelated worktrees, and leave the repo in
-a known, intelligible state.
+For Codex-specific worktree creation, reuse, cleanup, parallel-batch handling,
+and blocked cleanup reporting, follow
+[`tool-adapters/codex.md`](tool-adapters/codex.md#workspace-isolation). For
+other executors, follow the matching adapter when one documents stricter
+worktree handling.
 
 The expected pattern is:
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -197,10 +197,10 @@ External State Verification:
 - Run commands directly from inside the target repository worktree and follow
   the command-form rule in `docs/repo-readiness.md`; do not wrap ordinary repo
   commands in `zsh`, `bash`, `sh`, or equivalent shell forms.
-- For implementation changes, use a dedicated repo-local git worktree: one
-  repository, one branch, one worktree, and one PR per change. Run commands
-  from inside that target worktree and keep temporary or scratch state
-  repo-local.
+- For implementation changes, follow the dedicated worktree rule in
+  `docs/repo-readiness.md#pr-readiness`: one repository, one branch, one
+  dedicated repo-local worktree, and one PR per change. Run commands from
+  inside that target worktree and keep temporary or scratch state repo-local.
 - The only worktree exceptions are read-only inspection or explicit human
   instruction not to modify files.
 - Follow the direct PR inspection rule in `docs/review-packet.md` when a task
@@ -820,10 +820,10 @@ Scope:
 
 Constraints:
 - Keep changes minimal, scoped, and structurally local.
-- Use a dedicated repo-local git worktree for implementation changes: one
-  repository, one branch, one worktree, and one PR per change. Run commands
-  from inside the target worktree and keep temporary or scratch state
-  repo-local.
+- Follow the dedicated worktree rule in `docs/repo-readiness.md#pr-readiness`
+  for implementation changes: one repository, one branch, one dedicated
+  repo-local worktree, and one PR per change. Run commands from inside the
+  target worktree and keep temporary or scratch state repo-local.
 - Do not include unrelated cleanup.
 - Do not rely on noncanonical staging, runtime, generated, or local instruction
   surfaces as policy unless the rule has been promoted into the canonical
@@ -898,10 +898,10 @@ Delivery:
 - Follow the branch, PR readiness, and workspace rules in
   `docs/feature-lifecycle.md`, `docs/repo-readiness.md`, and
   `docs/tool-adapters/codex.md`.
-- Use a dedicated repo-local git worktree for implementation changes: one
-  repository, one branch, one worktree, and one PR per change. Run commands
-  from inside the target worktree and keep temporary or scratch state
-  repo-local.
+- Follow the dedicated worktree rule in `docs/repo-readiness.md#pr-readiness`
+  for implementation changes: one repository, one branch, one dedicated
+  repo-local worktree, and one PR per change. Run commands from inside the
+  target worktree and keep temporary or scratch state repo-local.
 - Run ordinary `git`, `gh`, `make`, `python`, repo-local script, and tool
   commands directly from the target worktree; reserve shell wrapping for
   commands that genuinely require shell syntax.
@@ -952,17 +952,17 @@ Inputs:
 - Summary-only requested: [summary_only]
 
 Instructions:
-- When a PR link or PR number is available, you must use connector inspection
-  and must open the PR through the GitHub connector before giving any review,
-  approval, readiness, or merge recommendation.
+- Apply the canonical direct PR inspection rule in
+  `docs/review-packet.md#direct-pr-inspection`. When a PR link or PR number is
+  available, use connector inspection before giving any review, approval,
+  readiness, or merge recommendation.
 - Stay in review/audit mode. Do not implement changes while performing the PR
   review unless the human explicitly changes the task to implementation.
 - Local checkouts, `git diff`, and `gh` commands may be used as supplemental
   evidence for PR review, but they must not replace connector inspection.
-- Treat "open the PR" as read-only connector inspection, not opening the PR in
-  a browser and not submitting a GitHub review.
-- Treat "review this PR" as inspect the PR and provide feedback in chat, unless
-  the human explicitly asks to post the review to GitHub.
+- Treat "open the PR" as read-only connector inspection, and treat "review this
+  PR" as inspect the PR and provide feedback in chat unless the human
+  explicitly asks to post the review to GitHub.
 - Apply the single-operator review posture from `docs/repo-readiness.md` when
   the repository ecosystem is primarily operated by one maintainer with rapid
   iteration and straightforward rollback. Bias toward actionable
@@ -973,13 +973,11 @@ Instructions:
 - Treat user-provided summaries, pasted titles, local path snippets, and copied
   diff excerpts as navigation and context only, not review evidence, when a PR
   link or PR number is available.
-- You must inspect the actual PR metadata, title and body, changed files,
-  relevant diffs, comments and unresolved review discussion, CI and check
-  status, mergeability, and scope against the task or issue where those inputs
-  are available.
-- You must not mutate the PR: do not submit, approve, request changes, comment
-  on, label, merge, close, or otherwise change the PR unless the human
-  explicitly asks for that GitHub action.
+- Inspect the PR surface described in
+  `docs/review-packet.md#direct-pr-inspection`, including metadata, changed
+  files, review discussion, CI/check status, mergeability, and scope where
+  available.
+- Do not mutate the PR unless the human explicitly asks for that GitHub action.
 - If GitHub connector access is unavailable or declined and Summary-only
   requested is not `yes`, stop the PR review, state that connector access is
   unavailable, and provide only clearly caveated feedback from the information

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -52,12 +52,17 @@ change.
 
 ## Workspace Isolation
 
+The canonical implementation-isolation mandate lives in
+[`repo-readiness.md`](../repo-readiness.md#pr-readiness): one repository, one
+branch, one dedicated repo-local worktree, and one PR per change. This section
+adds Codex-specific execution details for creating, reusing, coordinating, and
+cleaning up those worktrees.
+
 - read-only exploration, audit, or review work may use the active checkout when
   no repo changes are required
-- for repo-changing implementation work, always use `git worktree` from the
-  target repository and place every repo-changing worktree under
-  `<repo>/.worktrees/`; do not create sibling repo directories, sibling
-  worktree directories, or ad hoc full-copy repositories under the project root
+- place every repo-changing Codex worktree under `<repo>/.worktrees/`; do not
+  create sibling repo directories, sibling worktree directories, or ad hoc
+  full-copy repositories under the project root
 - before creating or reusing a repo-changing worktree, run `git worktree list`,
   select a repo-local `.worktrees/...` path, and report that selected path in
   setup or delivery notes
@@ -141,25 +146,12 @@ change.
   `bash -lc 'make check'`; use `gh pr view 145`, not
   `sh -c 'gh pr view 145'`
 - when the human posts a GitHub PR link, provides a PR number, or asks to
-  review, check, assess, approve, or comment on a PR, Codex must use connector
-  inspection and must open the PR through the GitHub connector before giving
-  review feedback
-- local checkouts, `git diff`, and `gh` commands may be used as supplemental
-  evidence for PR review, but they must not replace connector inspection
-- treat "open the PR" as read-only connector inspection, not opening the PR in
-  a browser and not submitting a GitHub review
-- treat "review this PR" as inspect the PR and provide feedback in chat, unless
-  the human explicitly asks to post the review to GitHub
-- Codex must inspect the actual PR metadata, title and body, changed files,
-  relevant diffs, comments and unresolved review discussion, CI and check
-  status, mergeability, and scope against the task or issue where those inputs
-  are available
-- treat user-provided PR summaries, pasted titles, local path snippets, and
-  copied diff excerpts as navigation and context only, not review evidence,
-  when a PR link or PR number is available
-- Codex must not mutate the PR: do not submit, approve, request changes,
-  comment on, label, merge, close, or otherwise change the PR unless the human
-  explicitly asks for that GitHub action
+  review, check, assess, approve, or comment on a PR, Codex must follow the
+  canonical connector-first PR review rule in
+  [`review-packet.md`](../review-packet.md#direct-pr-inspection)
+- after connector inspection, local checkouts, `git diff`, and `gh` commands
+  may be used as supplemental evidence for PR review, but they must not replace
+  connector inspection
 - if GitHub connector access is unavailable or declined for a PR review, stop
   the review, state that connector access is unavailable, and provide only
   clearly caveated feedback from the information already present


### PR DESCRIPTION
## Summary
- Consolidate duplicated implementation worktree guidance around the canonical `docs/repo-readiness.md#pr-readiness` rule.
- Replace repeated connector-first PR review prose with references to `docs/review-packet.md#direct-pr-inspection` while preserving supplemental `gh` guidance.
- Keep Codex-specific worktree and review details in the Codex adapter without restating the full canonical rules.

## Validation
- `make check`
- Dist regeneration was not required; no generated dist artifacts were present.

Closes #171
Closes #172