### PR TITLE
[codex] Document region policy drift automation

### DIFF
--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -242,26 +242,39 @@ uses a particular schedule, or currently contains a matching prompt.
 - Purpose / intent: Detect drift in the checked-in
   `linode-image-lab` region policy artifact workflow and recommend whether a
   PR or playbook guidance update is warranted.
-- Canonical prompt intent summary: Use GitHub as the source of truth. Rehydrate
-  from the playbook startup guidance and `linode-image-lab/AGENTS.md`, inspect
-  current `main`, regenerate and validate `policy/region-policy.toml`, then
-  inspect the resulting git diff. Report validation status, new and removed
-  provider regions, capability changes, generated group changes,
-  image-replication helper group changes, provider override changes, stale or
-  removable `provider_overrides.image_replication_excluded_regions` entries,
-  and whether a PR is warranted.
-- Canonical execution expectations: Use the documented `linode-image-lab`
-  workflow for regeneration and validation. Do not mutate provider resources,
-  read `LINODE_TOKEN`, open a PR, or update playbook guidance unless explicitly
-  asked.
+- Canonical prompt intent summary: Use GitHub as the source of truth and treat
+  detached or ephemeral worktree execution as normal for this report-only job.
+  Rehydrate from the playbook startup guidance, `linode-image-lab/AGENTS.md`,
+  and the documented region-policy commands in `linode-image-lab/README.md`.
+  Verify current `main`, regenerate and validate `policy/region-policy.toml`,
+  run the repository's canonical validation entrypoint when available, then
+  inspect the resulting artifact diff. Report the verified main commit,
+  validation status, new and removed provider regions, capability changes,
+  generated group changes, image-replication helper group changes, provider
+  override changes, stale or removable
+  `provider_overrides.image_replication_excluded_regions` entries, and whether
+  a PR is warranted.
+- Canonical execution expectations: Prefer the documented
+  `linode-image-lab region-policy ...` commands, and use the repo-local
+  `PYTHONPATH=src python3 -m linode_image_lab.cli region-policy ...`
+  equivalent when the package command is unavailable in the automation
+  environment. If regeneration succeeds and the artifact diff is empty, report
+  no drift without an extra external web research pass. Use official Linode
+  documentation only when the regenerated artifact, repository assumptions, or
+  provider override status creates a concrete ambiguity that repository sources
+  cannot resolve. Do not mutate provider resources, run live provider
+  operations, read `LINODE_TOKEN`, create summary or memory files, open a PR,
+  or update playbook guidance unless explicitly asked.
 - Companion config references: None.
 - Reconciliation / drift handling: Freshly inspect the active `automation.toml`
   before comparison. Prompt drift includes using local repository state as the
-  source of truth instead of current GitHub state, omitting regeneration,
-  validation, or diff inspection, dropping reported drift categories, reading
-  provider credentials, mutating provider resources, opening PRs without
-  explicit instruction, or treating observed drift as automatic authorization
-  to update playbook guidance.
+  source of truth instead of current GitHub state, treating detached worktree
+  execution as an implementation-mode problem, omitting regeneration,
+  validation, canonical validation, or diff inspection, dropping reported drift
+  categories, doing unnecessary external research after an empty artifact diff,
+  reading provider credentials, mutating provider resources, creating local
+  report or memory files, opening PRs without explicit instruction, or treating
+  observed drift as automatic authorization to update playbook guidance.
 
 ### 🗜️ Compact Memory
 

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -234,18 +234,23 @@ uses a particular schedule, or currently contains a matching prompt.
 
 - Automation name: 🛰️ Region Policy Drift Review
 - Automation ID: `region-policy-drift-review`
-- Scope / target repositories: `ai-workflow-playbook` and
-  `linode-image-lab`.
+- Scope / target repositories: Single execution root in `linode-image-lab`.
+  `ai-workflow-playbook` is a source to rehydrate from, not a second
+  automation workspace root.
 - Mode: Report-only scheduled drift review. Local artifact regeneration,
   validation, and diff inspection are allowed only inside the checked-out
   repository state being reviewed.
 - Purpose / intent: Detect drift in the checked-in
   `linode-image-lab` region policy artifact workflow and recommend whether a
   PR or playbook guidance update is warranted.
-- Canonical prompt intent summary: Use GitHub as the source of truth and treat
-  detached or ephemeral worktree execution as normal for this report-only job.
-  Rehydrate from the playbook startup guidance, `linode-image-lab/AGENTS.md`,
-  and the documented region-policy commands in `linode-image-lab/README.md`.
+- Canonical prompt intent summary: Use GitHub as the source of truth, keep the
+  automation single-rooted so the runner starts one job, and treat detached or
+  ephemeral worktree execution as normal for this report-only job. Rehydrate
+  from the playbook startup guidance, `linode-image-lab/AGENTS.md`, and the
+  documented region-policy commands in `linode-image-lab/README.md`.
+  Read playbook guidance from a sibling checkout when available, or from
+  `ctrl-alt-keith/ai-workflow-playbook` current GitHub `main` when the sibling
+  checkout is not present in the automation workspace.
   Verify current `main`, regenerate and validate `policy/region-policy.toml`,
   run the repository's canonical validation entrypoint when available, then
   inspect the resulting artifact diff. Report the verified main commit,
@@ -268,7 +273,8 @@ uses a particular schedule, or currently contains a matching prompt.
 - Companion config references: None.
 - Reconciliation / drift handling: Freshly inspect the active `automation.toml`
   before comparison. Prompt drift includes using local repository state as the
-  source of truth instead of current GitHub state, treating detached worktree
+  source of truth instead of current GitHub state, adding multiple automation
+  workspace roots that cause one run per repository, treating detached worktree
   execution as an implementation-mode problem, omitting regeneration,
   validation, canonical validation, or diff inspection, dropping reported drift
   categories, doing unnecessary external research after an empty artifact diff,

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -230,6 +230,39 @@ uses a particular schedule, or currently contains a matching prompt.
   behavior, mutation, PR creation, live-service checks, or replacing
   `make chaos-all` with a narrower validation command.
 
+### 🛰️ Region Policy Drift Review
+
+- Automation name: 🛰️ Region Policy Drift Review
+- Automation ID: `region-policy-drift-review`
+- Scope / target repositories: `ai-workflow-playbook` and
+  `linode-image-lab`.
+- Mode: Report-only scheduled drift review. Local artifact regeneration,
+  validation, and diff inspection are allowed only inside the checked-out
+  repository state being reviewed.
+- Purpose / intent: Detect drift in the checked-in
+  `linode-image-lab` region policy artifact workflow and recommend whether a
+  PR or playbook guidance update is warranted.
+- Canonical prompt intent summary: Use GitHub as the source of truth. Rehydrate
+  from the playbook startup guidance and `linode-image-lab/AGENTS.md`, inspect
+  current `main`, regenerate and validate `policy/region-policy.toml`, then
+  inspect the resulting git diff. Report validation status, new and removed
+  provider regions, capability changes, generated group changes,
+  image-replication helper group changes, provider override changes, stale or
+  removable `provider_overrides.image_replication_excluded_regions` entries,
+  and whether a PR is warranted.
+- Canonical execution expectations: Use the documented `linode-image-lab`
+  workflow for regeneration and validation. Do not mutate provider resources,
+  read `LINODE_TOKEN`, open a PR, or update playbook guidance unless explicitly
+  asked.
+- Companion config references: None.
+- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
+  before comparison. Prompt drift includes using local repository state as the
+  source of truth instead of current GitHub state, omitting regeneration,
+  validation, or diff inspection, dropping reported drift categories, reading
+  provider credentials, mutating provider resources, opening PRs without
+  explicit instruction, or treating observed drift as automatic authorization
+  to update playbook guidance.
+
 ### 🗜️ Compact Memory
 
 - Automation name: 🗜️ Compact Memory


### PR DESCRIPTION
## Summary

- add the Region Policy Drift Review automation to the maintenance automation intent registry
- document its source-of-truth expectations, report-only scope, policy artifact checks, and safety guardrails

## Rationale

The automation now exists in Codex local automation state, so the playbook registry should capture its durable intended semantics without copying runtime TOML, schedule metadata, or platform-managed state.

## Validation

- `make check`