### PR TITLE
Document deferred consolidation lanes

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -135,24 +135,41 @@ weakening reviewability, validation, or merge safety.
 
 Before launching parallel work, classify each task by lane:
 
-- docs/governance
+- independent capability
+- governance
 - isolated code path
 - shared API/client behavior
 - mutation/safety-critical path
 - release/checking
+- deferred consolidation
 
 Do not parallelize changes that share mutation paths, release state, schema
 contracts, or fragile overlapping files unless the dependency is explicit and a
 clear merge order exists before work starts.
 
+Independent capability lanes and governance lanes may run in parallel when they
+are separated by file area, behavior surface, or risk surface. Consolidation or
+reconciliation lanes that depend on outputs from other lanes should be gated,
+not launched against moving branches.
+
 For every parallel batch, define the intended merge order up front. If the work
 is truly independent, say that merge order is flexible and why. When ordering
 does matter, prefer the order that reduces conflict and review risk:
 
-- docs/governance before dependent docs
+- governance before dependent docs
 - reusable infrastructure before repo adoption
 - shared client/API behavior before callers
 - safety/mutation changes after dependent semantics are clear
+- deferred consolidation after upstream PRs have merged
+
+Start deferred consolidation lanes only after the upstream PRs are merged,
+current `main` has been fetched, and the human explicitly confirms
+continuation. These lanes should reconcile vocabulary, docs, contracts,
+examples, or shared semantics from current `main` rather than chasing moving
+branches.
+
+This gating avoids semantic churn, avoidable rebases, and accidental behavior
+changes during parallel implementation.
 
 If two PRs overlap unexpectedly, pause and re-establish the order before merging:
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -15,6 +15,7 @@ tooling.
 ## Quick Navigation
 
 - [Codex Task Prompt Format](#codex-task-prompt-format)
+- [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Notes vs Playbook Alignment Audit](#notes-vs-playbook-alignment-audit)
 - [Orchestration Handoff Prompt](#orchestration-handoff-prompt)
 - [Implementation Delivery Footer](#implementation-delivery-footer)
@@ -134,6 +135,28 @@ Stop rules:
 - Stop and report if the repo context is mismatched, validation failure implies
   broader work than requested, or live external state cannot be verified where
   it is required.
+```
+
+## Parallel Batch Add-On
+
+Use this compact add-on when asking an implementation agent to coordinate a
+parallel batch. Keep the concrete lane count and topology task-specific.
+
+```text
+Parallel execution:
+- Classify each task as an independent capability lane, governance lane, or
+  deferred consolidation lane before launch.
+- Run independent capability or governance lanes in parallel only when they are
+  separated by file area, behavior surface, or risk surface.
+- Define merge-order dependencies before launch. If merge order is flexible,
+  state why.
+- Keep one repository, one branch, one worktree, and one PR per lane.
+- Validate each lane with the repository's canonical validation path.
+- Gate deferred consolidation lanes until upstream PRs are merged, current
+  main is fetched, and the human explicitly confirms continuation.
+- Have consolidation lanes reconcile vocabulary, docs, contracts, examples, or
+  shared semantics from current main rather than chasing moving branches.
+- Stop before merge and before downstream gated consolidation steps.
 ```
 
 ## Notes vs Playbook Alignment Audit

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -92,9 +92,19 @@ cleaning up those worktrees.
   parallel execution guidance: classify each task by lane, confirm the work can
   be separated by repository, file area, or risk surface, and define the merge
   order before work starts
+- use parallel Codex worktrees for independent capability lanes and governance
+  lanes only when the work is separated by file area, behavior surface, or risk
+  surface
 - do not run parallel Codex arcs across shared mutation paths, release state,
   schema contracts, or fragile overlapping files unless a clear merge order and
   dependency chain have been stated up front
+- treat consolidation and semantic reconciliation work as a gated downstream
+  lane when it depends on other PRs; do not start that worktree until the
+  upstream PRs are merged, current `main` is fetched, and the human explicitly
+  confirms continuation
+- have gated consolidation lanes reconcile vocabulary, docs, contracts,
+  examples, and shared semantics from current `main` instead of chasing moving
+  branches
 - if Codex PRs in a parallel batch overlap unexpectedly, pause the batch,
   update or rebase in the intended order, rerun the repository's canonical
   validation in each affected worktree, and inspect the current PR surfaces


### PR DESCRIPTION
Summary:
- Adds deferred consolidation lane guidance to parallel execution and merge ordering.
- Updates Codex worktree-batch guidance to gate semantic reconciliation until upstream PRs are merged, current main is fetched, and the human confirms continuation.
- Adds a compact reusable parallel-batch prompt add-on.

Validation:
- make check

Residual risk:
- Docs-only guidance may need minor refinement after more parallel batches exercise the pattern.