### PR TITLE
docs: clarify bounded multi-phase hardening

### DIFF
--- a/docs/knowledge-ingestion-patterns.md
+++ b/docs/knowledge-ingestion-patterns.md
@@ -142,14 +142,16 @@ metadata, no-op safety fixtures, non-regression coverage, and observability or
 debugging loops. The goal is to make the source behavior explainable before a
 review repository has to spend human attention on it.
 
-Source-shape hardening can be a bounded multi-phase implementation task. Keep
-the phases together when they are one diagnostic-to-correction arc: detect the
-failure shape, preserve the metadata or fixture evidence, implement the bounded
+The bounded multi-phase hardening rule in
+[`repo-readiness.md`](repo-readiness.md#solo-operator-iteration-economics)
+applies here as one concrete case. For source-shape work, keep the phases
+together when they are one diagnostic-to-correction arc: detect the failure
+shape, preserve the metadata or fixture evidence, implement the bounded
 correction, and validate live and non-regression behavior. This keeps noisy
 iteration in the implementation repository until the source shape is
 review-ready.
 
-Split the work when the phases no longer share the same source shape,
+Split the work when the phases no longer share the same source type,
 validation story, or rollback boundary. A cohesive hardening PR should describe
 its phases clearly and should not include unrelated cleanup, new source
 families, crawler expansion, retention decisions, or broad redesign work.

--- a/docs/knowledge-ingestion-patterns.md
+++ b/docs/knowledge-ingestion-patterns.md
@@ -142,6 +142,18 @@ metadata, no-op safety fixtures, non-regression coverage, and observability or
 debugging loops. The goal is to make the source behavior explainable before a
 review repository has to spend human attention on it.
 
+Source-shape hardening can be a bounded multi-phase implementation task. Keep
+the phases together when they are one diagnostic-to-correction arc: detect the
+failure shape, preserve the metadata or fixture evidence, implement the bounded
+correction, and validate live and non-regression behavior. This keeps noisy
+iteration in the implementation repository until the source shape is
+review-ready.
+
+Split the work when the phases no longer share the same source shape,
+validation story, or rollback boundary. A cohesive hardening PR should describe
+its phases clearly and should not include unrelated cleanup, new source
+families, crawler expansion, retention decisions, or broad redesign work.
+
 Replay and review repositories should stay focused on milestone validation,
 retention review, promotion or no-promotion decisions, and durable provenance.
 They should not become the primary place where extraction heuristics, parser

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -439,43 +439,51 @@ For solo-operated workflows, choose the validation loop that answers the
 current question fastest without hiding real risk.
 
 Early integration-heavy validation is appropriate when the work is still
-proving workflow semantics, validating governance or retention boundaries, or
-establishing trust in a new pipeline. Full replays and cross-repo checks are
-useful while the question is whether the workflow behaves correctly end to end.
+proving workflow semantics, validating governance or trust boundaries, or
+establishing confidence in a new pipeline. Full environment checks,
+cross-system exercises, live smoke tests, and review environments are useful
+while the question is whether the workflow behaves correctly end to end.
 
-Once failures are mostly deterministic extraction, parsing, or normalization
-behavior, move the primary iteration loop into fast local regression fixtures.
-Use representative real-world examples as a regression corpus, keep those
-fixtures deterministic, and reserve integration replays for milestone checks,
+Once failures are mostly deterministic parsing, integration, normalization,
+state-transition, deployment, or automation behavior, move the primary
+iteration loop into fast local regression fixtures. Use representative
+real-world examples as a regression corpus where useful, keep those fixtures
+deterministic, and reserve full-environment validation for milestone checks,
 boundary checks, or confidence revalidation after meaningful changes.
 
-Replay repos validate usefulness; implementation repos absorb noisy iteration.
-Use replay or review repositories for milestone validation, retention review,
-promotion decisions, and durable provenance. Use the implementation repository
-for extraction cleanup, noisy-shape reproduction, fixture iteration, and
-observability or debugging loops.
+Review, replay, staging, or live-like environments validate usefulness and
+operational fit; implementation repositories absorb noisy iteration. Use those
+broader environments for milestone validation, governance or trust-boundary
+review, promotion decisions, and durable provenance. Use the implementation
+repository for deterministic reproduction, fixture iteration, bounded
+corrections, and observability or debugging loops.
 
 Bounded hardening may require multiple tightly coupled passes before opening a
 pull request. Keep those passes in one PR when each pass directly enables or
-validates the next, such as detecting an observed failure mode, adding metadata
-or fixtures for that shape, applying a bounded correction, then validating live
-and non-regression behavior.
+validates the next: detect an observed issue or failure mode, preserve evidence
+through tests, fixtures, logs, or metadata, apply a bounded correction, then
+validate non-regression and live behavior where appropriate.
 
-One PR is appropriate when the phases share one goal, one source shape, one
-validation story, and one rollback unit. Split the work when phases have
-independent goals, different risk profiles, unrelated files, or different
-validation or rollback boundaries.
+This pattern applies across implementation domains: parsers and extractors,
+API integrations, schema migrations, deployment workflows, infrastructure
+automation, CI/CD hardening, observability and debugging loops,
+synchronization or reconciliation systems, and state repair or recovery logic.
+
+One PR is appropriate when the phases share one goal, one affected behavior or
+boundary, one validation story, and one rollback unit. Split the work when
+phases have independent goals, different risk profiles, unrelated files, or
+different validation or rollback boundaries.
 
 In solo-operator workflows, prefer completing the coherent task before opening
 the PR when it is safe to do so. Avoid stopping after a diagnostic-only partial
 implementation when the safe bounded correction is part of the same task and
 can be validated locally.
 
-Pause and confirm before crawler-like behavior, broad external fetch or
-discovery, destructive changes, retention or promotion semantics, ambiguous
-target selection, or high-blast-radius architectural redesign. Multi-pass
-hardening is not permission for grab-bag PRs, unrelated cleanup, repo-hopping,
-or hidden scope expansion.
+Pause and confirm before external discovery or crawling, destructive behavior,
+irreversible state changes, ambiguous automation decisions,
+security/trust-boundary expansion, or high-blast-radius architectural change.
+Multi-pass hardening is not permission for grab-bag PRs, unrelated cleanup,
+repo-hopping, or hidden scope expansion.
 
 Intermediate passes should leave evidence through fixtures or tests where
 useful. The final PR should include the relevant docs, tests, live checks, and
@@ -483,32 +491,34 @@ non-regression evidence, and should explain the phases and why they form one
 cohesive task.
 
 For ingestion, extraction, ETL, scraping, OCR, export/import, and normalization
-systems, apply the source-shape hardening lifecycle in
-[`knowledge-ingestion-patterns.md`](knowledge-ingestion-patterns.md#source-shape-hardening-lifecycle).
-New source types should become diagnostic, review-ready, and
-promotion-capable inside the implementation repository before they become
-routine replay inputs.
+systems, the source-shape hardening lifecycle in
+[`knowledge-ingestion-patterns.md`](knowledge-ingestion-patterns.md#source-shape-hardening-lifecycle)
+is one application of this broader rule. New source types should become
+diagnostic, review-ready, and promotion-capable inside the implementation
+repository before they become routine replay inputs.
 
-If replay validation repeatedly produces "still noisy", "still no-promotion",
-or unchanged review outcomes, stop accumulating low-yield evidence PRs. Move
-the failing source shape into the implementation repository, make it a
-deterministic fixture or regression case there, and iterate until the output
-crosses a reviewability threshold. Return to replay validation for milestone
-verification, promotion review, or retained-content decisions.
+If broader validation repeatedly produces unchanged review outcomes, stop
+accumulating low-yield evidence PRs. Move the failing behavior into the
+implementation repository, make it a deterministic fixture or regression case
+there, and iterate until the output crosses the relevant reviewability,
+operability, or safety threshold. Return to broader validation for milestone
+verification, promotion review, live confidence checks, or retained-content
+decisions.
 
-Warning signs that integration validation has become a rabbit hole:
+Warning signs that broad validation has become a rabbit hole:
 
-- repeated cross-repo replay loops with little workflow learning
+- repeated full-environment loops with little workflow learning
 - high-latency validation cycles that slow each small correction
-- deterministic extraction bugs discovered only after full integration runs
-- replay records quietly becoming the de facto regression suite
-- replay evidence PRs adding provenance without changing the retention or
-  promotion decision
+- deterministic bugs discovered only after broad integration runs
+- review, replay, or live-check artifacts quietly becoming the de facto
+  regression suite
+- evidence PRs adding provenance without changing the review, release,
+  retention, or promotion decision
 
-The preferred steady state is fast local fixtures for day-to-day correction,
-a representative real-world regression corpus for coverage, explicit milestone
-checkpoints, and occasional integration revalidation to confirm the local loop
-still reflects end-to-end behavior.
+The preferred steady state is fast local fixtures for day-to-day correction, a
+representative real-world regression corpus where useful, explicit milestone
+checkpoints, and occasional broad revalidation to confirm the local loop still
+reflects end-to-end behavior.
 
 ### Minimum `make check` Coverage By Repo Type
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -455,6 +455,33 @@ promotion decisions, and durable provenance. Use the implementation repository
 for extraction cleanup, noisy-shape reproduction, fixture iteration, and
 observability or debugging loops.
 
+Bounded hardening may require multiple tightly coupled passes before opening a
+pull request. Keep those passes in one PR when each pass directly enables or
+validates the next, such as detecting an observed failure mode, adding metadata
+or fixtures for that shape, applying a bounded correction, then validating live
+and non-regression behavior.
+
+One PR is appropriate when the phases share one goal, one source shape, one
+validation story, and one rollback unit. Split the work when phases have
+independent goals, different risk profiles, unrelated files, or different
+validation or rollback boundaries.
+
+In solo-operator workflows, prefer completing the coherent task before opening
+the PR when it is safe to do so. Avoid stopping after a diagnostic-only partial
+implementation when the safe bounded correction is part of the same task and
+can be validated locally.
+
+Pause and confirm before crawler-like behavior, broad external fetch or
+discovery, destructive changes, retention or promotion semantics, ambiguous
+target selection, or high-blast-radius architectural redesign. Multi-pass
+hardening is not permission for grab-bag PRs, unrelated cleanup, repo-hopping,
+or hidden scope expansion.
+
+Intermediate passes should leave evidence through fixtures or tests where
+useful. The final PR should include the relevant docs, tests, live checks, and
+non-regression evidence, and should explain the phases and why they form one
+cohesive task.
+
 For ingestion, extraction, ETL, scraping, OCR, export/import, and normalization
 systems, apply the source-shape hardening lifecycle in
 [`knowledge-ingestion-patterns.md`](knowledge-ingestion-patterns.md#source-shape-hardening-lifecycle).


### PR DESCRIPTION
## Summary
- Generalize Solo-Operator Iteration Economics guidance for bounded multi-phase hardening across implementation domains.
- Preserve the key pattern: detect an issue, preserve evidence through tests/fixtures/logs/metadata, apply a bounded correction, validate non-regression/live behavior, and deliver one coherent rollback unit.
- Reframe source-shape lifecycle guidance as one ingestion-specific application of the broader principle.

## Why This Stays Bounded
This documents one cohesive task pattern: one goal, one affected behavior or boundary, one validation story, and one rollback unit. It also says to split when goals, risk profiles, files, validation, or rollback boundaries diverge, and it calls out pause points for external discovery/crawling, destructive behavior, irreversible state changes, ambiguous automation decisions, trust-boundary expansion, and broad architectural change.

## Validation
- git diff --check
- make check