### PR TITLE
[codex] Add distributed-systems lens for orchestration

### DIFF
--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -5,6 +5,27 @@ thread, split into multiple worker lanes, or pause for sequencing. The goal is
 solo-operator leverage, not ceremony: parallelism is useful only when it keeps
 work easier to review, validate, and merge.
 
+## Distributed-Systems Lens For Multi-Agent Work
+
+Treat multi-agent repository work like a small distributed system. The analogy
+is operational, not literal: each worker has partial local state, can drift from
+current truth, and may conflict with other workers unless ownership, source of
+truth, validation, and reconciliation rules are explicit.
+
+Use the lens to reinforce the existing rules:
+
+- authoritative repo, provider, issue, PR, and documentation state controls over
+  agent context, memory, pasted summaries, and prior-thread reports
+- worker lanes need explicit ownership, scope, exclusions, and stop conditions
+- overlapping writes require sequencing or reconciliation before mutation
+- commands and validation should be rerunnable enough for safe retry
+- the orchestrator or human owns coordination, merge order, and trust-boundary
+  decisions
+- worker implementation stops at the assigned lane unless further authority is
+  explicitly granted
+- canonical validation is the health check before readiness or reconciliation
+- review, rebase, validation, and merge sequencing are the reconciliation path
+
 ## Default To One Thread
 
 Prefer single-thread Codex work when the task has one coherent review surface.


### PR DESCRIPTION
## Summary

- Adds a concise `Distributed-Systems Lens For Multi-Agent Work` section to `docs/orchestration-and-parallelism.md`.
- Frames multi-agent repository work as an operational analogy, not a literal equivalence.
- Reinforces existing playbook invariants: source-first retrieval, summaries as navigation, bounded lanes, explicit ownership, validation, and deterministic reconciliation.

## Source Checks

- Rehydrated from `docs/start-here.md` and repo-local `AGENTS.md`.
- Applied `docs/tool-adapters/codex.md` for Codex execution guidance.
- Fetched current `origin/main` and based this branch on `c67b02c8c6efd8115f350a5387c41ecdfd3258d9`.
- Inspected current `origin/main` versions of `docs/orchestration-and-parallelism.md`, `docs/repo-readiness.md`, `docs/source-first-retrieval.md`, and `docs/sparse-rehydration-and-source-grounding.md` before editing.

## Validation

`make check`:

```text
Running markdownlint-cli2
markdownlint-cli2 v0.22.1 (markdownlint v0.40.0)
Finding: **/*.md
Linting: 32 file(s)
Summary: 0 error(s)
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
.............
----------------------------------------------------------------------
Ran 13 tests in 0.001s

OK
```

## Scope

Docs-only. No enforcement behavior, implementation repository, adapter behavior, or validation policy changes.