### PR TITLE
Fix stale playbook reference anchors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Tool-specific behavior belongs in documented adapter docs under [`docs/tool-adap
 
 The playbook is the canonical home for reusable workflow policy. Repo-local
 `AGENTS.md` files provide thin repository execution guidance; see
-[`docs/start-here.md`](docs/start-here.md#execution-model) and
+[`docs/start-here.md`](docs/start-here.md#startup-contract) and
 [`docs/repo-readiness.md`](docs/repo-readiness.md#agentsmd-responsibilities).
 
 Reusable pattern:
@@ -60,7 +60,7 @@ The first core module is delivery. Additional workflow families may be added lat
 
 ## Initial Map
 
-- [`docs/start-here.md`](docs/start-here.md): mandatory startup, source authority map, and adapter-routing contract
+- [`docs/start-here.md`](docs/start-here.md): mandatory startup, core invariants, and adapter-routing contract
 - [`docs/ai-workflow-ecosystem.md`](docs/ai-workflow-ecosystem.md): conceptual overview of the repository ecosystem, retained-knowledge boundaries, and architectural direction
 - [`docs/engineering-baseline.md`](docs/engineering-baseline.md): foundational engineering expectations, including validation, source authority, review, merge authority, and ready-for-review defaults
 - [`docs/authoritative-source-check.md`](docs/authoritative-source-check.md): advisory authoritative-source scanner adoption, domain classification, source justifications, and reusable workflow pinning

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -177,7 +177,7 @@ read-only or the human explicitly says not to modify files.
 
 For Codex-specific worktree creation, reuse, cleanup, parallel-batch handling,
 and blocked cleanup reporting, follow
-[`tool-adapters/codex.md`](tool-adapters/codex.md#workspace-isolation). For
+[`tool-adapters/codex.md`](tool-adapters/codex.md#worktrees). For
 other executors, follow the matching adapter when one documents stricter
 worktree handling.
 

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -258,7 +258,7 @@ uses a particular schedule, or currently contains a matching prompt.
 ## Guidance Layers
 
 - Follow the authority boundary in
-  [`start-here.md`](start-here.md#source-authority-map).
+  [`start-here.md`](start-here.md#core-invariants).
 - Live local automation configuration is authoritative for discovered
   automation inventory, current runtime prompt/config state, schedules,
   enablement state, execution environment, model selection, runtime IDs,


### PR DESCRIPTION
Summary:
- Repair stale README links and wording for the current start-here sections.
- Update maintenance automation guidance to point at current start-here core invariants.
- Update feature lifecycle Codex worktree guidance to point at the current adapter Worktrees section.

Validation:
- make check
- git merge-tree --write-tree origin/main HEAD