### PR TITLE
Clarify starter destination structures

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -25,6 +25,10 @@ Repo-local `.ai-workflow/` scaffolds remain useful when a project repository
 needs local adoption notes. Local-only folders are a fallback for
 experimentation before publishing anything.
 
+These are intentionally different structures: a work-local playbook repository
+gets repository-level `README.md`, `docs/`, `prompts/`, and `templates/`
+content, while an existing project repository gets `.ai-workflow/` scaffolding.
+
 The starter assumes ordinary contributor access, not administrator rights.
 
 The starter is optimized for:
@@ -99,3 +103,5 @@ Start with a reviewable hosted playbook repository when possible. Use
 repo-local scaffolds second, and local-only folders only when experimentation is
 the right first move. Capture what the team already does. Make suggested
 workflow changes advisory unless the team explicitly requests implementation.
+Do not create `.ai-workflow/` at the top level of a destination that is itself
+meant to become a standalone playbook repository.

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -46,7 +46,8 @@ repository that workplace AI tools can reference as canonical guidance. The
 preferred entrypoint is the URL-first launcher prompt, which points an agent at
 the canonical bootstrap prompt in this repository. Work-local playbook
 repositories should retain a reference to the upstream refresh prompt for
-periodic review.
+periodic review. The destination itself is the playbook repository, so starter
+content belongs at repository level rather than under `.ai-workflow/`.
 
 Secondary project-repository adoption can create advisory local files under
 the target repository's `.ai-workflow/` directory, such as:
@@ -59,8 +60,10 @@ the target repository's `.ai-workflow/` directory, such as:
 The bootstrap prompt must not create or modify root `AGENTS.md` unless the
 human explicitly requests that specific change.
 
-Local-only folder output is a fallback for experimentation. It should report
-the created path and should not imply the team has adopted durable process.
+Local-only folder output is a fallback for experimentation. Before creating
+files, determine whether the folder is a future playbook repository or a
+project-local scaffold. Report the created path and do not imply the team has
+adopted durable process.
 
 ## Explicit Non-Goals
 

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -26,7 +26,9 @@ does not replace it.
    agent at the canonical bootstrap prompt in this repository.
 6. Use project-repo `.ai-workflow/` scaffolding when a specific repository
    needs local notes or templates.
-7. Use a local-only folder when the team is not ready to publish anything.
+7. Use a local-only folder when the team is not ready to publish anything, but
+   first decide whether that folder is a future playbook repository or a
+   project-local scaffold.
 8. Apply the selected path with
    [`prompts/bootstrap-local-starter.md`](prompts/bootstrap-local-starter.md).
 9. Fill in notes from observed source evidence, not memory or assumptions.
@@ -41,7 +43,8 @@ reviewable branch that points workplace AI tools to canonical playbook docs and
 captures adoption notes or templates without duplicating doctrine. It should
 also retain a reference to
 [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md) for future
-upstream review.
+upstream review. This content belongs directly at the repository level; do not
+wrap it in `.ai-workflow/`.
 
 For a project repository, the bootstrap prompt may create local workflow
 scaffolding such as:
@@ -55,7 +58,9 @@ playbook docs. They should not impose requirements that the repository or team
 has not accepted.
 
 For a local-only folder, the bootstrap prompt should create files locally and
-report the path clearly.
+report the path clearly. If the folder is a future playbook repository, create
+repository-level playbook content. If it is a project-local scaffold, use
+`.ai-workflow/`.
 
 ## Ongoing Upstream Review
 

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -6,14 +6,14 @@ Use this prompt with an LLM that can inspect the intended adoption destination.
 
 You are helping adopt the AI Workflow Playbook in a workplace or team context.
 
-Your task is to inspect the intended destination and create workflow
-scaffolding only. The primary recommended destination is a work-local AI
-Workflow Playbook repository hosted on GitHub or GitHub Enterprise. Repo-local
-`.ai-workflow/` scaffolds are a secondary path for project repositories, and
-local-only folders are a fallback for experimentation.
+Your task is to inspect the intended destination and create the correct starter
+structure for that destination. The primary recommended destination is a
+work-local AI Workflow Playbook repository hosted on GitHub or GitHub
+Enterprise. Repo-local `.ai-workflow/` scaffolds are a secondary path for
+project repositories, and local-only folders are a fallback for experimentation.
 
 Canonical workflow guidance remains in the playbook `docs/` directory. Treat
-this local scaffold as advisory adoption support, not a fork of the playbook
+this starter output as advisory adoption support, not a fork of the playbook
 and not an enforcement layer.
 
 ## Destination Selection
@@ -26,6 +26,29 @@ Before writing files, determine which adoption target is intended:
 - local-only folder
 
 If the destination is ambiguous, stop and ask which target to use.
+
+## Destination Outcomes
+
+For a work-local playbook repository, the destination itself becomes the
+playbook. Create repository-level content directly in the destination. Do not
+create a top-level `.ai-workflow/` directory.
+
+Expected playbook-repository structure should resemble:
+
+- `README.md`
+- `docs/`
+- `prompts/`
+- `templates/`
+
+Adjust that structure only when local context shows a better lightweight shape.
+
+For an existing project repository, create local workflow scaffolding under
+`.ai-workflow/`. This is the only destination type that should receive a
+top-level `.ai-workflow/` directory by default.
+
+For a local-only folder, determine whether the folder represents a future
+playbook repository or project-local workflow scaffolding before creating
+files. If that intent is ambiguous, stop and ask.
 
 Before writing files:
 
@@ -41,10 +64,11 @@ Before writing files:
 5. Do not assume administrator rights.
 6. Do not assume solo-operator governance.
 
-For an existing playbook repository, create or update only lightweight adoption
-scaffold that points workplace AI tools to canonical playbook docs. Retain a
-reference to `distributions/starter/prompts/upstream-refresh.md` for periodic
-upstream review.
+For an existing playbook repository, create or update only lightweight
+repository-level content that points workplace AI tools to canonical playbook
+docs. Retain a reference to
+`distributions/starter/prompts/upstream-refresh.md` for periodic upstream
+review.
 
 For a new playbook repository, create the repository when tooling, user-provided
 repository details, and permissions allow. If repository creation is
@@ -52,17 +76,18 @@ unavailable, provide explicit repository creation instructions and stop before
 making assumptions. Include a reference to
 `distributions/starter/prompts/upstream-refresh.md` for future upstream review.
 
-For an existing project repository, create or update only local workflow
-scaffold files under `.ai-workflow/`. Recommended files:
+For an existing project repository, create or update only project-local
+workflow scaffold files under `.ai-workflow/`. Recommended files:
 
 - `.ai-workflow/repo-notes.md`
 - `.ai-workflow/review-packet-template.md`
 - `.ai-workflow/AGENTS.template.md` when useful
 
-For a local-only destination, create the selected scaffold files locally and
-report the path.
+For a local-only future playbook repository, create repository-level content
+directly in the selected folder. For a local-only project scaffold, create the
+selected scaffold files under `.ai-workflow/` and report the path.
 
-The repo notes should capture:
+Project repo notes should capture:
 
 - repository purpose and main technologies, based on inspected sources
 - canonical local setup and validation commands, if discoverable
@@ -119,7 +144,8 @@ user-provided repository details, and permissions allow. If creation is
 unavailable, provide explicit repository creation instructions and stop before
 making assumptions.
 
-For a local-only destination, create files locally and report the path.
+For a local-only destination, create files locally using the selected
+playbook-repository or project-scaffold structure and report the path.
 
 When finished, report:
 

--- a/distributions/starter/prompts/use-this-starter.md
+++ b/distributions/starter/prompts/use-this-starter.md
@@ -16,7 +16,7 @@ bootstrap prompt instead.
 Destination:
 - Type: [existing GitHub/GitHub Enterprise playbook repository | new GitHub/GitHub Enterprise playbook repository | existing project repository requiring .ai-workflow/ scaffolding | local-only folder]
 - Repository or folder: [URL, owner/name, or path]
-- Constraints: [team process, local-only pass, unavailable PR tooling, or none]
+- Constraints: [team process, local-only future playbook repo, local-only project scaffold, unavailable PR tooling, or none]
 
 If the destination is ambiguous, stop and ask which target to use.
 ```


### PR DESCRIPTION
## Summary

- Update the starter bootstrap prompt to explicitly separate work-local playbook repositories from project-repository `.ai-workflow/` scaffolds.
- Clarify README, onboarding, manifest, and launcher wording so playbook repositories receive repository-level content directly in the destination.
- Keep the upstream refresh workflow, advisory posture, canonical doctrine ownership, and governance/enforcement boundaries unchanged.

## Root cause of the ambiguity

The starter had grown to support multiple destination types, but the bootstrap prompt still used broad scaffold language and `.ai-workflow/` examples close enough to the general destination flow that a future playbook repository could be treated like a project repository. In real usage, that led to nested `.ai-workflow/` output when the destination folder itself was intended to become the playbook.

## Updated destination behavior

- Work-local playbook repository: the destination itself becomes the playbook; create repository-level content such as `README.md`, `docs/`, `prompts/`, and `templates/`; do not create a top-level `.ai-workflow/` directory.
- Existing project repository: create project-local workflow scaffolding under `.ai-workflow/`.
- Local-only folder: determine whether it is a future playbook repository or project-local scaffold before creating files; if ambiguous, stop and ask.

## Validation

- `make check` passed.
  - `markdownlint-cli2 "**/*.md"`: 0 errors across 42 Markdown files.
  - `python3 -m unittest discover -s tests`: 13 tests passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git merge-tree --write-tree HEAD origin/main` completed without conflicts.

## Review focus

- Is the playbook-repository path now clearly separated from the project-repository path?
- Is `.ai-workflow/` correctly limited to project-local adoption?
- Would a first-time user avoid creating a nested playbook by mistake?