### PR TITLE
Docs: add repo awareness refresh procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/engineering-baseline.md`](docs/engineering-baseline.md): foundational engineering expectations, including validation, source authority, review, merge authority, and ready-for-review defaults
 - [`docs/authoritative-source-check.md`](docs/authoritative-source-check.md): advisory authoritative-source scanner adoption, domain classification, source justifications, and reusable workflow pinning
 - [`docs/repo-readiness.md`](docs/repo-readiness.md): interaction-mode selection, repository workflow expectations, validation taxonomy, and `AGENTS.md` responsibilities
+- [`docs/repo-awareness-onboarding-refresh.md`](docs/repo-awareness-onboarding-refresh.md): repository discovery, inventory propagation, onboarding, and governance refresh procedure
 - [`docs/core-model.md`](docs/core-model.md): high-level operating model
 - [`docs/feature-lifecycle.md`](docs/feature-lifecycle.md): delivery lifecycle, branch behavior, and PR completion expectations
 - [`docs/alignment-checkpoints.md`](docs/alignment-checkpoints.md): pause points and branch/PR rules

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -53,6 +53,11 @@ execution paths.
 - Automation prompts should delegate reusable safety predicates to owning tools
   when such tools exist, and should not duplicate full implementation logic in
   prompt text.
+- When repository additions, removals, renames, archived state, visibility, or
+  coverage expectations change, refresh automation scope through the
+  repo-awareness and onboarding procedure in
+  [`repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md)
+  instead of editing prompt allowlists in isolation.
 - Skipped work should be reported with reasons, not hidden as a clean pass.
 - Automations must not replace repo validation, pull request review, or human
   approval gates.

--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -150,7 +150,11 @@ Keep this lightweight. Registration means inventories, audits, and context
 systems can classify the repo correctly. It does not imply mature automation
 support, operational ownership, or service guarantees. Distinguish
 intentionally excluded repositories from accidentally invisible ones, then
-update only the systems that should know about the repo.
+update only the systems that should know about the repo. When bootstrap reaches
+this point, use the repo-awareness and onboarding refresh procedure in
+[`repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md)
+to keep inventory propagation separate from governance checks and manual
+org-admin follow-up.
 
 ## Reuse
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -15,6 +15,7 @@ tooling.
 ## Quick Navigation
 
 - [Context Refresh Primitive](#context-refresh-primitive)
+- [Repo Awareness And Onboarding Refresh](#repo-awareness-and-onboarding-refresh)
 - [Filesystem-Scoped Audit Boundaries](#filesystem-scoped-audit-boundaries)
 - [Prompt Output Contract](#prompt-output-contract)
 - [Codex Task Prompt Format](#codex-task-prompt-format)
@@ -35,6 +36,23 @@ Canonical guidance for the verified org context refresh pattern lives in
 [`docs/context-refresh.md`](context-refresh.md). Use that page for when to run
 it, how to generate the repository orientation snapshot, and how to interpret
 blocked, unavailable, or stale output.
+
+## Repo Awareness And Onboarding Refresh
+
+Canonical guidance for repository inventory and governance refresh work lives in
+[`docs/repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md).
+Use that page to distinguish discovery and inventory refresh from onboarding
+and governance compliance.
+
+Short prompt:
+
+```text
+Run the repo-awareness and onboarding refresh for [repo names].
+```
+
+The receiving agent should report discovery/inventory changes separately from
+governance checks, repo-local PRs, automation or enforcement updates, and manual
+org-admin follow-ups.
 
 ## Filesystem-Scoped Audit Boundaries
 

--- a/docs/repo-awareness-onboarding-refresh.md
+++ b/docs/repo-awareness-onboarding-refresh.md
@@ -1,0 +1,171 @@
+# Repo Awareness And Onboarding Refresh
+
+## Purpose
+
+Use this procedure when repositories are added, removed, renamed, archived, or
+meaningfully reclassified in the `ctrl-alt-keith` workspace. The goal is to
+keep repository awareness current without turning every future prompt into a
+bespoke inventory and governance exercise.
+
+Future prompts can say:
+
+```text
+Run the repo-awareness and onboarding refresh for [repo names].
+```
+
+That prompt means two related but separate checks:
+
+- repo discovery and inventory refresh
+- repo onboarding and governance compliance
+
+Keep the distinction visible in reports, issues, pull requests, and follow-up
+lists.
+
+## Source Boundaries
+
+Repository awareness is layered. Do not collapse these sources into one
+document or one generated artifact.
+
+- GitHub organization state owns whether a repository exists, its visibility,
+  archived state, default branch, topics, description, settings, branch
+  protection, security features, installed apps, and other hosted metadata.
+- Maintained workspace manifests, such as `config/workspace-repos.txt`, own
+  the explicit repository set used by generated playbook context artifacts.
+- Repo-local files own repository execution truth: `AGENTS.md`, `README.md`,
+  Makefile targets, CI workflow files, CODEOWNERS, dependency config, tests,
+  and docs.
+- Automation configuration owns active schedules, runtime prompts, execution
+  paths, allowlists, and skip conditions for recurring jobs.
+- Org-admin settings own controls that cannot be changed safely or completely
+  from repository files, such as branch protection rules, required status check
+  registration, repository visibility, secret scanning, push protection,
+  Dependabot enablement, and app permissions.
+- The playbook owns reusable procedure and source-of-truth layering. It should
+  not duplicate volatile repository inventories except where a maintained
+  manifest or reference inventory is already intentionally part of the repo.
+- `ai-workflow-incubator` may stage operational checklists, examples, prompt
+  drafts, and evidence. Incubator material is noncanonical until a separate
+  promotion task moves a durable rule into the playbook.
+
+## Discovery And Inventory Refresh
+
+Repo discovery asks: "Which repositories should this workflow know about?"
+
+Use it for:
+
+- new repositories
+- renamed repositories
+- archived or deleted repositories
+- visibility changes that affect generated public or private artifacts
+- repository role changes that affect workspace context, automation coverage,
+  or enforcement scope
+
+Discovery should reconcile, not guess:
+
+1. Enumerate the relevant GitHub organization repositories or inspect the named
+   repositories directly.
+2. Compare live org state with explicit workspace manifests that intentionally
+   feed generated context, such as `config/workspace-repos.txt`.
+3. Compare local checkout state only after the explicit sources are known. Do
+   not treat the filesystem as authoritative workspace scope.
+4. Classify each repository as included, intentionally excluded, inaccessible,
+   archived, local-only, or needing human decision.
+5. Update only the maintained inventory sources that are supposed to know about
+   the repository.
+
+Avoid hard-coded repo lists in canonical prose. When an inventory must be
+maintained, keep it in the owning manifest, runtime config, or reference
+inventory and identify that owner explicitly.
+
+## Onboarding And Governance Compliance
+
+Onboarding asks: "Is each repository ready to participate safely in the
+workspace?"
+
+Run onboarding and governance checks for newly visible repositories and for
+repositories whose role, visibility, risk level, automation coverage, or default
+branch protection expectations changed.
+
+Check at least these surfaces:
+
+- repo-local startup and readiness: `AGENTS.md`, README orientation,
+  repo-local `docs/start-here.md` when used, `make check`, `make help` when the
+  Makefile has multiple useful targets, validation documentation, and local
+  workflow artifact hygiene
+- branch and review controls: default branch, pull-request flow, branch
+  protection expectations, required review posture, direct-push restrictions,
+  auto-merge policy, and whether ready-for-review PR defaults still make sense
+- required CI and status checks: hosted checks that should be required, checks
+  that are intentionally advisory, and checks that remain local-only
+- ownership and review routing: CODEOWNERS expectations, responsible maintainers
+  or teams, and repo-local escalation notes where applicable
+- Actions and automation policy: default token permissions, workflow write
+  permissions, third-party action review or pinning expectations, automation
+  schedules, automation allowlists, and skip conditions
+- security posture: visibility, secret scanning, push protection, dependency
+  alerts, Dependabot or equivalent dependency-update automation, private
+  vulnerability reporting, security advisories, and repository secret scope
+- metadata: repository description, topics, homepage/profile links, archived
+  state, default branch, and public/private/internal visibility
+- enforcement integration: advisory scanner coverage, drift config, reusable
+  workflow adoption, org scan inclusion, and intentionally excluded surfaces
+
+When a setting cannot be represented in repo files or changed from the current
+execution context, record it as a manual or org-admin follow-up. Do not pretend a
+docs PR enforced a hosted setting.
+
+## Propagation Targets
+
+A repo-awareness refresh should inspect these target families and update only
+the owning source when a change is needed:
+
+- Playbook references: canonical docs, reusable prompts, generated-context
+  source manifests, and reference inventories that intentionally summarize
+  current automation scope.
+- Incubator and bootstrap assumptions: staging checklists, bootstrap templates,
+  examples, and evidence notes that need to mention the new workflow shape
+  without becoming canonical policy.
+- Automation allowlists and configuration: local Codex automations, enforcement
+  configs, branch-cleanup coverage, drift-scan scope, scheduled validation
+  targets, and org scanners.
+- Org-level metadata and settings: repository visibility, description, topics,
+  default branch, branch protection, required status checks, Actions policy,
+  auto-merge policy, security features, Dependabot, installed apps, and access.
+- Enforcement surfaces: advisory checks, reusable workflows, CODEOWNERS
+  expectations, scanner configuration, CI workflows, and report-only audit
+  scope.
+- Repo-local readiness: `AGENTS.md`, README, Makefile, validation commands,
+  docs, CI files, dependency metadata, and local security posture notes.
+
+## Public And Private Handling
+
+Public-safe artifacts must not expose private repository details unless the
+owning artifact is explicitly private and intended to carry that detail. Prefer
+role-based language in canonical docs. Use concrete private repository names
+only when operational paths, examples, provenance, or ecosystem topology need
+them and the artifact's visibility supports that disclosure.
+
+For public repositories, verify that docs, generated artifacts, descriptions,
+topics, examples, and validation notes do not leak local paths, private topology,
+credentials, account identifiers, private hostnames, or sensitive operational
+context.
+
+For private repositories, still keep durable guidance portable and reviewable.
+Private visibility is not permission to mix source-of-truth layers or commit
+secrets.
+
+## Completion Report
+
+Report completion by lane:
+
+- discovery and inventory changes made
+- onboarding and governance checks completed
+- repo-local changes and pull requests opened
+- automation or enforcement changes and pull requests opened
+- manual or org-admin follow-ups that remain outside repo-local enforcement
+- validation performed, usually `make check` in each changed repository
+- inaccessible repositories, blocked settings, or intentionally excluded scope
+
+If no change is needed for a target, say why. If a repository is intentionally
+excluded from a manifest, automation, or enforcement surface, record that as an
+explicit decision rather than leaving it indistinguishable from an omission.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -200,6 +200,12 @@ Reconcile local workspace state against the canonical workspace inventory
 before cross-repo audits, `AGENTS.md` alignment, enforcement scans, or broad
 workflow updates.
 
+For repository additions, removals, role changes, or governance checks, use the
+repo-awareness and onboarding refresh procedure in
+[`repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md).
+That procedure keeps inventory refresh separate from onboarding and org-admin
+governance follow-up.
+
 ## Repo-Local Workflow State
 
 For implementation changes, run commands from inside the target repository's

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -11,6 +11,8 @@
 - `docs/authoritative-source-check.md` -> advisory source scanner adoption and
   reusable workflow operations
 - `docs/repo-readiness.md` -> repository workflow expectations
+- `docs/repo-awareness-onboarding-refresh.md` -> repository inventory and
+  governance refresh procedure
 - `docs/tool-adapters/codex.md` -> required adapter guidance for Codex
   executions; mandatory startup material for Codex runs, not optional
   deep-reference material


### PR DESCRIPTION
## Summary

- Add canonical repo-awareness and onboarding refresh guidance that separates discovery/inventory refresh from governance compliance.
- Define source-of-truth layering for org metadata, workspace manifests, repo-local readiness, automation config, org-admin settings, enforcement, and incubator staging.
- Link the procedure from startup, readiness, prompts, bootstrap, automation, and the README map.

## Validation

- `make check`

## Notes

Hosted protections and settings that cannot be enforced from repo files are documented as manual or org-admin follow-up items.