### PR TITLE
Add starter distribution for local adoption

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -36,11 +36,36 @@ The starter is optimized for:
 - hosted playbook adoption before repo-local scaffolds, governance, or
   automation
 
+## Usage
+
+### URL-First Preferred
+
+1. Create or identify the destination repository, typically a personal GitHub
+   Enterprise repository named `ai-workflow-playbook`.
+2. Open Codex, Claude, ChatGPT, or another agent with access to that
+   destination.
+3. Copy the launcher prompt from
+   [`prompts/use-this-starter.md`](prompts/use-this-starter.md).
+4. Fill in the destination type and repository or folder.
+5. Let the launcher point the agent at the canonical bootstrap prompt in this
+   repository.
+
+### Clone Or Download Fallback
+
+If URL access is unavailable, clone or download this repository and provide the
+agent with the local starter files. Use
+[`prompts/use-this-starter.md`](prompts/use-this-starter.md) as the tiny
+entrypoint and
+[`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md) as
+the full implementation prompt.
+
 ## Contents
 
 - [`onboarding.md`](onboarding.md): a short adoption path for teams
 - [`manifest.md`](manifest.md): package contents, boundaries, and intended
   outputs
+- [`prompts/use-this-starter.md`](prompts/use-this-starter.md): tiny
+  copy/paste launcher prompt for URL-first adoption
 - [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md):
   prompt for selecting an adoption destination and creating starter scaffold
 - [`templates/AGENTS.template.md`](templates/AGENTS.template.md): optional

--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This starter distribution helps an existing workplace or team repository adopt
-the AI Workflow Playbook locally without introducing a new governance,
-enforcement, or policy layer.
+This starter distribution helps a practitioner adopt the AI Workflow Playbook
+for a workplace or team without introducing a new governance, enforcement, or
+policy layer.
 
 It is an adoption scaffold, not a fork of the playbook. Canonical workflow
 guidance remains in [`../../docs/`](../../docs/), especially:
@@ -17,9 +17,15 @@ guidance remains in [`../../docs/`](../../docs/), especially:
 
 ## Intended Use
 
-Use this package when a team wants a lightweight local starting point before
-considering governance changes, automation, or repository settings changes.
-It assumes ordinary contributor access, not administrator rights.
+Use this package when the intended first step is a work-local AI Workflow
+Playbook repository hosted on GitHub or GitHub Enterprise. That repository
+becomes the canonical location referenced by workplace AI tools.
+
+Repo-local `.ai-workflow/` scaffolds remain useful when a project repository
+needs local adoption notes. Local-only folders are a fallback for
+experimentation before publishing anything.
+
+The starter assumes ordinary contributor access, not administrator rights.
 
 The starter is optimized for:
 
@@ -27,7 +33,8 @@ The starter is optimized for:
 - small, reviewable changes
 - visible validation evidence
 - human review and compatibility with existing team process
-- local adoption before governance or automation
+- hosted playbook adoption before repo-local scaffolds, governance, or
+  automation
 
 ## Contents
 
@@ -35,7 +42,7 @@ The starter is optimized for:
 - [`manifest.md`](manifest.md): package contents, boundaries, and intended
   outputs
 - [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md):
-  prompt for creating local `.ai-workflow/` scaffolding in an adopter repo
+  prompt for selecting an adoption destination and creating starter scaffold
 - [`templates/AGENTS.template.md`](templates/AGENTS.template.md): optional
   repo-local instruction template
 - [`templates/review-packet-template.md`](templates/review-packet-template.md):
@@ -49,5 +56,7 @@ This distribution should not modify source code, CI/CD, GitHub settings, branch
 protection, `CODEOWNERS`, release automation, or enforcement controls. It should
 not create a parallel rulebook for the adopting repository.
 
-Start locally. Capture what the team already does. Make suggested workflow
-changes advisory unless the team explicitly requests implementation.
+Start with a reviewable hosted playbook repository when possible. Use
+repo-local scaffolds second, and local-only folders only when experimentation is
+the right first move. Capture what the team already does. Make suggested
+workflow changes advisory unless the team explicitly requests implementation.

--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -1,0 +1,53 @@
+# Starter Distribution
+
+## Purpose
+
+This starter distribution helps an existing workplace or team repository adopt
+the AI Workflow Playbook locally without introducing a new governance,
+enforcement, or policy layer.
+
+It is an adoption scaffold, not a fork of the playbook. Canonical workflow
+guidance remains in [`../../docs/`](../../docs/), especially:
+
+- [`../../docs/start-here.md`](../../docs/start-here.md)
+- [`../../docs/source-first-retrieval.md`](../../docs/source-first-retrieval.md)
+- [`../../docs/repo-readiness.md`](../../docs/repo-readiness.md)
+- [`../../docs/engineering-baseline.md`](../../docs/engineering-baseline.md)
+- [`../../docs/review-packet.md`](../../docs/review-packet.md)
+
+## Intended Use
+
+Use this package when a team wants a lightweight local starting point before
+considering governance changes, automation, or repository settings changes.
+It assumes ordinary contributor access, not administrator rights.
+
+The starter is optimized for:
+
+- source-first verification before claims about current repo state
+- small, reviewable changes
+- visible validation evidence
+- human review and compatibility with existing team process
+- local adoption before governance or automation
+
+## Contents
+
+- [`onboarding.md`](onboarding.md): a short adoption path for teams
+- [`manifest.md`](manifest.md): package contents, boundaries, and intended
+  outputs
+- [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md):
+  prompt for creating local `.ai-workflow/` scaffolding in an adopter repo
+- [`templates/AGENTS.template.md`](templates/AGENTS.template.md): optional
+  repo-local instruction template
+- [`templates/review-packet-template.md`](templates/review-packet-template.md):
+  lightweight review packet template
+- [`templates/repo-notes-template.md`](templates/repo-notes-template.md):
+  repo discovery notes template
+
+## Boundary
+
+This distribution should not modify source code, CI/CD, GitHub settings, branch
+protection, `CODEOWNERS`, release automation, or enforcement controls. It should
+not create a parallel rulebook for the adopting repository.
+
+Start locally. Capture what the team already does. Make suggested workflow
+changes advisory unless the team explicitly requests implementation.

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -1,0 +1,74 @@
+# Starter Manifest
+
+## Package Role
+
+`distributions/starter/` is a lightweight adoption scaffold for applying the AI
+Workflow Playbook in an existing team repository.
+
+It is not canonical doctrine. It is not a fork of the playbook. It is not an
+enforcement layer.
+
+Canonical guidance remains in [`../../docs/`](../../docs/), with these primary
+entry points:
+
+- [`../../docs/start-here.md`](../../docs/start-here.md): startup routing and
+  invariants
+- [`../../docs/source-first-retrieval.md`](../../docs/source-first-retrieval.md):
+  source-first verification model
+- [`../../docs/repo-readiness.md`](../../docs/repo-readiness.md): interaction
+  modes, validation, PR readiness, and governance operating model
+- [`../../docs/engineering-baseline.md`](../../docs/engineering-baseline.md):
+  engineering expectations for small, validated changes
+- [`../../docs/review-packet.md`](../../docs/review-packet.md): human review
+  packet format
+
+## Files
+
+- `README.md`: distribution overview and boundaries
+- `onboarding.md`: first-pass adoption path
+- `manifest.md`: this package inventory
+- `prompts/bootstrap-local-starter.md`: LLM prompt for creating local
+  `.ai-workflow/` scaffolding
+- `templates/AGENTS.template.md`: optional repo-local agent instruction
+  template
+- `templates/review-packet-template.md`: local review packet template
+- `templates/repo-notes-template.md`: local repo notes template
+
+## Expected Adopter Outputs
+
+The bootstrap prompt is expected to create advisory local files under the
+target repository's `.ai-workflow/` directory, such as:
+
+- `.ai-workflow/repo-notes.md`
+- `.ai-workflow/review-packet-template.md`
+- `.ai-workflow/AGENTS.template.md` when the repository would benefit from a
+  draft template
+
+The bootstrap prompt must not create or modify root `AGENTS.md` unless the
+human explicitly requests that specific change.
+
+## Explicit Non-Goals
+
+This starter must not:
+
+- duplicate large amounts of doctrine from `docs/`
+- create secondary governance, policy, or enforcement rules
+- assume administrator rights
+- assume solo-operator governance
+- modify source code
+- modify CI/CD
+- modify GitHub settings or branch protection
+- modify `CODEOWNERS`
+- modify release automation
+- modify enforcement controls
+
+## Review Heuristic
+
+A starter change belongs here when it helps a team adopt the playbook locally
+with clearer notes, prompts, or templates.
+
+A change belongs in `docs/` when it changes canonical workflow guidance.
+
+A change belongs outside this repository when it implements automation,
+enforcement, repository settings management, or project-specific operational
+logic.

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -28,6 +28,8 @@ entry points:
 - `README.md`: distribution overview and boundaries
 - `onboarding.md`: first-pass adoption path
 - `manifest.md`: this package inventory
+- `prompts/use-this-starter.md`: tiny copy/paste launcher prompt for URL-first
+  adoption
 - `prompts/bootstrap-local-starter.md`: LLM prompt for selecting an adoption
   destination and creating starter scaffold
 - `templates/AGENTS.template.md`: optional repo-local agent instruction
@@ -38,7 +40,9 @@ entry points:
 ## Expected Adopter Outputs
 
 The primary expected destination is a GitHub or GitHub Enterprise playbook
-repository that workplace AI tools can reference as canonical guidance.
+repository that workplace AI tools can reference as canonical guidance. The
+preferred entrypoint is the URL-first launcher prompt, which points an agent at
+the canonical bootstrap prompt in this repository.
 
 Secondary project-repository adoption can create advisory local files under
 the target repository's `.ai-workflow/` directory, such as:

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -2,8 +2,9 @@
 
 ## Package Role
 
-`distributions/starter/` is a lightweight adoption scaffold for applying the AI
-Workflow Playbook in an existing team repository.
+`distributions/starter/` is a lightweight adoption scaffold for establishing a
+work-local AI Workflow Playbook repository and, when needed, project-local
+workflow notes.
 
 It is not canonical doctrine. It is not a fork of the playbook. It is not an
 enforcement layer.
@@ -27,8 +28,8 @@ entry points:
 - `README.md`: distribution overview and boundaries
 - `onboarding.md`: first-pass adoption path
 - `manifest.md`: this package inventory
-- `prompts/bootstrap-local-starter.md`: LLM prompt for creating local
-  `.ai-workflow/` scaffolding
+- `prompts/bootstrap-local-starter.md`: LLM prompt for selecting an adoption
+  destination and creating starter scaffold
 - `templates/AGENTS.template.md`: optional repo-local agent instruction
   template
 - `templates/review-packet-template.md`: local review packet template
@@ -36,8 +37,11 @@ entry points:
 
 ## Expected Adopter Outputs
 
-The bootstrap prompt is expected to create advisory local files under the
-target repository's `.ai-workflow/` directory, such as:
+The primary expected destination is a GitHub or GitHub Enterprise playbook
+repository that workplace AI tools can reference as canonical guidance.
+
+Secondary project-repository adoption can create advisory local files under
+the target repository's `.ai-workflow/` directory, such as:
 
 - `.ai-workflow/repo-notes.md`
 - `.ai-workflow/review-packet-template.md`
@@ -46,6 +50,9 @@ target repository's `.ai-workflow/` directory, such as:
 
 The bootstrap prompt must not create or modify root `AGENTS.md` unless the
 human explicitly requests that specific change.
+
+Local-only folder output is a fallback for experimentation. It should report
+the created path and should not imply the team has adopted durable process.
 
 ## Explicit Non-Goals
 

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -1,0 +1,55 @@
+# Starter Onboarding
+
+## Goal
+
+Adopt the playbook in an existing team repository with the smallest useful local
+scaffold: notes, review packet shape, and optional repo-local agent guidance.
+
+Canonical workflow guidance stays in [`../../docs/`](../../docs/). This
+distribution helps a team point to that guidance from local working files; it
+does not replace it.
+
+## Adoption Path
+
+1. Read the canonical startup guidance in
+   [`../../docs/start-here.md`](../../docs/start-here.md).
+2. Inspect the target repository's existing contributor guidance, review norms,
+   validation commands, and team process.
+3. Create local `.ai-workflow/` scaffolding in the target repository using
+   [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md).
+4. Fill in repo-specific notes from observed source evidence, not memory or
+   assumptions.
+5. Use the review packet template for one or two small PRs before changing
+   team-wide process.
+6. Consider a root `AGENTS.md` only if the team explicitly wants repo-local
+   agent instructions.
+
+## First-Pass Local Outputs
+
+The bootstrap prompt should create local workflow scaffolding only, such as:
+
+- `.ai-workflow/repo-notes.md`
+- `.ai-workflow/review-packet-template.md`
+- `.ai-workflow/AGENTS.template.md` when useful
+
+These files should describe current local practice and point to canonical
+playbook docs. They should not impose requirements that the repository or team
+has not accepted.
+
+## Team Compatibility
+
+When applying the starter in a workplace repository:
+
+- respect existing review, approval, release, and incident processes
+- identify the repository's actual validation command before proposing changes
+- prefer advisory notes over settings changes
+- avoid assuming administrator access or solo-operator governance
+- keep adoption reversible and easy to review
+
+## What To Defer
+
+Defer governance, automation, and enforcement until the team has used the local
+scaffold and decided what, if anything, should become durable process.
+
+Do not use this starter to change CI/CD, GitHub settings, branch protection,
+`CODEOWNERS`, release automation, or enforcement controls.

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -11,8 +11,7 @@ does not replace it.
 
 ## Adoption Path
 
-1. Read the canonical startup guidance in
-   [`../../docs/start-here.md`](../../docs/start-here.md).
+1. Create or identify the destination repository or local folder.
 2. Choose the adoption destination:
    - an existing GitHub or GitHub Enterprise playbook repository
    - a new GitHub or GitHub Enterprise playbook repository
@@ -20,14 +19,19 @@ does not replace it.
    - a local-only folder for experimentation
 3. Prefer a hosted playbook repository when workplace AI tools need one
    canonical place to read guidance.
-4. Use project-repo `.ai-workflow/` scaffolding when a specific repository
+4. Open Codex, Claude, ChatGPT, or another agent with access to the selected
+   destination.
+5. Copy the tiny launcher prompt from
+   [`prompts/use-this-starter.md`](prompts/use-this-starter.md). It points the
+   agent at the canonical bootstrap prompt in this repository.
+6. Use project-repo `.ai-workflow/` scaffolding when a specific repository
    needs local notes or templates.
-5. Use a local-only folder when the team is not ready to publish anything.
-6. Apply the selected path with
+7. Use a local-only folder when the team is not ready to publish anything.
+8. Apply the selected path with
    [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md).
-7. Fill in notes from observed source evidence, not memory or assumptions.
-8. Use reviewable PRs for hosted repository changes when tooling is available.
-9. Consider a root `AGENTS.md` only if the team explicitly wants repo-local
+9. Fill in notes from observed source evidence, not memory or assumptions.
+10. Use reviewable PRs for hosted repository changes when tooling is available.
+11. Consider a root `AGENTS.md` only if the team explicitly wants repo-local
    agent instructions.
 
 ## First-Pass Outputs

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -2,8 +2,8 @@
 
 ## Goal
 
-Adopt the playbook in an existing team repository with the smallest useful local
-scaffold: notes, review packet shape, and optional repo-local agent guidance.
+Adopt the playbook through a work-local AI Workflow Playbook repository that
+workplace AI tools can reference as the canonical guidance source.
 
 Canonical workflow guidance stays in [`../../docs/`](../../docs/). This
 distribution helps a team point to that guidance from local working files; it
@@ -13,20 +13,31 @@ does not replace it.
 
 1. Read the canonical startup guidance in
    [`../../docs/start-here.md`](../../docs/start-here.md).
-2. Inspect the target repository's existing contributor guidance, review norms,
-   validation commands, and team process.
-3. Create local `.ai-workflow/` scaffolding in the target repository using
+2. Choose the adoption destination:
+   - an existing GitHub or GitHub Enterprise playbook repository
+   - a new GitHub or GitHub Enterprise playbook repository
+   - a project repository that needs `.ai-workflow/` scaffolding
+   - a local-only folder for experimentation
+3. Prefer a hosted playbook repository when workplace AI tools need one
+   canonical place to read guidance.
+4. Use project-repo `.ai-workflow/` scaffolding when a specific repository
+   needs local notes or templates.
+5. Use a local-only folder when the team is not ready to publish anything.
+6. Apply the selected path with
    [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md).
-4. Fill in repo-specific notes from observed source evidence, not memory or
-   assumptions.
-5. Use the review packet template for one or two small PRs before changing
-   team-wide process.
-6. Consider a root `AGENTS.md` only if the team explicitly wants repo-local
+7. Fill in notes from observed source evidence, not memory or assumptions.
+8. Use reviewable PRs for hosted repository changes when tooling is available.
+9. Consider a root `AGENTS.md` only if the team explicitly wants repo-local
    agent instructions.
 
-## First-Pass Local Outputs
+## First-Pass Outputs
 
-The bootstrap prompt should create local workflow scaffolding only, such as:
+For a hosted playbook repository, the bootstrap prompt should create a small,
+reviewable branch that points workplace AI tools to canonical playbook docs and
+captures adoption notes or templates without duplicating doctrine.
+
+For a project repository, the bootstrap prompt may create local workflow
+scaffolding such as:
 
 - `.ai-workflow/repo-notes.md`
 - `.ai-workflow/review-packet-template.md`
@@ -36,9 +47,12 @@ These files should describe current local practice and point to canonical
 playbook docs. They should not impose requirements that the repository or team
 has not accepted.
 
+For a local-only folder, the bootstrap prompt should create files locally and
+report the path clearly.
+
 ## Team Compatibility
 
-When applying the starter in a workplace repository:
+When applying the starter in a workplace context:
 
 - respect existing review, approval, release, and incident processes
 - identify the repository's actual validation command before proposing changes

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -1,0 +1,91 @@
+# Bootstrap Local Starter Prompt
+
+Use this prompt with an LLM inside the target repository.
+
+## Prompt
+
+You are helping adopt the AI Workflow Playbook in an existing workplace or team
+repository.
+
+Your task is to inspect the target repository and create local workflow
+scaffolding only. Create a `.ai-workflow/` directory with repo-specific notes,
+a review packet template, and, when useful, an optional `AGENTS.template.md`.
+
+Canonical workflow guidance remains in the playbook `docs/` directory. Treat
+this local scaffold as advisory adoption support, not a fork of the playbook
+and not an enforcement layer.
+
+Before writing files:
+
+1. Inspect the repository's existing contributor docs, README files,
+   validation commands, package metadata, Makefile or task runner, CI config,
+   review guidance, and any existing `AGENTS.md`.
+2. Identify the repository's current source of truth for validation, review,
+   release, and team process.
+3. Use source-first verification: rely on inspected files and command output,
+   not memory, summaries, or assumptions.
+4. Respect existing workplace and team processes.
+5. Do not assume administrator rights.
+6. Do not assume solo-operator governance.
+
+Create or update only local workflow scaffold files under `.ai-workflow/`.
+Recommended files:
+
+- `.ai-workflow/repo-notes.md`
+- `.ai-workflow/review-packet-template.md`
+- `.ai-workflow/AGENTS.template.md` when useful
+
+The repo notes should capture:
+
+- repository purpose and main technologies, based on inspected sources
+- canonical local setup and validation commands, if discoverable
+- current review or contribution process, if documented
+- source-first retrieval reminders for this repository
+- known unknowns where source evidence was not available
+- links back to canonical playbook docs:
+  - `docs/start-here.md`
+  - `docs/source-first-retrieval.md`
+  - `docs/repo-readiness.md`
+  - `docs/engineering-baseline.md`
+  - `docs/review-packet.md`
+
+The review packet template should help contributors report:
+
+- objective
+- scope and explicit non-scope
+- source evidence inspected
+- validation run and results
+- risks, unknowns, and follow-up decisions
+- recommendation for human review
+
+The optional `AGENTS.template.md` should be a draft template only. It may show
+how repo-local agent guidance could point to canonical playbook docs and local
+validation commands, but it must not be installed as root `AGENTS.md` unless the
+user explicitly requests that in a separate instruction.
+
+Hard boundaries:
+
+- Do not create or modify root `AGENTS.md` unless the user explicitly requests
+  it.
+- Do not modify source code.
+- Do not modify CI/CD.
+- Do not modify GitHub settings.
+- Do not modify branch protection.
+- Do not modify `CODEOWNERS`.
+- Do not modify release automation.
+- Do not modify enforcement controls.
+- Do not create new governance requirements.
+- Do not make settings or process changes on behalf of the team.
+
+Make every suggested workflow change advisory unless the user explicitly
+requests implementation.
+
+When finished, report:
+
+- files created or updated
+- source evidence inspected
+- validation commands discovered
+- any unknowns or assumptions
+- confirmation that no source code, CI/CD, GitHub settings, branch protection,
+  `CODEOWNERS`, release automation, enforcement controls, or root `AGENTS.md`
+  were modified

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -1,39 +1,63 @@
 # Bootstrap Local Starter Prompt
 
-Use this prompt with an LLM inside the target repository.
+Use this prompt with an LLM that can inspect the intended adoption destination.
 
 ## Prompt
 
-You are helping adopt the AI Workflow Playbook in an existing workplace or team
-repository.
+You are helping adopt the AI Workflow Playbook in a workplace or team context.
 
-Your task is to inspect the target repository and create local workflow
-scaffolding only. Create a `.ai-workflow/` directory with repo-specific notes,
-a review packet template, and, when useful, an optional `AGENTS.template.md`.
+Your task is to inspect the intended destination and create workflow
+scaffolding only. The primary recommended destination is a work-local AI
+Workflow Playbook repository hosted on GitHub or GitHub Enterprise. Repo-local
+`.ai-workflow/` scaffolds are a secondary path for project repositories, and
+local-only folders are a fallback for experimentation.
 
 Canonical workflow guidance remains in the playbook `docs/` directory. Treat
 this local scaffold as advisory adoption support, not a fork of the playbook
 and not an enforcement layer.
 
+## Destination Selection
+
+Before writing files, determine which adoption target is intended:
+
+- existing GitHub or GitHub Enterprise playbook repository
+- new GitHub or GitHub Enterprise playbook repository
+- existing project repository requiring `.ai-workflow/` scaffolding
+- local-only folder
+
+If the destination is ambiguous, stop and ask which target to use.
+
 Before writing files:
 
-1. Inspect the repository's existing contributor docs, README files,
-   validation commands, package metadata, Makefile or task runner, CI config,
-   review guidance, and any existing `AGENTS.md`.
-2. Identify the repository's current source of truth for validation, review,
-   release, and team process.
+1. For any repository destination, inspect the repository's existing
+   contributor docs, README files, validation commands, package metadata,
+   Makefile or task runner, CI config, review guidance, and any existing
+   `AGENTS.md`.
+2. For any repository destination, identify the repository's current source of
+   truth for validation, review, release, and team process.
 3. Use source-first verification: rely on inspected files and command output,
    not memory, summaries, or assumptions.
 4. Respect existing workplace and team processes.
 5. Do not assume administrator rights.
 6. Do not assume solo-operator governance.
 
-Create or update only local workflow scaffold files under `.ai-workflow/`.
-Recommended files:
+For an existing playbook repository, create or update only lightweight adoption
+scaffold that points workplace AI tools to canonical playbook docs.
+
+For a new playbook repository, create the repository when tooling, user-provided
+repository details, and permissions allow. If repository creation is
+unavailable, provide explicit repository creation instructions and stop before
+making assumptions.
+
+For an existing project repository, create or update only local workflow
+scaffold files under `.ai-workflow/`. Recommended files:
 
 - `.ai-workflow/repo-notes.md`
 - `.ai-workflow/review-packet-template.md`
 - `.ai-workflow/AGENTS.template.md` when useful
+
+For a local-only destination, create the selected scaffold files locally and
+report the path.
 
 The repo notes should capture:
 
@@ -82,11 +106,17 @@ requests implementation.
 
 ## Deliverable
 
-If repository write access and GitHub/PR tooling are available, create a
-branch, commit the `.ai-workflow/` scaffold changes, and open a pull request
-ready for review. If PR creation is unavailable or the user requested a
-local-only pass, leave the changes in the working tree and report the exact
-files changed.
+For an existing repository destination, create a branch, commit changes, and
+open a reviewable pull request when tooling is available. If PR creation is
+unavailable, leave the changes in the working tree and report the exact files
+changed.
+
+For a new repository destination, create the repository when tooling,
+user-provided repository details, and permissions allow. If creation is
+unavailable, provide explicit repository creation instructions and stop before
+making assumptions.
+
+For a local-only destination, create files locally and report the path.
 
 When finished, report:
 

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -80,6 +80,14 @@ Hard boundaries:
 Make every suggested workflow change advisory unless the user explicitly
 requests implementation.
 
+## Deliverable
+
+If repository write access and GitHub/PR tooling are available, create a
+branch, commit the `.ai-workflow/` scaffold changes, and open a pull request
+ready for review. If PR creation is unavailable or the user requested a
+local-only pass, leave the changes in the working tree and report the exact
+files changed.
+
 When finished, report:
 
 - files created or updated

--- a/distributions/starter/prompts/use-this-starter.md
+++ b/distributions/starter/prompts/use-this-starter.md
@@ -1,0 +1,22 @@
+# Use This Starter
+
+Copy this launcher prompt into Codex, Claude, ChatGPT, or another agent that
+has access to the intended destination.
+
+```text
+You are helping me apply the AI Workflow Playbook starter.
+
+First, retrieve and read the canonical bootstrap prompt from:
+https://github.com/ctrl-alt-keith/ai-workflow-playbook/blob/main/distributions/starter/prompts/bootstrap-local-starter.md
+
+Use that bootstrap prompt as the controlling instructions for this task. Do not
+continue from memory if the URL cannot be retrieved; ask me to paste the
+bootstrap prompt instead.
+
+Destination:
+- Type: [existing GitHub/GitHub Enterprise playbook repository | new GitHub/GitHub Enterprise playbook repository | existing project repository requiring .ai-workflow/ scaffolding | local-only folder]
+- Repository or folder: [URL, owner/name, or path]
+- Constraints: [team process, local-only pass, unavailable PR tooling, or none]
+
+If the destination is ambiguous, stop and ask which target to use.
+```

--- a/distributions/starter/templates/AGENTS.template.md
+++ b/distributions/starter/templates/AGENTS.template.md
@@ -1,0 +1,62 @@
+# AGENTS.md Template
+
+This is a draft template for a repository that chooses to adopt repo-local AI
+workflow guidance. Do not install it as root `AGENTS.md` unless the repository
+team explicitly requests that change.
+
+## Canonical Guidance
+
+This repository uses the AI Workflow Playbook as the canonical source for
+reusable workflow guidance. Repo-local instructions describe only this
+repository's execution details, such as setup, validation, branch conventions,
+and team process.
+
+Recommended canonical entry points:
+
+- `[playbook]/docs/start-here.md`
+- `[playbook]/docs/source-first-retrieval.md`
+- `[playbook]/docs/repo-readiness.md`
+- `[playbook]/docs/engineering-baseline.md`
+- `[playbook]/docs/review-packet.md`
+
+## Repository Startup
+
+Before acting:
+
+1. Read this repository's current contributor, setup, and validation docs.
+2. Inspect current source state before relying on summaries or prior context.
+3. Identify the interaction mode: implementation, review/audit, or
+   orchestration/prompt-authoring.
+4. Use the repository's documented validation path.
+5. Respect existing team review, release, and approval processes.
+
+## Local Commands
+
+Replace this section with commands verified from repository sources.
+
+- Setup: `[documented setup command or "not documented"]`
+- Validation: `[canonical validation command or "not documented"]`
+- Tests: `[test command or "covered by validation"]`
+- Formatting or linting: `[command or "covered by validation"]`
+
+## Working Expectations
+
+- Prefer small, reviewable changes.
+- Keep source-first evidence visible in summaries and review packets.
+- Report validation evidence clearly.
+- Keep suggested workflow changes advisory unless explicitly asked to implement
+  them.
+- Do not modify CI/CD, GitHub settings, branch protection, `CODEOWNERS`,
+  release automation, or enforcement controls unless the team explicitly
+  requests that specific work.
+
+## Review Packet
+
+Before requesting human review, include:
+
+- objective
+- scope and explicit non-scope
+- source evidence inspected
+- validation run and result
+- risks, unknowns, and follow-up decisions
+- recommendation for review

--- a/distributions/starter/templates/repo-notes-template.md
+++ b/distributions/starter/templates/repo-notes-template.md
@@ -1,0 +1,69 @@
+# Repo Notes Template
+
+Use this file for local adoption notes under `.ai-workflow/`. Keep it factual,
+source-grounded, and advisory.
+
+Canonical workflow guidance remains in the playbook `docs/` directory:
+
+- `[playbook]/docs/start-here.md`
+- `[playbook]/docs/source-first-retrieval.md`
+- `[playbook]/docs/repo-readiness.md`
+- `[playbook]/docs/engineering-baseline.md`
+- `[playbook]/docs/review-packet.md`
+
+## Repository Purpose
+
+Summarize the repository purpose using inspected sources.
+
+Sources inspected:
+
+- `[file or command]`
+
+## Technologies And Entry Points
+
+Capture the main technologies, package managers, services, and entry points
+visible in repository sources.
+
+Sources inspected:
+
+- `[file or command]`
+
+## Setup And Validation
+
+- Setup command: `[documented command or "not documented"]`
+- Canonical validation command: `[documented command or "not documented"]`
+- Test command: `[command or "covered by validation"]`
+- Formatting or linting command: `[command or "covered by validation"]`
+
+Sources inspected:
+
+- `[file or command]`
+
+## Team Process
+
+Record documented contribution, review, release, approval, or incident process.
+If the repository does not document a process, say so instead of inventing one.
+
+Sources inspected:
+
+- `[file or command]`
+
+## Source-First Reminders
+
+- Inspect current repository, issue, PR, branch, validation, and CI state before
+  making stateful claims.
+- Treat summaries and prior context as navigation, not proof.
+- Preserve unknowns when authoritative source evidence is not available.
+
+## Advisory Workflow Suggestions
+
+List optional suggestions for the team to consider. Do not present suggestions
+as requirements unless the team has accepted them.
+
+- `[suggestion]`
+
+## Unknowns
+
+List important gaps that could not be verified from source evidence.
+
+- `[unknown]`

--- a/distributions/starter/templates/review-packet-template.md
+++ b/distributions/starter/templates/review-packet-template.md
@@ -1,0 +1,43 @@
+# Review Packet Template
+
+Use this template to make human review faster and more grounded. Canonical
+review packet guidance remains in `[playbook]/docs/review-packet.md`.
+
+## Objective
+
+What was this change meant to accomplish?
+
+## Scope
+
+What changed?
+
+## Explicit Non-Scope
+
+What intentionally did not change?
+
+## Interaction Mode
+
+Implementation, review/audit, or orchestration/prompt-authoring.
+
+## Source Evidence
+
+List the repository files, issue or PR links, docs, commands, logs, or other
+authoritative sources inspected.
+
+## Validation
+
+List commands run and results. If validation is unavailable or incomplete, say
+so directly.
+
+## Risks And Unknowns
+
+Name remaining risks, assumptions, follow-up decisions, or gaps between local
+validation and real-world behavior.
+
+## Recommendation
+
+Choose one and explain briefly:
+
+- ready to merge
+- needs decision
+- blocked


### PR DESCRIPTION
## Summary

- Add `distributions/starter/` as a lightweight adoption scaffold for workplace AI Workflow Playbook adoption.
- Add a URL-first launcher prompt at `distributions/starter/prompts/use-this-starter.md` so users can copy a tiny entrypoint into Codex, Claude, ChatGPT, or another agent without cloning this repository first.
- Keep `bootstrap-local-starter.md` as the full implementation prompt, now with destination selection for existing playbook repos, new playbook repos, project-repo `.ai-workflow/` scaffolds, and local-only folders.
- Keep canonical workflow doctrine in `docs/` and link to deeper canonical docs instead of duplicating them.

## Scope boundaries

- This is an adoption scaffold, not a fork of the playbook and not an enforcement layer.
- Does not modify source code, CI/CD, GitHub settings, branch protection, `CODEOWNERS`, release automation, or enforcement controls.
- Does not assume administrator rights or solo-operator governance.
- Does not create or modify root `AGENTS.md` unless explicitly requested by the adopting team.

## Adoption path rationale

- Destination selection was added because review clarified that the starter has more than one valid target; the prompt now stops and asks when the intended destination is ambiguous.
- Work-local GitHub or GitHub Enterprise playbook repositories are now the primary recommended adoption target because workplace AI tools need one canonical URL-backed place to retrieve guidance.
- Repo-local `.ai-workflow/` scaffolds remain supported as a secondary path for project-specific notes, review templates, and optional local agent guidance.
- Local-only folders remain a fallback for experimentation when URL or repository access is unavailable.

## Validation

- `make check` passed.
  - `markdownlint-cli2 "**/*.md"`: 0 errors across 41 Markdown files.
  - `python3 -m unittest discover -s tests`: 13 tests passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git merge-tree --write-tree HEAD origin/main` completed without conflicts.

## Review focus

- Whether the URL-first launcher is small enough for copy/paste use.
- Whether the starter now correctly presents hosted work-local playbook repositories as the primary path.
- Whether project-repo `.ai-workflow/` scaffolds remain clear as a secondary path without creating governance or enforcement expectations.