### PR TITLE
Document Codex orchestration and parallelism

### DIFF
--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -170,6 +170,9 @@ with safe parallel work delegated to self-contained subagents or workers. The
 top-level prompt owns decomposition, lane boundaries, reconciliation, and
 reporting. Workers own only their assigned task envelope and should not depend
 on full conversation history, implicit role inheritance, or shared hidden state.
+The canonical operating guidance for deciding when to stay single-threaded,
+when to fan out, and how to reconcile worker outputs lives in
+[`orchestration-and-parallelism.md`](orchestration-and-parallelism.md).
 
 Worker envelopes should make the repository, goal, scope, constraints,
 validation path, stop conditions, and reporting expectations explicit. Parallel

--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -143,6 +143,11 @@ serialization.
 
 ## Parallel Execution And Merge Ordering
 
+For the full solo-operator decision model, worker envelope, reconciliation
+sequence, and "when not to parallelize" guidance, use
+[`orchestration-and-parallelism.md`](orchestration-and-parallelism.md). This
+section records the engineering baseline that applies to any parallel batch.
+
 Prefer parallel task execution when work can be cleanly separated by repository,
 file area, or risk surface. Parallelism should improve throughput without
 weakening reviewability, validation, or merge safety.

--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -1,0 +1,140 @@
+# Orchestration And Parallelism
+
+Use this page when deciding whether a repo task should stay in one Codex
+thread, split into multiple worker lanes, or pause for sequencing. The goal is
+solo-operator leverage, not ceremony: parallelism is useful only when it keeps
+work easier to review, validate, and merge.
+
+## Default To One Thread
+
+Prefer single-thread Codex work when the task has one coherent review surface.
+This is the default for most repository changes.
+
+Single-thread work is usually right when:
+
+- one person or agent can inspect the relevant sources and complete the change
+  without losing context
+- the change touches one repository, one branch, one validation path, and one
+  pull request
+- the work depends on a shared semantic decision that should be made once
+- the affected files are tightly coupled, such as one function, one command,
+  one schema contract, one generated artifact family, or one user-facing
+  wording surface
+- validation or review cost would not shrink meaningfully by splitting
+
+Do not split work merely because several agents are available. If the split
+would create coordination work larger than the task itself, keep the task in one
+thread and ship the smallest coherent change.
+
+## Fan Out Deliberately
+
+Fan out only when the lanes can be bounded before workers start. A useful
+parallel batch has independent deliverables, clear ownership, and a known
+reconciliation path.
+
+Parallel work is a good fit when:
+
+- lanes can be separated by repository, issue, file family, behavior surface,
+  or risk surface
+- each lane can produce one branch, one worktree, one validation result, and
+  one pull request or review artifact
+- expected overlap is named before launch
+- a merge or review order is declared before branch state changes
+- workers can stop at PR readiness without needing to inspect or update other
+  lanes
+- the orchestrator or human can reconcile outputs sequentially
+
+For same-repository Codex fan-out, use repo-local `.worktrees/` and keep each
+worker on its own branch. One issue, one branch, one worktree, and one PR per
+worker is the preferred shape when issues already describe the work cleanly.
+
+## Worker Envelope
+
+Every worker lane needs a self-contained task envelope. Do not rely on hidden
+conversation history, implicit role inheritance, or broad instructions such as
+"continue from the same context."
+
+Include:
+
+- repository and working directory
+- interaction mode and expected deliverable
+- assigned issue, branch, worktree, and file or behavior surface
+- goal, scope, and explicit exclusions
+- source evidence or retrieval instructions
+- canonical validation path
+- expected overlap and dependency-stop conditions
+- whether to open a draft or ready-for-review PR
+- reporting expectations: changed files, validation, overlap, blockers,
+  residual risk, and any merge-order dependency
+
+Workers should implement the assigned lane, run canonical validation, commit the
+scoped change, open or prepare the requested PR surface, report evidence, and
+stop. They should not merge, enable auto-merge, update other branches, absorb
+unassigned issues, or decide the next lane unless the human explicitly grants
+that authority for the specific step.
+
+## Orchestrator Responsibilities
+
+The orchestrator owns the batch-level view. In a solo-operator workflow this is
+often the human plus one top-level Codex thread.
+
+Before fan-out, the orchestrator should:
+
+- verify the repository and issue set
+- select a small lane count, usually one to three lanes
+- assign one bounded lane to each worker
+- serialize shared setup such as fetching, branch creation, and worktree
+  creation when needed
+- name expected overlap and the intended merge order
+- define stop conditions for dependency, validation, or scope surprises
+
+After workers report, the orchestrator should:
+
+- inspect worker diffs, PRs, and validation evidence directly
+- preserve or revise the merge order before changing branch state
+- decide which lanes can proceed, wait, or need reconciliation
+- update or rebase branches sequentially when earlier merges affect later lanes
+- resolve conflicts with semantic judgment, not mechanical cleanliness alone
+- rerun canonical validation after each reconciliation update
+- keep implementation records separate from staging or promotion notes
+
+## Reconciliation And Merge Sequence
+
+Parallel execution ends at lane readiness. Integration is a sequential workflow.
+
+Use this sequence when lanes will be merged or reviewed together:
+
+1. Inspect each PR or review surface directly.
+2. Confirm or revise the merge order.
+3. Merge or update the first lane only after explicit merge authorization when
+   the workflow requires human approval.
+4. Fetch current `main` before each later lane.
+5. Update, rebase, or recreate later branches only as needed for conflicts,
+   branch protection, repo policy, or explicit human request.
+6. Rerun the repository's canonical validation entrypoint after each
+   reconciliation update.
+7. Re-check readiness before continuing to the next lane.
+8. Run final validation on the integrated result when the repository workflow
+   calls for it or when the batch changed shared behavior.
+
+Open PRs as draft when they are ready for orchestrator inspection but not yet
+ready to merge. Mark them ready only when the implementation is complete,
+validation passes, and the remaining overlap or sequencing risk is low.
+
+## When Not To Parallelize
+
+Keep the work single-threaded or staged sequentially when:
+
+- lanes share mutation paths, safety-critical behavior, release state, schema
+  contracts, generated artifacts, or fragile overlapping files
+- the task needs one unresolved product, policy, security, or semantic decision
+- worker prompts would need large hidden context to behave correctly
+- the validation surface is global and expensive enough that each lane cannot
+  be checked meaningfully on its own
+- merge order cannot be described before launch
+- the likely reconciliation work would be harder than doing the change once
+- the work is destructive, externally visible, permissions-sensitive, or
+  governed by a human approval step
+
+Report-only exploration may still run in parallel for ambiguous areas, but
+mutation should wait until the split is clear.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -87,6 +87,8 @@ Stop rules:
 
 Use this compact add-on when asking an implementation agent to coordinate a
 parallel batch. Keep the concrete lane count and topology task-specific.
+Use [`orchestration-and-parallelism.md`](orchestration-and-parallelism.md) to
+decide whether the work should be split at all.
 
 ```text
 Parallel execution:
@@ -94,7 +96,11 @@ Parallel execution:
 - Define any merge-order dependencies before launch.
 - Keep one repository, one branch, one worktree, and one PR per lane.
 - Validate each lane with the repository's canonical validation path.
-- Stop before merge and before any downstream step that depends on a merge.
+- Workers stop at PR readiness and report changed files, validation, overlap,
+  blockers, residual risk, and merge-order dependencies.
+- The orchestrator inspects outputs directly, reconciles sequentially, reruns
+  canonical validation after updates, and stops before merge unless explicitly
+  authorized.
 ```
 
 ## Orchestration Handoff

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -13,6 +13,8 @@ acting.
   state before stateful repository reasoning
 - `docs/repo-readiness.md` -> interaction mode, governance operating model,
   command form, worktree, branch, validation, and PR expectations
+- `docs/orchestration-and-parallelism.md` -> single-thread, worker fan-out,
+  reconciliation, validation, and merge sequencing guidance
 - `docs/tool-adapters/codex.md` -> required Codex-specific deltas for Codex
   executions
 - `docs/tool-adapters/` -> adapter guidance for other executors when a
@@ -80,4 +82,6 @@ advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
 - Keep changes in the target repository, branch, and worktree.
 - Follow `docs/repo-readiness.md` for implementation isolation, governance
   operating model, command form, interaction mode, validation, and PR readiness.
+- Use `docs/orchestration-and-parallelism.md` before splitting a task across
+  workers or parallel PR lanes.
 - Open PRs ready for review by default unless explicitly instructed otherwise.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -76,6 +76,12 @@ Codex-specific application:
 
 ## Subagent And Worker Prompts
 
+Use
+[`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md) for
+the canonical decision model: default to one Codex thread for one coherent
+review surface, fan out only when worker lanes are bounded before launch, and
+keep integration or merge decisions with the orchestrator or human.
+
 The ecosystem-level scaling direction prefers one top-level orchestration
 prompt that delegates safe parallel work through explicit task envelopes. For
 Codex, treat this as a compatibility constraint as well as a workflow
@@ -97,6 +103,12 @@ Prefer standalone worker prompts that include:
 - constraints, validation path, and stop conditions
 - branch, worktree, file-surface, or non-overlap expectations
 - reporting expectations for summary, validation, blockers, and residual risks
+
+Worker authority stops at the assigned task envelope. A worker may implement,
+validate, commit, and open or prepare the requested PR surface. It should not
+merge, enable auto-merge, update other workers' branches, absorb unassigned
+issues, or continue into downstream reconciliation unless the human explicitly
+authorizes that specific step.
 
 This is a Codex execution quirk, not a universal playbook rule. Other adapters
 may describe different context-passing mechanisms when their execution surfaces


### PR DESCRIPTION
## Summary
- add canonical orchestration and parallelism guidance for single-thread work, worker fan-out, bounded lanes, reconciliation, validation, and merge sequencing
- link the new guidance from start-here, engineering baseline, ecosystem overview, prompts, and the Codex adapter
- clarify Codex worker authority stops at PR readiness unless explicitly authorized

## Validation
- make check
- changed Markdown link scan: checked 6 changed Markdown files