### PR TITLE
Add recovery ordering experiment

### DIFF
--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -188,6 +188,26 @@ stale-state handling when it changes what the next action should trust. Preserve
 unknowns when retrieval did not happen. Do not add confidence scores, fixed
 tiers, required labels, templates, audit requirements, or governance process.
 
+## Recovery Ordering Experiment
+
+When source-first retrieval was missed and retrieval remains available,
+operational recovery should restore verified state before conversational repair.
+Perform the missed retrieval, verify the result, and resume the task from that
+state. Explain only remaining blockers, uncertainty, or corrections that still
+matter after inspection.
+
+Good:
+
+- "You're right. Retrieval should have happened first." Then inspect the source
+  and continue from direct evidence.
+- "Remote CI state was not revalidated." Then revalidate and continue the task.
+
+Bad:
+
+- apologizing or explaining before performing the available retrieval
+- continuing speculative discussion from stale or unverified state
+- describing why inspection mattered without doing the inspection
+
 ## Recovery Re-Entry
 
 Recovery is required when source-first ordering has already been missed. This


### PR DESCRIPTION
## Summary

- Add a compact recovery-ordering experiment to `docs/source-first-retrieval.md`.
- Clarify that when retrieval was missed and remains available, operational recovery should retrieve and verify before explanation or speculative continuation.
- Include small good/bad examples focused on missed retrieval, stale state, apology loops, and explanation-before-retrieval drift.

## Rationale

This is a recovery-ordering experiment, not a formal recovery framework, mode system, protocol, governance layer, or execution-state machine. The intent is to reduce explanation-before-retrieval drift by shaping normal recovery behavior toward verified state first, then only the explanation that still matters.

## Validation

- `git diff --check`
- `make check`