### PR TITLE
Add multi-agent synthesis guidance

### DIFF
--- a/docs/multi-agent-synthesis.md
+++ b/docs/multi-agent-synthesis.md
@@ -1,0 +1,99 @@
+# Multi-Agent Synthesis
+
+Use multi-agent synthesis when independent perspectives can reveal better
+options than one agent would find alone. This is discovery and judgment support,
+not automatic authority transfer.
+
+## When To Use It
+
+Multi-agent synthesis is appropriate when the work benefits from meaningfully
+different perspectives, such as architecture review, backlog discovery,
+workflow-risk analysis, repo-ecosystem scanning, or comparison of alternative
+implementation strategies.
+
+It is usually not worth the coordination cost when the task is a small coherent
+implementation change, a direct bug fix, a tightly coupled edit, or a decision
+that needs one source-grounded answer rather than multiple speculative views.
+
+Use multiple agents to widen the idea surface. Use source inspection,
+validation, and human judgment to decide what becomes work.
+
+## Phase Boundaries
+
+Keep these phases separate:
+
+- idea generation: ask agents to inspect sources and propose opportunities,
+  risks, or options
+- synthesis: compare outputs for convergence, divergence, missing evidence, and
+  unresolved assumptions
+- execution planning: choose a bounded lane, owner, validation path, and stop
+  condition
+- implementation: make repository changes in the normal branch, worktree,
+  validation, and PR flow
+
+Do not let an agent-generated synthesis become the execution plan until a human
+or orchestrator has verified the relevant sources and selected the next action.
+Do not let a synthesis artifact become canonical merely because it is polished.
+
+## Reading Convergence And Divergence
+
+Convergence is a strong signal that a pattern, risk, or opportunity deserves
+attention. It is not proof. Before promotion or implementation, verify the
+claim against the authoritative source: repository files, current PRs, issues,
+official provider documentation, validation output, or the relevant system of
+record.
+
+Divergence is useful evidence. Treat it as a signal of ambiguity, hidden
+coupling, underspecified goals, stale context, model-specific bias, or
+legitimate tradeoff space. The response should be reconciliation, source
+verification, or a narrower decision prompt, not a vote-counting exercise.
+
+Record unresolved divergence when it affects architecture, policy, execution
+sequence, safety, or trust boundaries. Do not bury it in a blended summary.
+
+## Promotion Readiness
+
+Classify findings before moving them into durable workflow doctrine:
+
+- experimental: interesting observation, but source evidence or repeatability is
+  still weak
+- candidate: plausible reusable pattern with named evidence gaps and promotion
+  criteria
+- evidence-supported: repeated source-verified examples show the pattern is
+  useful beyond one run
+- playbook-ready: generalized, repeatable, source-verified guidance that can be
+  stated without raw experiment detail
+
+Only promote playbook-ready findings into this repository. Keep raw experiment
+logs, comparative model behavior, failed synthesis attempts, and evolving
+heuristics in an incubator or staging repository until the durable rule is
+clear.
+
+## Human Checkpoints
+
+Preserve human-in-the-loop checkpoints for:
+
+- architectural decisions
+- cross-repo policy or governance changes
+- destructive, externally visible, credentialed, or permissions-sensitive work
+- promotion from experiment to playbook doctrine
+- reconciliation where agent outputs disagree about scope, risk, or sequencing
+
+The human checkpoint should decide the next bounded action, not merely approve a
+generated narrative.
+
+## Solo-Operator Leverage
+
+The goal is to reduce human bottlenecking without hiding decisions that still
+need judgment. A useful synthesis should identify:
+
+- safe autonomous lanes that can proceed with clear ownership, validation, and
+  stop conditions
+- decisions that need architectural review before mutation
+- reconciliation needs between agent outputs or work lanes
+- source evidence still missing before implementation or promotion
+- follow-up that belongs in an incubator rather than the playbook
+
+Use the playbook for generalized repeatable rules. Use an incubator for raw
+experiment logs, comparative observations, synthesis notes, and promotion
+candidates that need more proof.

--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -26,6 +26,11 @@ Use the lens to reinforce the existing rules:
 - canonical validation is the health check before readiness or reconciliation
 - review, rebase, validation, and merge sequencing are the reconciliation path
 
+For comparative discovery and synthesis across multiple agents, use
+[`multi-agent-synthesis.md`](multi-agent-synthesis.md). Convergence and
+divergence can guide what deserves inspection, but source verification and
+human judgment still decide what becomes doctrine, planning, or implementation.
+
 ## Default To One Thread
 
 Prefer single-thread Codex work when the task has one coherent review surface.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -15,6 +15,8 @@ acting.
   command form, worktree, branch, validation, and PR expectations
 - `docs/orchestration-and-parallelism.md` -> single-thread, worker fan-out,
   reconciliation, validation, and merge sequencing guidance
+- `docs/multi-agent-synthesis.md` -> comparative discovery, convergence and
+  divergence interpretation, and promotion boundaries
 - `docs/tool-adapters/codex.md` -> required Codex-specific deltas for Codex
   executions
 - `docs/tool-adapters/` -> adapter guidance for other executors when a
@@ -84,4 +86,6 @@ advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
   operating model, command form, interaction mode, validation, and PR readiness.
 - Use `docs/orchestration-and-parallelism.md` before splitting a task across
   workers or parallel PR lanes.
+- Use `docs/multi-agent-synthesis.md` before treating independent agent outputs
+  as promotion, planning, or implementation evidence.
 - Open PRs ready for review by default unless explicitly instructed otherwise.


### PR DESCRIPTION
## Summary

- Add durable playbook guidance for multi-agent synthesis, convergence/divergence interpretation, and promotion readiness.
- Link the new guidance from `docs/start-here.md` and `docs/orchestration-and-parallelism.md`.
- Clarify that source verification and human checkpoints are required before generated synthesis becomes planning, implementation, or doctrine.

## Files Changed

- `docs/multi-agent-synthesis.md`
- `docs/orchestration-and-parallelism.md`
- `docs/start-here.md`

## Validation

- `make check`

## Scope Note

Documentation/knowledge-structure only. This PR promotes stable, generalized workflow doctrine into the playbook. Raw experiment logs, comparative model behavior, synthesis artifacts, and evolving heuristics remain incubator material until source-verified and promotion-ready.