### PR TITLE
[codex] Document coherent PR commit guidance

### DIFF
--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -50,7 +50,9 @@ Single-thread work is usually right when:
 
 Do not split work merely because several agents are available. If the split
 would create coordination work larger than the task itself, keep the task in one
-thread and ship the smallest coherent change.
+thread and ship the smallest coherent change. For PR packaging guidance in
+solo-operator or low-coordination contexts, use
+[`repo-readiness.md`](repo-readiness.md#solo-operator-iteration-economics).
 
 ## Fan Out Deliberately
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -613,10 +613,13 @@ API integrations, schema migrations, deployment workflows, infrastructure
 automation, CI/CD hardening, observability and debugging loops,
 synchronization or reconciliation systems, and state repair or recovery logic.
 
-One PR is appropriate when the phases share one goal, one affected behavior or
-boundary, one validation story, and one rollback unit. Split the work when
-phases have independent goals, different risk profiles, unrelated files, or
-different validation or rollback boundaries.
+Prefer one coherent PR per reviewable outcome. In solo-operator or
+low-coordination contexts, multiple meaningful commits inside that PR can
+preserve phase-level auditability when work naturally progresses through
+foundation, hardening, docs, tests, provider-source verification, or follow-up
+refinement. Do not split into ceremony PRs solely to expose internal phases.
+Split the work when review scope, risk, ownership, validation path, merge
+timing, or rollback or revert strategy diverges.
 
 In solo-operator workflows, prefer completing the coherent task before opening
 the PR when it is safe to do so. Avoid stopping after a diagnostic-only partial


### PR DESCRIPTION
## Summary

- Adds canonical playbook guidance to prefer one coherent PR per reviewable
  outcome in solo-operator or low-coordination contexts.
- Clarifies that multiple meaningful commits inside that PR can preserve
  phase-level auditability across foundation, hardening, docs, tests,
  provider-source verification, or follow-up refinement.
- Cross-references the guidance from orchestration docs where single-thread
  work is already preferred for coherent review surfaces.

## Authority boundary

- `ai-workflow-playbook` is the canonical workflow doctrine source for this
  reusable rule.
- `ai-workflow-incubator` remains noncanonical staging/provenance and was not
  updated to avoid duplicating doctrine.

## Why this reduces ceremony without reducing auditability

- The guidance discourages ceremony-only PR splitting when internal phases still
  share one reviewable outcome.
- It keeps auditability by encouraging meaningful commits inside the coherent PR
  and by naming when separate PRs are still warranted: review scope, risk,
  ownership, validation path, merge timing, or rollback/revert strategy
  divergence.

## Validation

- `make check`
- `git diff --check`

## Incubator/playbook relationship notes

- Source inspection found adjacent stable doctrine already in
  `docs/repo-readiness.md` and `docs/orchestration-and-parallelism.md`, so this
  promotion went directly into playbook.
- No incubator PR was opened because an incubator-only pointer would add process
  surface without durable value.
