### PR TITLE
Add repo-family policy alignment guidance

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -206,6 +206,32 @@ repo-awareness and onboarding refresh procedure in
 That procedure keeps inventory refresh separate from onboarding and org-admin
 governance follow-up.
 
+## Repo-Family Policy Alignment
+
+Local repository metadata is not always the full policy. Before changing
+policy-sensitive surfaces, check repo-local guidance and nearby sibling
+repositories for an established ecosystem direction.
+
+This applies when a change would widen or reinterpret:
+
+- Python or runtime support policy
+- CI version matrices
+- packaging, release, publication, install, or distribution posture
+- branch protection, governance, or review settings
+- provider-live validation policy
+- compatibility shims, legacy dependencies, or support floors
+
+Prefer intentional consistency across a repo family unless the human or
+repo-local guidance explicitly asks for divergence. Do not silently widen
+compatibility, support, release, or governance scope only because local
+metadata permits it.
+
+If local metadata points one way and sibling precedent points another, stop and
+report the mismatch before implementing the policy-sensitive change. Example:
+a package metadata floor such as `>=3.10` may describe installability, while a
+repo family may be intentionally using a current-runtime-only CI and support
+posture.
+
 ## Repo-Local Workflow State
 
 For implementation changes, run commands from inside the target repository's

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -36,9 +36,11 @@ advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
 4. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.
 5. Identify the canonical source for the rule, behavior, or state being used.
-6. Confirm command form and execution settings for planned repository commands.
-7. Identify the repository's canonical validation path.
-8. Act only after those checks are clear, or report the blocker, uncertainty,
+6. For policy-sensitive changes, apply the repo-family alignment check in
+   `docs/repo-readiness.md`.
+7. Confirm command form and execution settings for planned repository commands.
+8. Identify the repository's canonical validation path.
+9. Act only after those checks are clear, or report the blocker, uncertainty,
    or missing context.
 
 ## Core Invariants

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -31,6 +31,9 @@ Before repo-scoped work:
   [`source-first-retrieval.md`](../source-first-retrieval.md): retrieve or
   revalidate authoritative repository, PR, issue, file, CI, log, artifact, and
   external-state sources before relying on them.
+- For policy-sensitive changes, apply the repo-family alignment check in
+  [`repo-readiness.md`](../repo-readiness.md#repo-family-policy-alignment)
+  before implementation.
 - Treat summaries, memory, pasted descriptions, generated notes, and local
   branch state as navigation only until the relevant source has been inspected.
 - If required source state is unavailable, report it as unknown or blocked
@@ -85,6 +88,7 @@ Prefer standalone worker prompts that include:
 - interaction mode and expected deliverable
 - goal, scope, and explicit exclusions
 - relevant source evidence or retrieval instructions
+- repo-family policy alignment expectations for policy-sensitive changes
 - constraints, validation path, and stop conditions
 - branch, worktree, file-surface, or non-overlap expectations
 - reporting expectations for summary, validation, blockers, and residual risks


### PR DESCRIPTION
## Summary
- Add a reusable repo-family policy alignment rule to repo readiness guidance.
- Add startup and Codex adapter pointers so implementation agents and parallel workers see the check before execution.

## Drift Scenario Addressed
A recent sibling-repo change optimized from local package metadata, such as a broad runtime floor, and expanded CI/runtime support. The local implementation was reasonable in isolation, but sibling repo precedent showed a narrower current-runtime support posture.

## Why Local Metadata Was Insufficient
Local metadata can describe installability or a technical lower bound. It does not always express the repo-family policy for compatibility, CI matrices, release posture, governance, provider-live validation, distribution strategy, or legacy support.

## Where The Guidance Lives
- docs/repo-readiness.md: new Repo-Family Policy Alignment rule and policy-sensitive checklist.
- docs/start-here.md: startup contract now points policy-sensitive work to the alignment check.
- docs/tool-adapters/codex.md: Codex startup and standalone worker prompts now include repo-family alignment expectations.

## Future Codex Orchestration Impact
Codex and parallel workers should inspect relevant sibling-repo precedent before widening support or governance scope. If local metadata and repo-family precedent disagree, they should stop and report the mismatch instead of silently implementing the wider policy.

## Validation
- make check: passed
- git diff --check: passed