### PR TITLE
Clarify worktree ignore bootstrap baseline

### DIFF
--- a/docs/new-repo-bootstrap.md
+++ b/docs/new-repo-bootstrap.md
@@ -67,10 +67,22 @@ create locally. Keep this intentionally narrow: include repo-local workflow path
 such as `.worktrees/`, and avoid expanding bootstrap into generic workstation,
 editor, runtime, or temporary-file policy.
 
+The starter baseline is intentionally concrete:
+
+```gitignore
+.worktrees/
+```
+
 Dirty-tree safety checks depend on this baseline. If standardized local workflow
 artifacts appear as untracked files, conservative automation should skip rather
 than mutate the repository, but the repo has lost the predictable clean state the
 workflow expects.
+
+For existing repositories, the doctrine-consistent enforcement home is
+`ai-workflow-enforcement`: add a local-source advisory check that reports a
+missing root `.gitignore` `.worktrees/` rule for repositories that follow the
+repo-local worktree baseline. Keep the playbook as the rule source, and avoid
+copying this as repo-local policy except for repository-specific exceptions.
 
 ### Positioning, Scope, And Architecture
 


### PR DESCRIPTION
## Summary

- make the new-repo bootstrap `.worktrees/` ignore baseline explicit
- document `ai-workflow-enforcement` as the doctrine-consistent home for a future local-source advisory check

## Rationale

`docs/new-repo-bootstrap.md` already said new repositories should include a narrow local workflow artifact ignore baseline and named `.worktrees/`. This clarifies the exact `.gitignore` rule and keeps enforcement guidance centralized instead of copying policy into repo-local `AGENTS.md` files.

## Recommendation

Add a small `ai-workflow-enforcement` local-source advisory check that reports repositories following the repo-local worktree baseline when their root `.gitignore` does not include `.worktrees/`. Keep it advisory at first so existing repositories can be cleaned up without blocking unrelated work.

## Validation

- `make check`
