### PR TITLE
Clarify work-local playbook authority

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -21,6 +21,11 @@ Use this package when the intended first step is a work-local AI Workflow
 Playbook repository hosted on GitHub or GitHub Enterprise. That repository
 becomes the canonical location referenced by workplace AI tools.
 
+After creation, the work-local playbook is the daily authority for its
+environment. Its local `docs/start-here.md` is the entrypoint for users and
+tools. Upstream `ctrl-alt-keith/ai-workflow-playbook` remains the provenance
+and refresh source.
+
 Repo-local `.ai-workflow/` scaffolds remain useful when a project repository
 needs local adoption notes. Local-only folders are a fallback for
 experimentation before publishing anything.
@@ -74,6 +79,10 @@ or escalate them.
 
 This is not synchronization, enforcement, or automatic promotion. Local
 ownership and workplace context control the final decision.
+
+Model:
+
+`upstream playbook -> refresh/adapt -> work-local playbook -> work/project repos`
 
 ## Contents
 

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -49,6 +49,20 @@ repositories should retain a reference to the upstream refresh prompt for
 periodic review. The destination itself is the playbook repository, so starter
 content belongs at repository level rather than under `.ai-workflow/`.
 
+Expected work-local playbook skeleton:
+
+- `README.md`
+- `docs/start-here.md`
+- `docs/source-first-retrieval.md`
+- `docs/repo-readiness.md`
+- `docs/review-packet.md`
+- `prompts/upstream-refresh.md`
+- `templates/AGENTS.template.md`
+- `templates/review-packet-template.md`
+
+Local `docs/start-here.md` is the canonical entrypoint for that environment.
+Upstream provides source material and future improvements to review and adapt.
+
 Secondary project-repository adoption can create advisory local files under
 the target repository's `.ai-workflow/` directory, such as:
 

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -5,9 +5,9 @@
 Adopt the playbook through a work-local AI Workflow Playbook repository that
 workplace AI tools can reference as the canonical guidance source.
 
-Canonical workflow guidance stays in [`../../docs/`](../../docs/). This
-distribution helps a team point to that guidance from local working files; it
-does not replace it.
+The generated work-local playbook becomes the canonical starting point for that
+environment. Upstream `ctrl-alt-keith/ai-workflow-playbook` remains provenance
+and refresh source material.
 
 ## Adoption Path
 
@@ -39,12 +39,23 @@ does not replace it.
 ## First-Pass Outputs
 
 For a hosted playbook repository, the bootstrap prompt should create a small,
-reviewable branch that points workplace AI tools to canonical playbook docs and
-captures adoption notes or templates without duplicating doctrine. It should
-also retain a reference to
+reviewable branch that points workplace AI tools to local `docs/start-here.md`
+and captures adapted docs, prompts, and templates without duplicating upstream
+doctrine. It should also retain a reference to
 [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md) for future
 upstream review. This content belongs directly at the repository level; do not
 wrap it in `.ai-workflow/`.
+
+Minimum work-local playbook skeleton:
+
+- `README.md`
+- `docs/start-here.md`
+- `docs/source-first-retrieval.md`
+- `docs/repo-readiness.md`
+- `docs/review-packet.md`
+- `prompts/upstream-refresh.md`
+- `templates/AGENTS.template.md`
+- `templates/review-packet-template.md`
 
 For a project repository, the bootstrap prompt may create local workflow
 scaffolding such as:

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -12,9 +12,11 @@ work-local AI Workflow Playbook repository hosted on GitHub or GitHub
 Enterprise. Repo-local `.ai-workflow/` scaffolds are a secondary path for
 project repositories, and local-only folders are a fallback for experimentation.
 
-Canonical workflow guidance remains in the playbook `docs/` directory. Treat
-this starter output as advisory adoption support, not a fork of the playbook
-and not an enforcement layer.
+For a generated work-local playbook repository, local `docs/start-here.md`
+becomes the canonical starting point for that environment. Upstream
+`ctrl-alt-keith/ai-workflow-playbook` is the provenance and refresh source, not
+the day-to-day authority. Treat this starter output as advisory adoption
+support, not an enforcement layer.
 
 ## Destination Selection
 
@@ -36,11 +38,17 @@ create a top-level `.ai-workflow/` directory.
 Expected playbook-repository structure should resemble:
 
 - `README.md`
-- `docs/`
-- `prompts/`
-- `templates/`
+- `docs/start-here.md`
+- `docs/source-first-retrieval.md`
+- `docs/repo-readiness.md`
+- `docs/review-packet.md`
+- `prompts/upstream-refresh.md`
+- `templates/AGENTS.template.md`
+- `templates/review-packet-template.md`
 
 Adjust that structure only when local context shows a better lightweight shape.
+Keep the content lightweight and adapted to the environment; do not wholesale
+copy upstream doctrine.
 
 For an existing project repository, create local workflow scaffolding under
 `.ai-workflow/`. This is the only destination type that should receive a
@@ -65,16 +73,16 @@ Before writing files:
 6. Do not assume solo-operator governance.
 
 For an existing playbook repository, create or update only lightweight
-repository-level content that points workplace AI tools to canonical playbook
-docs. Retain a reference to
-`distributions/starter/prompts/upstream-refresh.md` for periodic upstream
-review.
+repository-level content that points workplace AI tools to local
+`docs/start-here.md`. Retain a reference to `prompts/upstream-refresh.md` for
+periodic upstream review.
 
 For a new playbook repository, create the repository when tooling, user-provided
 repository details, and permissions allow. If repository creation is
 unavailable, provide explicit repository creation instructions and stop before
-making assumptions. Include a reference to
-`distributions/starter/prompts/upstream-refresh.md` for future upstream review.
+making assumptions. Include local `docs/start-here.md` as the environment's
+canonical starting point and `prompts/upstream-refresh.md` for future upstream
+review.
 
 For an existing project repository, create or update only project-local
 workflow scaffold files under `.ai-workflow/`. Recommended files:
@@ -87,6 +95,20 @@ For a local-only future playbook repository, create repository-level content
 directly in the selected folder. For a local-only project scaffold, create the
 selected scaffold files under `.ai-workflow/` and report the path.
 
+Work-local playbook repository content should include:
+
+- a `README.md` that tells users and tools to start with local
+  `docs/start-here.md`
+- a lightweight local `docs/start-here.md` that identifies this repository as
+  the environment's canonical playbook entrypoint
+- lightweight local docs for source-first retrieval, repo readiness, and review
+  packets, adapted to local context
+- `prompts/upstream-refresh.md`, describing upstream as source material and
+  future improvements to review, not blindly sync
+- `templates/AGENTS.template.md`, pointing adopters to local
+  `docs/start-here.md`
+- `templates/review-packet-template.md`
+
 Project repo notes should capture:
 
 - repository purpose and main technologies, based on inspected sources
@@ -94,12 +116,11 @@ Project repo notes should capture:
 - current review or contribution process, if documented
 - source-first retrieval reminders for this repository
 - known unknowns where source evidence was not available
-- links back to canonical playbook docs:
-  - `docs/start-here.md`
-  - `docs/source-first-retrieval.md`
-  - `docs/repo-readiness.md`
-  - `docs/engineering-baseline.md`
-  - `docs/review-packet.md`
+- links to the local playbook's canonical docs:
+  - `[local-playbook]/docs/start-here.md`
+  - `[local-playbook]/docs/source-first-retrieval.md`
+  - `[local-playbook]/docs/repo-readiness.md`
+  - `[local-playbook]/docs/review-packet.md`
 
 The review packet template should help contributors report:
 

--- a/distributions/starter/templates/AGENTS.template.md
+++ b/distributions/starter/templates/AGENTS.template.md
@@ -6,18 +6,19 @@ team explicitly requests that change.
 
 ## Canonical Guidance
 
-This repository uses the AI Workflow Playbook as the canonical source for
-reusable workflow guidance. Repo-local instructions describe only this
-repository's execution details, such as setup, validation, branch conventions,
-and team process.
+This repository uses the local AI Workflow Playbook as the canonical source for
+reusable workflow guidance in this environment. Repo-local instructions
+describe only this repository's execution details, such as setup, validation,
+branch conventions, and team process.
 
-Recommended canonical entry points:
+Recommended canonical entry points are local to the generated playbook
+repository. When installing this template into a project repository, replace
+`docs/` paths with the URL or path to the local playbook repository.
 
-- `[playbook]/docs/start-here.md`
-- `[playbook]/docs/source-first-retrieval.md`
-- `[playbook]/docs/repo-readiness.md`
-- `[playbook]/docs/engineering-baseline.md`
-- `[playbook]/docs/review-packet.md`
+- `docs/start-here.md`
+- `docs/source-first-retrieval.md`
+- `docs/repo-readiness.md`
+- `docs/review-packet.md`
 
 ## Repository Startup
 

--- a/distributions/starter/templates/repo-notes-template.md
+++ b/distributions/starter/templates/repo-notes-template.md
@@ -3,13 +3,12 @@
 Use this file for local adoption notes under `.ai-workflow/`. Keep it factual,
 source-grounded, and advisory.
 
-Canonical workflow guidance remains in the playbook `docs/` directory:
+Canonical workflow guidance for this environment starts in the local playbook:
 
-- `[playbook]/docs/start-here.md`
-- `[playbook]/docs/source-first-retrieval.md`
-- `[playbook]/docs/repo-readiness.md`
-- `[playbook]/docs/engineering-baseline.md`
-- `[playbook]/docs/review-packet.md`
+- `[local-playbook]/docs/start-here.md`
+- `[local-playbook]/docs/source-first-retrieval.md`
+- `[local-playbook]/docs/repo-readiness.md`
+- `[local-playbook]/docs/review-packet.md`
 
 ## Repository Purpose
 

--- a/distributions/starter/templates/review-packet-template.md
+++ b/distributions/starter/templates/review-packet-template.md
@@ -1,7 +1,8 @@
 # Review Packet Template
 
 Use this template to make human review faster and more grounded. Canonical
-review packet guidance remains in `[playbook]/docs/review-packet.md`.
+review packet guidance for this environment starts in
+`[local-playbook]/docs/review-packet.md`.
 
 ## Objective
 


### PR DESCRIPTION
## Summary

- Update the starter bootstrap prompt so generated work-local playbook repositories create a minimum self-contained local skeleton.
- Clarify that local `docs/start-here.md` is the canonical starting point for that environment, while upstream `ctrl-alt-keith/ai-workflow-playbook` is provenance and refresh source only.
- Update starter README, onboarding, manifest, and templates so generated local playbooks direct day-to-day users and tools to local docs instead of upstream docs.

## Root cause / authority-model issue

The starter correctly separated work-local playbook repositories from project-repository `.ai-workflow/` scaffolds, but the generated playbook model could still be too thin and point daily users back to upstream docs. That blurred authority: upstream should provide source material and future improvements to review, while the generated work-local playbook owns environment-specific guidance.

## Updated generated playbook behavior

- Work-local playbook repositories should include a lightweight local skeleton:
  - `README.md`
  - `docs/start-here.md`
  - `docs/source-first-retrieval.md`
  - `docs/repo-readiness.md`
  - `docs/review-packet.md`
  - `prompts/upstream-refresh.md`
  - `templates/AGENTS.template.md`
  - `templates/review-packet-template.md`
- Local `README.md` should tell users and tools to start with local `docs/start-here.md`.
- Local `templates/AGENTS.template.md` should point to local `docs/start-here.md` when stored in the generated playbook repository.
- Upstream remains the provenance and refresh source; refresh reviews upstream changes and adapts them, without blind sync.

## Validation

- `make check` passed.
  - `markdownlint-cli2 "**/*.md"`: 0 errors across 42 Markdown files.
  - `python3 -m unittest discover -s tests`: 13 tests passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git merge-tree --write-tree HEAD origin/main` completed without conflicts.

## Review focus

- Does the starter now make the work-local playbook self-contained enough to be useful?
- Does it correctly point day-to-day users/tools to local `docs/start-here.md`?
- Does it keep upstream as provenance/refresh source instead of daily authority?
- Does it avoid copying too much doctrine?