### PR TITLE
[codex] Document readable automation TOML

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -127,6 +127,12 @@ human-maintained configuration. Compact serialized TOML is usually appropriate
 for intentionally machine-generated artifacts or local runtime state where
 round-trip serialization is more important than review readability.
 
+This applies to local operational configuration such as Codex
+`automation.toml` files when humans are expected to inspect, tune, or review
+their prompts, schedules, or execution settings. Keep long prompt fields as
+real multiline strings and prefer one setting per line over compact generated
+serialization.
+
 ## Parallel Execution And Merge Ordering
 
 Prefer parallel task execution when work can be cleanly separated by repository,

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -71,5 +71,8 @@ execution paths.
   operational state, not canonical workflow guidance.
 - Detailed automation configuration should remain in local configuration files,
   not in the playbook.
+- When local automation configuration is human-maintained, follow the TOML
+  readability guidance in
+  [`engineering-baseline.md`](engineering-baseline.md#human-maintained-toml-readability).
 - Do not expose secrets, local-only paths, raw prompts containing private
   context, or environment-specific details in the playbook.


### PR DESCRIPTION
## Summary
- extend the existing TOML readability guidance to explicitly cover human-maintained Codex automation.toml files
- point maintenance automation configuration notes to the general TOML readability rule

## Local automation update
- reformatted /Users/keith/.codex/automations/delete-merged-repo-branches/automation.toml into multiline, human-readable TOML
- preserved the parsed automation prompt and validated the TOML with Python tomllib

## Validation
- make check
- parsed the reformatted local automation.toml with tomllib