### PR TITLE
Clarify completion report source grounding

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -49,8 +49,8 @@ Retrieval:
   `AGENTS.md`, and any required tool adapter before acting.
 - Retrieve or revalidate authoritative repository, issue, PR, file, CI, log, or
   artifact state before relying on it.
-- Treat summaries, memory, and pasted descriptions as navigation, not proof of
-  current source state.
+- Treat summaries, completion reports, memory, and pasted descriptions as
+  navigation, not proof of current source state.
 - Stop broad search once the target files, constraints, validation path, and
   delivery expectation are clear.
 
@@ -148,8 +148,8 @@ Inputs:
 Retrieval:
 - Read the shared playbook startup guidance and repo-local `AGENTS.md` first.
 - Inspect only the files, issues, PRs, docs, or artifacts needed for the goal.
-- Retrieve authoritative source state before relying on it; treat summaries as
-  navigation only.
+- Retrieve authoritative source state before relying on it; treat summaries and
+  completion reports as navigation only.
 - Stop once the target surface, constraints, validation path, and delivery
   expectation are clear.
 
@@ -238,7 +238,8 @@ Retrieval:
 Instructions:
 - Apply `docs/review-packet.md#direct-pr-inspection`.
 - Stay in review/audit mode unless the human explicitly changes the task.
-- Treat user summaries and pasted excerpts as navigation, not PR evidence.
+- Treat user summaries, completion reports, and pasted excerpts as navigation,
+  not PR evidence.
 - Do not mutate the PR unless explicitly asked.
 - If required PR evidence is unavailable, state that blocker and caveat any
   feedback from already-present information.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -38,7 +38,8 @@ When relevant, say explicitly whether validation was mocked, contract-level, or 
 
 ## Direct PR Inspection
 
-Linked review artifacts are authoritative; pasted summaries are context.
+Linked review artifacts are authoritative; pasted summaries and completion
+reports are context.
 The source-first ordering rule in
 [`source-first-retrieval.md`](source-first-retrieval.md) applies before
 continuity or summary-based reasoning whenever a PR, issue, branch, commit, or
@@ -56,11 +57,11 @@ evidence for PR review, but they must not replace connector inspection.
 Treat "open the PR" as read-only connector inspection. It does not mean opening
 the PR in a browser, and it does not mean submitting a GitHub review.
 
-User-provided PR summaries, pasted titles, local path snippets, and copied
-diff excerpts are useful navigation and context, but they are not the review
-source of truth when a PR link, name, or number is available. A PR review must
-be grounded in the actual PR surface from the connector. The reviewer must
-inspect, where available:
+User-provided PR summaries, completion reports, pasted titles, local path
+snippets, and copied diff excerpts are useful navigation and context, but they
+are not the review source of truth when a PR link, name, or number is
+available. A PR review must be grounded in the actual PR surface from the
+connector. The reviewer must inspect, where available:
 
 - PR title and body
 - changed files

--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -29,11 +29,11 @@ Prefer evidence in this order when repository state is available:
 4. Raw logs or artifacts.
 5. User summaries.
 6. Prior-thread summaries.
-7. Agent-generated summaries or status claims.
+7. Agent-generated summaries, completion reports, or status claims.
 
-Summaries are leads, not state. They may guide what to inspect, but they are
-never authoritative when a live artifact, repository, check, workflow, log, or
-file can be inspected directly.
+Summaries, reports, and completion narratives are leads, not state. They may
+guide what to inspect, but they are never authoritative when a live artifact,
+repository, check, workflow, log, or file can be inspected directly.
 
 ## Triggers
 
@@ -64,8 +64,8 @@ Optional triggers may guide retrieval when the next action depends on current
 state, but they do not require source inspection for purely conversational
 answers:
 
-- pasted summaries, copied diffs, screenshots, or release notes without a live
-  artifact identifier
+- pasted summaries, completion reports, copied diffs, screenshots, or release
+  notes without a live artifact identifier
 - references to earlier conversation, prior work, a remembered plan, previous
   operational synthesis, or broad repository names without a state-dependent
   action
@@ -219,9 +219,9 @@ Watch for these observable failure patterns:
   status report as current after repo or remote state may have changed
 - inferred repo or PR state: claiming files, checks, comments, mergeability, or
   readiness from expectations instead of inspection
-- summary substitution for live state: using cached summaries, pasted PR
-  summaries, or copied diffs as the source of truth when a live artifact is
-  available
+- summary substitution for live state: using cached summaries, completion
+  reports, pasted PR summaries, or copied diffs as the source of truth when a
+  live artifact is available
 - local-state versus remote-state confusion: treating a clean local checkout as
   proof of GitHub mergeability, CI success, review resolution, or issue closure
 - coherent but unverified responses: producing plausible recommendations

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -39,8 +39,9 @@ Before repo-scoped work:
   [`repo-readiness.md`](../repo-readiness.md#governance-operating-model):
   distinguish safety and integrity protections from coordination overhead
   before proposing new gates or widening existing ones.
-- Treat summaries, memory, pasted descriptions, generated notes, and local
-  branch state as navigation only until the relevant source has been inspected.
+- Treat summaries, completion reports, memory, pasted descriptions, generated
+  notes, and local branch state as navigation only until the relevant source
+  has been inspected.
 - If required source state is unavailable, report it as unknown or blocked
   instead of inferring from conversation.
 


### PR DESCRIPTION
Summary:
- Treat completion reports and coherent operational narratives as summary evidence, not proof, in source-first retrieval.
- Mirror that wording in PR review, prompt, and Codex adapter surfaces without adding a new checklist or doctrine page.

Validation:
- make check