### PR TITLE
Add starter upstream refresh workflow

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -35,6 +35,7 @@ The starter is optimized for:
 - human review and compatibility with existing team process
 - hosted playbook adoption before repo-local scaffolds, governance, or
   automation
+- periodic upstream review without blind synchronization
 
 ## Usage
 
@@ -59,6 +60,17 @@ entrypoint and
 [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md) as
 the full implementation prompt.
 
+## Upstream Refresh
+
+Work-local playbook repositories should retain a reference to
+[`prompts/upstream-refresh.md`](prompts/upstream-refresh.md). Use it
+periodically to review upstream changes from
+`ctrl-alt-keith/ai-workflow-playbook` and decide whether to adopt, adapt, skip,
+or escalate them.
+
+This is not synchronization, enforcement, or automatic promotion. Local
+ownership and workplace context control the final decision.
+
 ## Contents
 
 - [`onboarding.md`](onboarding.md): a short adoption path for teams
@@ -68,6 +80,8 @@ the full implementation prompt.
   copy/paste launcher prompt for URL-first adoption
 - [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md):
   prompt for selecting an adoption destination and creating starter scaffold
+- [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md): review-oriented
+  prompt for evaluating upstream changes
 - [`templates/AGENTS.template.md`](templates/AGENTS.template.md): optional
   repo-local instruction template
 - [`templates/review-packet-template.md`](templates/review-packet-template.md):

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -32,6 +32,8 @@ entry points:
   adoption
 - `prompts/bootstrap-local-starter.md`: LLM prompt for selecting an adoption
   destination and creating starter scaffold
+- `prompts/upstream-refresh.md`: review-oriented prompt for evaluating upstream
+  changes without blind synchronization
 - `templates/AGENTS.template.md`: optional repo-local agent instruction
   template
 - `templates/review-packet-template.md`: local review packet template
@@ -42,7 +44,9 @@ entry points:
 The primary expected destination is a GitHub or GitHub Enterprise playbook
 repository that workplace AI tools can reference as canonical guidance. The
 preferred entrypoint is the URL-first launcher prompt, which points an agent at
-the canonical bootstrap prompt in this repository.
+the canonical bootstrap prompt in this repository. Work-local playbook
+repositories should retain a reference to the upstream refresh prompt for
+periodic review.
 
 Secondary project-repository adoption can create advisory local files under
 the target repository's `.ai-workflow/` directory, such as:
@@ -63,6 +67,7 @@ the created path and should not imply the team has adopted durable process.
 This starter must not:
 
 - duplicate large amounts of doctrine from `docs/`
+- introduce automatic synchronization with upstream
 - create secondary governance, policy, or enforcement rules
 - assume administrator rights
 - assume solo-operator governance

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -38,7 +38,10 @@ does not replace it.
 
 For a hosted playbook repository, the bootstrap prompt should create a small,
 reviewable branch that points workplace AI tools to canonical playbook docs and
-captures adoption notes or templates without duplicating doctrine.
+captures adoption notes or templates without duplicating doctrine. It should
+also retain a reference to
+[`prompts/upstream-refresh.md`](prompts/upstream-refresh.md) for future
+upstream review.
 
 For a project repository, the bootstrap prompt may create local workflow
 scaffolding such as:
@@ -53,6 +56,15 @@ has not accepted.
 
 For a local-only folder, the bootstrap prompt should create files locally and
 report the path clearly.
+
+## Ongoing Upstream Review
+
+Use [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md) periodically to
+compare the local playbook with upstream `ctrl-alt-keith/ai-workflow-playbook`.
+The goal is to review and decide, not synchronize.
+
+Classify candidate changes as adopt now, adapt with edits, not applicable, or
+human decision required. Preserve local ownership and workplace context.
 
 ## Team Compatibility
 

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -42,12 +42,15 @@ Before writing files:
 6. Do not assume solo-operator governance.
 
 For an existing playbook repository, create or update only lightweight adoption
-scaffold that points workplace AI tools to canonical playbook docs.
+scaffold that points workplace AI tools to canonical playbook docs. Retain a
+reference to `distributions/starter/prompts/upstream-refresh.md` for periodic
+upstream review.
 
 For a new playbook repository, create the repository when tooling, user-provided
 repository details, and permissions allow. If repository creation is
 unavailable, provide explicit repository creation instructions and stop before
-making assumptions.
+making assumptions. Include a reference to
+`distributions/starter/prompts/upstream-refresh.md` for future upstream review.
 
 For an existing project repository, create or update only local workflow
 scaffold files under `.ai-workflow/`. Recommended files:

--- a/distributions/starter/prompts/upstream-refresh.md
+++ b/distributions/starter/prompts/upstream-refresh.md
@@ -1,0 +1,89 @@
+# Upstream Refresh Prompt
+
+Use this prompt in a work-local or organization-local AI Workflow Playbook
+repository when you want to review upstream changes from
+`ctrl-alt-keith/ai-workflow-playbook`.
+
+## Prompt
+
+You are helping review upstream AI Workflow Playbook changes for a local
+workplace or organization playbook repository.
+
+This is an upstream review workflow, not synchronization.
+
+Do not blindly synchronize. Do not overwrite local decisions. Do not assume
+upstream is automatically correct for the local environment. Evaluate
+applicability and intent. Prefer adaptation over copying when local context
+differs.
+
+## Inputs
+
+- Local playbook repository: `[local repository URL, owner/name, or path]`
+- Upstream repository: `ctrl-alt-keith/ai-workflow-playbook`
+- Review range or period: `[since last refresh, date range, commit range, or recent merged PRs]`
+- Requested output: `[review report only | implement recommended updates]`
+
+If the local repository, upstream source, or review range is ambiguous, stop
+and ask for the missing target.
+
+## Review Process
+
+1. Inspect the local playbook repository, including its README, local adoption
+   notes, templates, prompts, and any local `AGENTS.md`.
+2. Inspect upstream `ctrl-alt-keith/ai-workflow-playbook`.
+3. Review relevant canonical upstream docs, especially:
+   - `docs/start-here.md`
+   - `docs/source-first-retrieval.md`
+   - `docs/repo-readiness.md`
+   - `docs/engineering-baseline.md`
+   - `docs/review-packet.md`
+4. Review recent merged upstream pull requests in the requested range.
+5. Identify candidate upstream changes that may affect the local playbook.
+6. Classify each candidate:
+   - adopt now
+   - adapt with edits
+   - not applicable
+   - human decision required
+
+## Evaluation Guidance
+
+For each candidate, consider:
+
+- upstream intent and problem addressed
+- local workplace or organization context
+- existing local decisions and documented deviations
+- whether adopting the change would improve source-first verification,
+  reviewability, validation evidence, or team compatibility
+- whether adaptation is safer than copying
+- whether the change would introduce governance, enforcement, CI/CD, settings,
+  branch protection, `CODEOWNERS`, release automation, or automatic promotion
+  behavior
+
+Do not create a requirement to track every upstream change. Preserve local
+ownership.
+
+## Deliverables
+
+Produce a review report with:
+
+- upstream changes reviewed
+- recommended actions
+- rationale for each recommendation
+- proposed implementation plan when updates are recommended
+- explicit unknowns or source evidence that could not be inspected
+
+If repository modifications are requested and tooling is available:
+
+1. Create a branch.
+2. Commit only the selected local playbook updates.
+3. Open a reviewable pull request.
+4. Report the PR link, files changed, validation run, and residual risks.
+
+Otherwise, produce a review report only.
+
+## Boundaries
+
+Do not introduce automatic synchronization. Do not introduce enforcement
+behavior. Do not overwrite local decisions. Do not create a requirement to
+track every upstream change. Do not duplicate large amounts of upstream
+doctrine.


### PR DESCRIPTION
## Summary

- Add `distributions/starter/prompts/upstream-refresh.md` as a reusable review prompt for comparing local playbook repositories with upstream `ctrl-alt-keith/ai-workflow-playbook`.
- Update starter README, onboarding, manifest, and bootstrap prompt so work-local playbooks retain a reference to the upstream refresh workflow.
- Keep the workflow review-oriented: classify candidate upstream changes as adopt now, adapt with edits, not applicable, or human decision required.

## Why upstream refresh is useful

Work-local and organization-local playbook repositories will intentionally diverge from upstream in places. A lightweight upstream refresh prompt gives teams a repeatable way to review recent upstream improvements, understand intent, and decide whether to adopt or adapt changes without treating upstream as automatically correct.

## Scope boundaries

- This is periodic upstream review, not synchronization.
- Does not introduce automatic synchronization, enforcement behavior, automatic promotion, or a requirement to track every upstream change.
- Does not modify CI/CD, GitHub settings, branch protection, `CODEOWNERS`, release automation, or enforcement controls.
- Keeps canonical doctrine ownership in `docs/` and avoids duplicating large amounts of doctrine.

## Validation

- `make check` passed.
  - `markdownlint-cli2 "**/*.md"`: 0 errors across 42 Markdown files.
  - `python3 -m unittest discover -s tests`: 13 tests passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git merge-tree --write-tree HEAD origin/main` completed without conflicts.

## Review focus

- Is the refresh model adaptation-oriented rather than synchronization-oriented?
- Is the workflow lightweight enough?
- Does it preserve local ownership while still benefiting from upstream improvements?