### PR TITLE
[codex] Clarify reasoning evidence hierarchy

### DIFF
--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -35,6 +35,13 @@ Summaries, reports, and completion narratives are leads, not state. They may
 guide what to inspect, but they are never authoritative when a live artifact,
 repository, check, workflow, log, or file can be inspected directly.
 
+Reasoning traces, telemetry, generated summaries, and agent self-reports are
+supplementary evidence only. They are not authoritative proof of source state,
+intent, or correctness. When they conflict with verified source state or
+observed action and outcome, the verified source state or action and outcome
+control. This matters because reasoning traces can be post-hoc, incomplete, or
+optimized toward what the workflow appears to reward.
+
 ## Triggers
 
 Classify triggers before using prior conversation, summaries, memory, or pasted


### PR DESCRIPTION
## Summary

- Add a small evidence-hierarchy caveat for reasoning traces, telemetry, generated summaries, and agent self-reports.
- Clarify that verified source state and observed action/outcome evidence control when those supplementary signals conflict.
- Note that reasoning traces can be post-hoc, incomplete, or optimized toward rewarded workflow signals.

## Validation

- `make check`

## Scope notes

- Canonical playbook docs refinement only.
- No enforcement changes.
- No heavyweight control-plane, orchestration, mainframe, or DDD-specific doctrine promoted.