### PR TITLE
Trim duplicated playbook guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ These generated artifacts are complementary:
 - `context-refresh` captures durable repo orientation state.
 - `github-context` rehydrates GitHub connector repo scope.
 
+Repository code, docs, issues, pull requests, and repo-local `AGENTS.md` remain
+source-of-truth surfaces.
+
 Generated artifacts are convenience snapshots; regenerate them instead of
 editing them directly.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ Tool-specific behavior belongs in documented adapter docs under [`docs/tool-adap
 
 ## Repo-Local AGENTS.md
 
-The playbook is the canonical home for reusable workflow policy. A repo-local `AGENTS.md` is the execution layer for that repository, layered on top of the playbook and authoritative only for repo-specific validation, commands, and PR expectations. Playbook changes and `AGENTS.md` edits are separate work types; update `AGENTS.md` only with explicit authorization or when that update is the task's purpose.
+The playbook is the canonical home for reusable workflow policy. Repo-local
+`AGENTS.md` files provide thin repository execution guidance; see
+[`docs/start-here.md`](docs/start-here.md#execution-model) and
+[`docs/repo-readiness.md`](docs/repo-readiness.md#agentsmd-responsibilities).
 
 Reusable pattern:
 
@@ -53,9 +56,14 @@ Reusable pattern:
 
 ## Workspace Bootstrap Bundle
 
-Run `make workspace-bootstrap` to generate `dist/workspace-bootstrap.md`, a noncanonical hydration bundle for fresh-thread and project-source context loading. Canonical guidance remains in the source docs and repo-local `AGENTS.md`; the generated bundle is only a convenience snapshot and should be regenerated instead of edited directly.
+Run `make workspace-bootstrap` to generate `dist/workspace-bootstrap.md`, a
+noncanonical hydration bundle for fresh-thread and project-source context
+loading.
 
-Run `make context-refresh` to generate `dist/context-refresh.md`, a noncanonical repository orientation brief for fresh-thread handoff and repo orientation refresh. Dynamic PR and issue state is intentionally omitted; inspect GitHub directly before acting.
+Run `make context-refresh` to generate `dist/context-refresh.md`, a
+noncanonical repository orientation brief for fresh-thread handoff and repo
+orientation refresh. Dynamic PR and issue state is intentionally omitted;
+inspect GitHub directly before acting.
 
 Run `make github-context` to generate `dist/github-context.md`, a paste-ready `@GitHub` repo list for connector rehydration in fresh threads. The artifact is noncanonical and generated from `config/workspace-repos.txt`.
 
@@ -65,7 +73,8 @@ These generated artifacts are complementary:
 - `context-refresh` captures durable repo orientation state.
 - `github-context` rehydrates GitHub connector repo scope.
 
-Repository code, issues, pull requests, docs, and repo-local `AGENTS.md` files remain the source of truth.
+Generated artifacts are convenience snapshots; regenerate them instead of
+editing them directly.
 
 ## Current Focus
 

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -23,15 +23,14 @@ execution paths.
 
 ## Guidance Layers
 
-- Canonical playbook guidance lives in this repository and defines reusable
-  cross-repo workflow expectations.
+- Follow the authority boundary in
+  [`start-here.md`](start-here.md#source-authority-map).
 - Workspace-level routing guidance may live in a local-only workspace
   `AGENTS.md`. It can describe multi-repository boundaries, scratch usage,
   command form, and how to enter target repositories, but it is noncanonical
   and must not define repository branch, commit, PR, or validation policy.
-- Repo-local execution guidance lives in each repository's `AGENTS.md` and
-  remains authoritative for that repository's validation path, file placement,
-  branch conventions, PR expectations, and repo-specific constraints.
+- Repo-local execution guidance belongs in each repository's `AGENTS.md`; see
+  [`repo-readiness.md`](repo-readiness.md#agentsmd-responsibilities).
 - Drift review should compare repo-local `AGENTS.md` files against the playbook
   and any relevant workspace-routing guidance, while comparing workspace-level
   routing guidance against reusable playbook expectations and observed

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -285,12 +285,6 @@ Before executing any shell-wrapped command, perform a command-form preflight:
 - if shell semantics are required, keep the wrapped command narrow enough that
   the operational intent remains inspectable
 
-Use a shell wrapper when the operation genuinely needs shell semantics, such as
-pipes, redirection, glob expansion, command chaining, shell builtins, inline
-environment assignment, compound conditionals, or other composition that the
-command cannot express directly. When shell semantics are needed, keep the
-wrapped command narrow enough that the operational intent remains inspectable.
-
 Examples:
 
 - incorrect: `zsh -lc 'git status'`
@@ -334,22 +328,12 @@ This document defines expectations, not exact GitHub settings.
 - branch or commit conventions that are specific to the repository
 - repo-specific constraints, boundaries, or file placement rules
 
-Reusable workflow rules belong in the playbook, not duplicated into each repository's `AGENTS.md`.
-
-Canonical playbook updates and `AGENTS.md` edits are separate work types:
-
-- Playbook guidance changes update reusable workflow policy in this repository.
-- `AGENTS.md` edits, including in `ai-workflow-playbook` itself, require
-  explicit user authorization or a task whose primary purpose is `AGENTS.md`
-  update, rollout, or enforcement.
-- Cross-repo `AGENTS.md` updates are rollout or enforcement work and should not
-  be inferred from a playbook docs change.
-- Global rollout and implementation changes must use one repository, one
-  branch, one dedicated worktree, and one pull request per target repository
-  unless a target repository's documented process says otherwise.
-- Reviews and delivery notes for workflow changes should state which category
-  the change belongs to: canonical playbook guidance only or explicitly
-  authorized `AGENTS.md` update/enforcement.
+Reusable workflow rules belong in the playbook, not duplicated into each
+repository's `AGENTS.md`. Canonical playbook updates and `AGENTS.md` edits are
+separate work types; do not infer repo-local guidance rollout from a playbook
+docs change. Reviews and delivery notes for workflow changes should state
+whether the change is canonical playbook guidance only or an explicitly
+authorized `AGENTS.md` update/enforcement task.
 
 ## Repository Categories
 
@@ -365,9 +349,9 @@ repositories for org profile content, community health files, templates,
 metadata, or GitHub-supported defaults.
 
 Org infrastructure repositories still follow the shared workflow rules where
-they apply: one repo, one branch, one dedicated worktree, one pull request;
-current `origin/main` as the base; purpose-based branch names; small scoped diffs; human-readable review
-summaries; no unrelated cleanup; and public artifact path hygiene.
+they apply, including PR readiness, implementation isolation, scoped diffs,
+human-readable review summaries, no unrelated cleanup, and public artifact path
+hygiene.
 
 Normal project-repository expectations may not apply until the repository grows:
 `make check`, tests, package, build, release, or implementation-specific file

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -24,13 +24,11 @@
 ## Execution Model
 
 - Use `ai-workflow-playbook` as the canonical source of reusable workflow rules.
-- Treat `AGENTS.md` as the repo-local execution layer.
-- Repo-local rules take precedence only for repo-specific behavior.
-- Treat canonical playbook changes and `AGENTS.md` edits as separate work
-  types. Updating the playbook does not implicitly authorize any `AGENTS.md`
-  edit, including in `ai-workflow-playbook` itself.
-- Edit `AGENTS.md` only with explicit user authorization or when the task's
-  primary purpose is `AGENTS.md` update, rollout, or enforcement.
+- Treat `AGENTS.md` as the repo-local execution layer; repo-local rules take
+  precedence only for repo-specific behavior.
+- Treat playbook changes and `AGENTS.md` edits as separate work types. Edit
+  `AGENTS.md` only with explicit authorization or when the task's primary
+  purpose is `AGENTS.md` update, rollout, or enforcement.
 - Before acting on repository or software work, determine the interaction mode
   using `docs/repo-readiness.md`: implementation, review/audit, or
   orchestration/prompt-authoring.
@@ -74,11 +72,7 @@ Before acting on repository or software work:
 
 ## Source Authority Map
 
-- `ai-workflow-playbook` is the canonical source for reusable workflow policy.
-- Repo-local `AGENTS.md` files are repo-local execution guidance layered on top
-  of the playbook.
-- `AGENTS.md` alignment is update, enforcement, or rollout work, not a side
-  effect of changing canonical playbook guidance.
+- The execution model above owns the playbook-vs-`AGENTS.md` boundary.
 - Incubation, staging, and evidence repositories, including
   `ai-workflow-incubator`, are noncanonical unless a durable rule is explicitly
   promoted into the playbook.
@@ -91,9 +85,9 @@ Before acting on repository or software work:
 
 - The private staging/incubation layer is for ideas and experiments.
 - It is not canonical and is not a direct path into playbook guidance.
-- Durable workflow guidance follows this order: idea -> notes staging ->
-  bounded repo issue or PR -> evidence-supported reusable lesson -> playbook
-  promotion -> notes cleanup.
+- Durable workflow guidance moves from staging to bounded repo work, then to an
+  evidence-supported playbook promotion and notes cleanup when it proves
+  reusable.
 - Treat repository code, tests, docs, reviews, and merged PRs as the evidence
   source for reusable lessons before promoting them into the playbook.
 - Canonical guidance should generally describe staging and incubation by role;
@@ -105,14 +99,6 @@ Before acting on repository or software work:
 - Prefer small, scoped changes.
 - Report whether a workflow change is canonical playbook guidance only or an
   explicitly authorized `AGENTS.md` update/enforcement task.
-- For global rollout and implementation changes, use one repository, one
-  branch, one dedicated worktree, and one pull request per target repository
-  unless that repository's documented process says otherwise.
-- In ctrl-alt-keith workflows, default ambiguous repository tasks to
-  review/audit or orchestration/prompt-authoring unless the human explicitly
-  asks for direct implementation.
-- Run commands directly from inside the target repository worktree; follow
-  `docs/repo-readiness.md` for command form and shell-wrapping rules.
-- Run repository validation through the repo's Makefile when it provides the
-  canonical entrypoint.
+- Follow `docs/repo-readiness.md` for implementation isolation, command form,
+  interaction mode, and validation rules.
 - Open PRs ready for review by default unless explicitly instructed otherwise.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -128,30 +128,16 @@ cleaning up those worktrees.
   cached context, summaries, or local branch state
 - apply the command-form guidance in
   [`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility):
-  keep normal repository operations in their structurally minimal form, and
-  reserve shell wrapping for operations that need shell semantics
+  keep normal repository operations in their structurally minimal form
 - prefer clear direct invocations for normal repository operations, such as
   `git status`, `git merge --ff-only origin/main`, `gh repo view`,
   `gh pr view`, `make check`, `python ...`, and repo-local scripts
-- for standard Git and GitHub CLI flows, use `git` and `gh` directly rather
-  than alternate APIs, helper scripts, connectors, or tool substitutions unless
-  the task requires a non-CLI capability or direct CLI access is blocked and
-  the fallback is reported
 - when the execution tool supports native argv arrays, prefer direct argv forms
   such as `["git", "status"]` or `["gh", "pr", "view", "145"]`
 - if the execution surface defaults to shell or login-shell behavior, disable
   that behavior for `git` and `gh` where supported, using options such as
   `shell=false`, `login=false`, `use_shell=false`, or the platform-native
   equivalent
-- do not use `zsh -lc`, `bash -lc`, `sh -c`, or equivalent wrapper forms for
-  ordinary repo commands
-- before executing a shell-wrapped command, perform a command-form preflight:
-  decide whether shell semantics are genuinely required; if not, rewrite the
-  operation into direct argv form before execution
-- treat pipes, redirects, glob expansion, command chaining, shell builtins,
-  inline environment assignment, and compound shell conditionals as examples of
-  shell semantics that can justify a wrapper when no direct command form is
-  sufficient
 - when a `git` or `gh` operation needs shell composition, keep the wrapped
   command narrow enough that the requested operation remains visible to local
   approval and review surfaces
@@ -327,20 +313,8 @@ When behavior or supported capability changes, quickly check the existing docs f
 
 ## CI Expectations
 
-- use the repository's canonical validation command, such as `make check`, when
-  one exists
-- when the canonical validation command exists and can run locally, run it
-  before opening or updating a PR; do not treat CI as a replacement for that
-  local step
-- do not introduce, invoke, or rely on alternate local validation tools unless
-  they are explicitly part of the repository-defined workflow
-- if a tool needed by the canonical command is missing locally, report that
-  limitation, do not substitute another parser, linter, or manual validation
-  path, and rely on required CI checks for enforcement of checks that cannot be
-  run locally
-- treat checks as CI-only only when the repository does not expose a local
-  canonical path for them or the local canonical path cannot run in the current
-  environment
+- follow the validation rules and check taxonomy in
+  [`repo-readiness.md`](../repo-readiness.md#validation)
 - do not infer merge or release gates from check names alone; use the
   repository's documented validation taxonomy and required CI status
 - report clearly when no local validation path exists


### PR DESCRIPTION
## Summary
- compress duplicated playbook-vs-AGENTS authority wording in startup, README, and automation guidance
- keep repo-readiness as the canonical home for command-form, implementation-isolation, AGENTS, and validation rules
- replace repeated Codex adapter validation and shell-preflight text with references to repo-readiness while preserving Codex-specific execution notes

## Validation
- make check

## Notes
- Source docs only; generated dist artifacts were regenerated and remained current.
- This is canonical playbook guidance only, not an AGENTS.md rollout.