### PR TITLE
Document trusted registry automation scope

### DIFF
--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -33,7 +33,7 @@ uses a particular schedule, or currently contains a matching prompt.
 - Scope / target repositories: `knowledge-adapters`, `knowledge-vault`,
   `ka-destinations`, `ai-workflow-playbook`, `ai-workflow-enforcement`,
   `ai-workflow-incubator`, `linode-image-lab`, `linode-backup-lab`, `nexus`,
-  and `.github`.
+  `trusted-network-registry`, and `.github`.
 - Mode: Mutating only through the owning tool's explicit `--apply` path for
   Git-proven normal cleanup. Stale non-ancestor cleanup remains report-only
   unless explicit human-approved evidence exists in the companion config and
@@ -100,8 +100,8 @@ uses a particular schedule, or currently contains a matching prompt.
 - Scope / target repositories: `ai-workflow-playbook`,
   `ai-workflow-enforcement`, `ai-workflow-incubator`, `knowledge-adapters`,
   `knowledge-vault`, `ka-destinations`, `linode-image-lab`,
-  `linode-backup-lab`, `nexus`, and `.github`, plus the local-only workspace
-  `AGENTS.md`.
+  `linode-backup-lab`, `nexus`, `trusted-network-registry`, and `.github`,
+  plus the local-only workspace `AGENTS.md`.
 - Mode: Report-only audit.
 - Purpose / intent: Audit repo-local `AGENTS.md` guidance and local
   workspace-routing guidance against the canonical playbook.
@@ -131,7 +131,8 @@ uses a particular schedule, or currently contains a matching prompt.
   configured organization repositories `.github`,
   `ai-workflow-incubator`, `ai-workflow-playbook`,
   `ai-workflow-enforcement`, `linode-image-lab`, `linode-backup-lab`,
-  `knowledge-adapters`, `knowledge-vault`, `ka-destinations`, and `nexus`.
+  `knowledge-adapters`, `knowledge-vault`, `ka-destinations`, `nexus`, and
+  `trusted-network-registry`.
 - Mode: Report-only advisory scan.
 - Purpose / intent: Invoke the calibrated `ai-workflow-enforcement` drift
   scanner directly and report workflow-policy drift findings.


### PR DESCRIPTION
Updates the maintenance automation intent registry so current hard-coded automation scopes include trusted-network-registry where the active configs now include it. Validation: make check; git diff --check.