### PR TITLE
Strengthen repo state verification gate

### DIFF
--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -107,6 +107,9 @@ Use this reusable gate whenever a mandatory trigger is present:
 - Result: mark the gate `verified`, `partial`, or `blocked`.
 - Unknowns: state anything required for the task that remains unverified.
 
+If direct verification did not happen, say exactly:
+`unknown → referenced repo state was not verified`.
+
 Acceptable authoritative sources depend on the claim:
 
 - Repository files, local `git` state, and checked-out refs are authoritative
@@ -154,8 +157,9 @@ When recovery is required, execute this sequence:
 
 Acknowledgment alone is not recovery. Explaining the violation is not
 remediation. Recovery must perform the missing retrieval or inspection, not
-only discuss that retrieval should have happened. Continuity remains blocked
-until the recovery gate is `verified`, `partial`, or `blocked`.
+only discuss that retrieval should have happened. When the missing step is
+available, do it before analyzing the workflow failure. Continuity remains
+blocked until the recovery gate is `verified`, `partial`, or `blocked`.
 
 Useful human recovery commands are short and imperative:
 
@@ -188,6 +192,9 @@ Watch for these observable failure patterns:
   retrieval but not performing the retrieval.
 - Explanation replacing remediation: describing the correct ordering instead
   of re-entering it.
+- Meta-analysis replacing action: recognizing a concrete operational request
+  but discussing the workflow issue instead of inspecting, reviewing, updating,
+  or generating the requested artifact.
 
 ## Enforceable Workflow Rules
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -33,15 +33,27 @@
   purpose is `AGENTS.md` update, rollout, or enforcement.
 - Before acting on repository or software work, determine the interaction mode
   using `docs/repo-readiness.md`: implementation, review/audit, or
-  orchestration/prompt-authoring.
+  orchestration/prompt-authoring. This applies before implementation, review,
+  audit, architecture analysis, workflow analysis, PR/issue/branch
+  recommendations, "what changed?", and "what should we do next?" responses.
 - Deterministic workflow triggers, operational invariants, and source-of-truth
   retrieval requirements execute before conversational interpretation,
   continuity, or summary-based reasoning.
+- When the human asks for a concrete operational action and the needed tools
+  and context are available, perform that action before discussing workflow
+  philosophy, intent analysis, or speculative improvements. Examples include
+  inspecting a repo or PR, generating the requested implementation prompt,
+  reviewing the actual PR, updating an open PR, or running validation.
 - Conversational coherence is subordinate to operational trigger handling:
   references to authoritative operational state, including pull requests,
   issues, repositories, runtime state, CI state, files, logs, and uploaded
   artifacts, require retrieval or revalidation before conversational
   continuation.
+- In fresh threads, assume no repository, pull request, branch, issue, or local
+  path state is verified until the referenced source is directly inspected.
+- Treat advisory summaries, generated snapshots, organization briefs, staged
+  notes, memory, and conversational context as aids for finding what to inspect,
+  not proof of current repository state.
 - Conversational fluency, prior thread context, summaries, inferred intent, and
   pasted descriptions must not suppress required retrieval, inspection, or
   validation steps.
@@ -49,12 +61,17 @@
   retrieve it before asking the human to restate, summarize, or paste it. Merely
   acknowledging missing state without performing available retrieval is not
   sufficient recovery.
+- If referenced repository state was not directly verified, state
+  `unknown → referenced repo state was not verified` before answering from that
+  state.
 - When a deterministic trigger applies, perform the required retrieval or
   inspection first, then continue the conversation from the inspected state. If
   the required source is unavailable, report that blocker instead of inferring
   the state from conversation.
 - Anti-pattern: a human references a PR, and the assistant continues
   philosophical or meta discussion instead of retrieving the PR state.
+- Anti-pattern: the assistant recognizes an operational request but explains
+  the workflow problem instead of performing the available action.
 - Anti-pattern: the assistant asks the human to paste retrievable PR, CI, file,
   log, or artifact state instead of inspecting the available source.
 - Use `docs/source-first-retrieval.md` for the reusable trigger
@@ -62,7 +79,9 @@
 
 ## Startup Contract
 
-Before acting on repository or software work:
+Before acting on repository or software work, including read-only analysis,
+review, audit, advisory, architecture/workflow analysis, PR/issue/branch
+recommendations, and "what changed?" or "what should we do next?" requests:
 
 1. Read `docs/start-here.md` first.
 2. Read the target repository's repo-local `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Make start-here explicitly apply to read-only repository analysis, review, audit, advisory, architecture/workflow analysis, PR/issue/branch recommendations, and what-changed/next requests.
- State that fresh threads have zero verified repo/PR/branch state until direct inspection.
- Add the exact source-first unknown marker for unverified referenced repo state.

## Validation
- make check
- git diff --check