### PR TITLE
Clarify starter upstream source location

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -23,8 +23,8 @@ becomes the canonical location referenced by workplace AI tools.
 
 After creation, the work-local playbook is the daily authority for its
 environment. Its local `docs/start-here.md` is the entrypoint for users and
-tools. Upstream `ctrl-alt-keith/ai-workflow-playbook` remains the provenance
-and refresh source.
+tools. Upstream `https://github.com/ctrl-alt-keith/ai-workflow-playbook`
+remains the provenance and refresh source.
 
 Repo-local `.ai-workflow/` scaffolds remain useful when a project repository
 needs local adoption notes. Local-only folders are a fallback for
@@ -74,8 +74,12 @@ the full implementation prompt.
 Work-local playbook repositories should retain a reference to
 [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md). Use it
 periodically to review upstream changes from
-`ctrl-alt-keith/ai-workflow-playbook` and decide whether to adopt, adapt, skip,
-or escalate them.
+`https://github.com/ctrl-alt-keith/ai-workflow-playbook` and decide whether to
+adopt, adapt, skip, or escalate them.
+
+The local work playbook may live on GitHub Enterprise, GitHub.com, or another
+host. The upstream source may live on a different host. Use the fully qualified
+upstream URL; do not infer upstream from the local repository host.
 
 This is not synchronization, enforcement, or automatic promotion. Local
 ownership and workplace context control the final decision.

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -61,7 +61,10 @@ Expected work-local playbook skeleton:
 - `templates/review-packet-template.md`
 
 Local `docs/start-here.md` is the canonical entrypoint for that environment.
-Upstream provides source material and future improvements to review and adapt.
+The fully qualified upstream source,
+`https://github.com/ctrl-alt-keith/ai-workflow-playbook`, provides source
+material and future improvements to review and adapt. The local playbook and
+upstream source may live on different repository hosts.
 
 Secondary project-repository adoption can create advisory local files under
 the target repository's `.ai-workflow/` directory, such as:

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -6,8 +6,8 @@ Adopt the playbook through a work-local AI Workflow Playbook repository that
 workplace AI tools can reference as the canonical guidance source.
 
 The generated work-local playbook becomes the canonical starting point for that
-environment. Upstream `ctrl-alt-keith/ai-workflow-playbook` remains provenance
-and refresh source material.
+environment. Upstream `https://github.com/ctrl-alt-keith/ai-workflow-playbook`
+remains provenance and refresh source material.
 
 ## Adoption Path
 
@@ -76,8 +76,13 @@ repository-level playbook content. If it is a project-local scaffold, use
 ## Ongoing Upstream Review
 
 Use [`prompts/upstream-refresh.md`](prompts/upstream-refresh.md) periodically to
-compare the local playbook with upstream `ctrl-alt-keith/ai-workflow-playbook`.
-The goal is to review and decide, not synchronize.
+compare the local playbook with upstream
+`https://github.com/ctrl-alt-keith/ai-workflow-playbook`. The goal is to review
+and decide, not synchronize.
+
+The local playbook and upstream source do not need to share a repository host.
+Resolve upstream from the explicit URL, and ask for an alternate source if that
+URL is unavailable.
 
 Classify candidate changes as adopt now, adapt with edits, not applicable, or
 human decision required. Preserve local ownership and workplace context.

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -14,9 +14,10 @@ project repositories, and local-only folders are a fallback for experimentation.
 
 For a generated work-local playbook repository, local `docs/start-here.md`
 becomes the canonical starting point for that environment. Upstream
-`ctrl-alt-keith/ai-workflow-playbook` is the provenance and refresh source, not
-the day-to-day authority. Treat this starter output as advisory adoption
-support, not an enforcement layer.
+`https://github.com/ctrl-alt-keith/ai-workflow-playbook` is the provenance and
+refresh source, not the day-to-day authority. The local playbook and upstream
+source may live on different repository hosts. Treat this starter output as
+advisory adoption support, not an enforcement layer.
 
 ## Destination Selection
 
@@ -104,7 +105,8 @@ Work-local playbook repository content should include:
 - lightweight local docs for source-first retrieval, repo readiness, and review
   packets, adapted to local context
 - `prompts/upstream-refresh.md`, describing upstream as source material and
-  future improvements to review, not blindly sync
+  future improvements to review from
+  `https://github.com/ctrl-alt-keith/ai-workflow-playbook`, not blindly sync
 - `templates/AGENTS.template.md`, pointing adopters to local
   `docs/start-here.md`
 - `templates/review-packet-template.md`

--- a/distributions/starter/prompts/upstream-refresh.md
+++ b/distributions/starter/prompts/upstream-refresh.md
@@ -2,7 +2,7 @@
 
 Use this prompt in a work-local or organization-local AI Workflow Playbook
 repository when you want to review upstream changes from
-`ctrl-alt-keith/ai-workflow-playbook`.
+`https://github.com/ctrl-alt-keith/ai-workflow-playbook`.
 
 ## Prompt
 
@@ -19,18 +19,29 @@ differs.
 ## Inputs
 
 - Local playbook repository: `[local repository URL, owner/name, or path]`
-- Upstream repository: `ctrl-alt-keith/ai-workflow-playbook`
+- Upstream source: `https://github.com/ctrl-alt-keith/ai-workflow-playbook`
 - Review range or period: `[since last refresh, date range, commit range, or recent merged PRs]`
 - Requested output: `[review report only | implement recommended updates]`
 
 If the local repository, upstream source, or review range is ambiguous, stop
 and ask for the missing target.
 
+## Host Separation
+
+Repository identity and repository host are separate. The local playbook
+repository may live on GitHub Enterprise, GitHub.com, or another accessible
+repository host. The upstream source may live on a different host.
+
+Do not assume the upstream repository exists on the same Git host as the local
+repository. Resolve the upstream source from its fully qualified repository URL.
+If the upstream source cannot be reached, stop and ask for an alternate source
+location.
+
 ## Review Process
 
 1. Inspect the local playbook repository, including its README, local adoption
    notes, templates, prompts, and any local `AGENTS.md`.
-2. Inspect upstream `ctrl-alt-keith/ai-workflow-playbook`.
+2. Inspect upstream `https://github.com/ctrl-alt-keith/ai-workflow-playbook`.
 3. Review relevant canonical upstream docs, especially:
    - `docs/start-here.md`
    - `docs/source-first-retrieval.md`


### PR DESCRIPTION
## Summary

- Update the starter upstream refresh workflow to use the fully qualified upstream source `https://github.com/ctrl-alt-keith/ai-workflow-playbook`.
- Clarify that local playbook repositories may live on GitHub Enterprise, GitHub.com, or another accessible host while upstream may live elsewhere.
- Update README, onboarding, manifest, and bootstrap references so upstream is resolved from an explicit URL instead of an owner/name shorthand.

## Root cause of the source-location ambiguity

The refresh prompt used `ctrl-alt-keith/ai-workflow-playbook` as the upstream identifier. Inside GitHub Enterprise contexts, agents can interpret that shorthand relative to the current enterprise host rather than GitHub.com, causing them to inspect the wrong repository or fail to find upstream.

## Updated upstream-source behavior

- The upstream refresh prompt now separates `Local playbook repository` from `Upstream source`.
- The upstream source is a fully qualified repository URL: `https://github.com/ctrl-alt-keith/ai-workflow-playbook`.
- The prompt explicitly says not to assume upstream exists on the same Git host as the local repository.
- If the upstream source cannot be reached, the workflow stops and asks for an alternate source location.

## Validation

- `make check` passed.
  - `markdownlint-cli2 "**/*.md"`: 0 errors across 42 Markdown files.
  - `python3 -m unittest discover -s tests`: 13 tests passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `git merge-tree --write-tree HEAD origin/main` completed without conflicts.

## Review focus

- Is the upstream source now unambiguous?
- Would a GitHub Enterprise user correctly resolve the GitHub.com upstream repository?
- Does the workflow properly separate repository identity from repository location?
- Does the guidance remain host-agnostic?