### PR TITLE
[codex] Document interaction mode transitions

### DIFF
--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -86,6 +86,13 @@ Every worker lane needs a self-contained task envelope. Do not rely on hidden
 conversation history, implicit role inheritance, or broad instructions such as
 "continue from the same context."
 
+Prompts intended for delegated execution should name the expected deliverable
+whenever practical, such as research findings, an audit report, a design
+proposal, an implementation plan, an implementation, or an implementation that
+results in a pull request. When delegated work will modify a repository, the
+default expected deliverable is a reviewable pull request unless another
+artifact is explicitly requested.
+
 Include:
 
 - repository and working directory

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -162,6 +162,15 @@ Do not infer implementation mode from vague wording such as "fix this",
 "handle this", or "let's fix the bug" when the surrounding context suggests
 advisory review, audit, orchestration, or prompt generation.
 
+Re-evaluate the interaction mode when a review, audit, planning, architecture,
+or prompt-authoring discussion converges on a selected direction and the
+remaining work becomes implementation-oriented. Convergence on a direction does
+not by itself authorize repository mutation. Before continuing, briefly decide
+whether the next step is to continue design, capture the decision, implement
+directly, delegate implementation, open or update a pull request, or stop.
+Keep this checkpoint lightweight: use the current user intent, repository
+guidance, and visible completion state instead of adding a separate ceremony.
+
 For ctrl-alt-keith workflows, default ambiguous repository tasks to
 review/audit mode or orchestration/prompt-authoring mode unless the human
 explicitly asks for direct implementation. Implementation mode requires clear


### PR DESCRIPTION
## Summary
- Add a lightweight interaction-mode checkpoint for review, audit, planning, architecture, and prompt-authoring discussions that have converged on implementation-oriented next work.
- Add delegated-execution guidance that prompts should name the expected deliverable, with repository-changing delegated work defaulting to a reviewable pull request unless another artifact is requested.

## Why the guidance is needed
Recent playbook usage showed two small gaps: discussions can settle on a direction without explicitly switching into implementation mode, and delegated prompts can leave the expected artifact ambiguous. The new wording makes the next step explicit without adding a heavy process step.

## Scope boundaries
- Keeps the existing implementation, review/audit, and orchestration/prompt-authoring modes intact.
- Preserves existing ready-for-review and PR readiness doctrine.
- Adds general workflow guidance only; no tool-specific executor behavior or ctrl-alt-keith-only rule is introduced.

## Validation
- `make check`
- `git diff --check`
- Verified the branch merges cleanly with current `origin/main` using `git merge-tree --write-tree origin/main HEAD`.

## Review focus
- Is the guidance sufficiently general?
- Is the transition checkpoint lightweight enough?
- Is the delegated-deliverable rule correctly scoped to repository-changing work?