### PR TITLE
Document Codex orchestration worker pattern

### DIFF
--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -165,10 +165,23 @@ verification, and review compression rather than raw implementation speed.
 Prefer small, repo-local, independently verifiable changes with clear
 validation and stop rules.
 
+The preferred scaling model is one top-level orchestration prompt for the run,
+with safe parallel work delegated to self-contained subagents or workers. The
+top-level prompt owns decomposition, lane boundaries, reconciliation, and
+reporting. Workers own only their assigned task envelope and should not depend
+on full conversation history, implicit role inheritance, or shared hidden state.
+
+Worker envelopes should make the repository, goal, scope, constraints,
+validation path, stop conditions, and reporting expectations explicit. Parallel
+workers should operate independently on separate worktrees and branches, or on
+clearly non-overlapping file, behavior, or risk surfaces when a branch split is
+not the right unit. If overlap appears, reconciliation belongs to the
+orchestrator or human reviewer, not to unsupervised worker coordination.
+
 Repo-local sovereignty remains the default. Discovery should be report-only
 before mutation, and cross-repo changes should be decomposed into separately
-reviewable repository PRs rather than bundled into mega-changes. Avoid
-centralized orchestration, unbounded autonomy, and premature standardization.
+reviewable repository PRs rather than bundled into mega-changes. Avoid standing
+centralized control planes, unbounded autonomy, and premature standardization.
 
 Promote new workflow abstractions only after repeated evidence from real repo
 work shows that they reduce review or coordination burden without becoming

--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -165,7 +165,7 @@ verification, and review compression rather than raw implementation speed.
 Prefer small, repo-local, independently verifiable changes with clear
 validation and stop rules.
 
-The preferred scaling model is one top-level orchestration prompt for the run,
+A preferred scaling model is one top-level orchestration prompt for the run,
 with safe parallel work delegated to self-contained subagents or workers. The
 top-level prompt owns decomposition, lane boundaries, reconciliation, and
 reporting. Workers own only their assigned task envelope and should not depend

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -66,6 +66,33 @@ Codex-specific application:
 - When cleanup is in scope, remove only the task worktrees and account for any
   blocked or deferred cleanup.
 
+## Subagent And Worker Prompts
+
+The ecosystem-level scaling direction prefers one top-level orchestration
+prompt that delegates safe parallel work through explicit task envelopes. For
+Codex, treat this as a compatibility constraint as well as a workflow
+preference: some Codex execution surfaces reject or cannot reliably honor
+requests for full-history conversation forking with explicit worker roles.
+
+Codex prompts should therefore avoid asking workers to inherit the complete chat
+history, parent-agent role, implicit project state, or hidden constraints. Do
+not rely on phrases such as "fork this conversation" or "use the same role and
+context as above" as the source of authority for worker behavior.
+
+Prefer standalone worker prompts that include:
+
+- repository and working directory
+- interaction mode and expected deliverable
+- goal, scope, and explicit exclusions
+- relevant source evidence or retrieval instructions
+- constraints, validation path, and stop conditions
+- branch, worktree, file-surface, or non-overlap expectations
+- reporting expectations for summary, validation, blockers, and residual risks
+
+This is a Codex execution quirk, not a universal playbook rule. Other adapters
+may describe different context-passing mechanisms when their execution surfaces
+support them, but Codex orchestration should remain self-contained by default.
+
 ## Command Execution
 
 Follow the command-form guidance in


### PR DESCRIPTION
## Summary
- Expand the solo-operator scaling direction around one top-level orchestration prompt delegating safe parallel work to self-contained subagents/workers.
- Add Codex-specific subagent guidance that standalone worker prompts should carry repo, scope, constraints, validation, stop conditions, and reporting expectations.
- Document the rationale for avoiding full-history worker forking and implicit role inheritance assumptions on Codex execution surfaces that reject or cannot reliably honor them.

## Validation
- make check