### PR TITLE
Clarify playbook instruction hierarchy

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -47,11 +47,20 @@ posture, compliance notes, and other local execution constraints. When
 repo-local instructions intentionally disable, narrow, or replace a global
 default, follow the repo-local rule for that repository.
 
-Before selecting a workflow, identify the repository or workspace's primary
-purpose: documentation, research, planning, leadership, knowledge management,
-experimentation, enforcement, tooling, implementation, or a mix of those
-surfaces. Then choose the appropriate validation, review, inspection, Git, PR,
-or non-Git workflow from repo-local policy and the task type.
+Before selecting a workflow, distinguish repository or workspace purpose from
+interaction mode. Purpose describes what kind of workspace this is:
+implementation, documentation, research, planning, leadership, knowledge
+management, experimentation, enforcement, tooling, or a mix of those surfaces.
+Interaction mode describes what kind of work the agent is doing there:
+implementing, reviewing, auditing, planning, advising, orchestrating, or
+authoring prompts.
+
+Purpose and mode are related, but they are not the same. A documentation
+repository can have a review or audit task. An implementation repository can
+have a planning task. A leadership workspace can have a prompt-authoring task.
+A tooling repository can have an implementation task. Use both purpose and
+mode to choose the appropriate validation, review, inspection, Git, PR, or
+non-Git workflow from repo-local policy and the interaction mode.
 
 If instructions appear to conflict, resolve them by authority and specificity:
 use the narrowest applicable instruction from the strongest source. If the
@@ -78,16 +87,17 @@ changed?" or "what should we do next?" requests:
 2. Read the target repository's repo-local `AGENTS.md`.
 3. Apply the matching executor adapter. Codex runs must apply
    `docs/tool-adapters/codex.md`.
-4. Identify the repository or workspace's primary purpose and task type.
+4. Identify the repository or workspace's primary purpose.
 5. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.
-6. Identify the canonical source for the rule, behavior, or state being used.
-7. For policy-sensitive changes, apply the repo-family alignment check in
+6. Use the purpose and mode to choose the appropriate workflow path.
+7. Identify the canonical source for the rule, behavior, or state being used.
+8. For policy-sensitive changes, apply the repo-family alignment check in
    `docs/repo-readiness.md`.
-8. Confirm command form and execution settings for planned repository commands,
+9. Confirm command form and execution settings for planned repository commands,
    if commands are needed.
-9. Identify the repository's canonical validation, review, or inspection path.
-10. Act only after those checks are clear, or report the blocker, uncertainty,
+10. Identify the repository's canonical validation, review, or inspection path.
+11. Act only after those checks are clear, or report the blocker, uncertainty,
    or missing context.
 
 ## Required Core Invariants

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -27,11 +27,46 @@ acting.
   expectations
 - `docs/prompts.md` -> reusable prompt templates
 
-## Startup Contract
+## Instruction Hierarchy
 
-Before repository or software work, including read-only review, audit,
-advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
-"what changed?" or "what should we do next?" requests:
+Repository work combines reusable workflow guidance with local execution
+policy. Apply instructions in this order when they overlap:
+
+1. The human's explicit task, plus any tool, safety, environment, or access
+   constraints that govern the current run.
+2. The target repository's repo-local `AGENTS.md` and other repo-local policy
+   for repository-specific execution details.
+3. The matching executor adapter, such as `docs/tool-adapters/codex.md` for
+   Codex-specific behavior.
+4. The shared playbook docs as global workflow defaults and reusable operating
+   guidance.
+
+Repo-local instructions own repository-specific policy: allowed tools, Git
+usage, validation path, file placement, release posture, compliance notes, and
+other local execution constraints. When repo-local instructions intentionally
+disable, narrow, or replace a global default, follow the repo-local rule for
+that repository.
+
+If instructions appear to conflict, resolve them by authority and specificity:
+use the narrowest applicable instruction from the strongest source. If the
+conflict cannot be resolved safely from the available sources, stop and report
+the conflict instead of silently choosing a side. Do not edit repo-local
+`AGENTS.md` merely to reconcile the conflict unless that edit is explicitly in
+scope.
+
+When following repo-local policy causes a significant deviation from the normal
+playbook workflow, explain it briefly. Significant deviations include skipping
+Git or PR workflow, using inspection-based validation, avoiding a normal
+validation command, changing worktree or branch behavior, or treating a
+repository as documentation, research, planning, leadership, or other non-code
+work rather than implementation code.
+
+## Required Startup Contract
+
+Before repository-scoped work, including code, documentation, research,
+planning, leadership, read-only review, audit, advisory,
+architecture/workflow analysis, PR/issue/branch recommendations, and "what
+changed?" or "what should we do next?" requests:
 
 1. Read this page.
 2. Read the target repository's repo-local `AGENTS.md`.
@@ -42,16 +77,17 @@ advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
 5. Identify the canonical source for the rule, behavior, or state being used.
 6. For policy-sensitive changes, apply the repo-family alignment check in
    `docs/repo-readiness.md`.
-7. Confirm command form and execution settings for planned repository commands.
-8. Identify the repository's canonical validation path.
+7. Confirm command form and execution settings for planned repository commands,
+   if commands are needed.
+8. Identify the repository's canonical validation, review, or inspection path.
 9. Act only after those checks are clear, or report the blocker, uncertainty,
    or missing context.
 
-## Core Invariants
+## Required Core Invariants
 
 - `ai-workflow-playbook` is the canonical source for reusable workflow rules.
-- `AGENTS.md` is the repo-local execution layer; repo-local rules take
-  precedence only for repo-specific behavior.
+- `AGENTS.md` is the repo-local execution layer. Repo-local rules override
+  shared playbook defaults for repo-specific behavior.
 - Playbook changes and `AGENTS.md` edits are separate work types. Edit
   `AGENTS.md` only with explicit authorization or when the task's primary
   purpose is an `AGENTS.md` update, rollout, or enforcement.
@@ -78,14 +114,19 @@ advisory, architecture/workflow analysis, PR/issue/branch recommendations, and
   are noncanonical unless a durable rule is explicitly promoted into the
   playbook.
 
-## Rule of Thumb
+## Defaults And Recommendations
 
 - Prefer small, scoped changes.
 - Keep changes in the target repository, branch, and worktree.
 - Follow `docs/repo-readiness.md` for implementation isolation, governance
   operating model, command form, interaction mode, validation, and PR readiness.
+- Treat Git, branch, worktree, validation, and PR guidance as implementation
+  defaults when the repository's policy and task type support them; do not
+  force those workflows onto repositories that intentionally use another
+  operating model.
 - Use `docs/orchestration-and-parallelism.md` before splitting a task across
   workers or parallel PR lanes.
 - Use `docs/multi-agent-synthesis.md` before treating independent agent outputs
   as promotion, planning, or implementation evidence.
-- Open PRs ready for review by default unless explicitly instructed otherwise.
+- Open PRs ready for review by default when repo-local guidance calls for PR
+  delivery and validation is complete.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -41,11 +41,17 @@ policy. Apply instructions in this order when they overlap:
 4. The shared playbook docs as global workflow defaults and reusable operating
    guidance.
 
-Repo-local instructions own repository-specific policy: allowed tools, Git
-usage, validation path, file placement, release posture, compliance notes, and
-other local execution constraints. When repo-local instructions intentionally
-disable, narrow, or replace a global default, follow the repo-local rule for
-that repository.
+Repo-local instructions are the authoritative source for repository-specific
+policy: allowed tools, Git usage, validation path, file placement, release
+posture, compliance notes, and other local execution constraints. When
+repo-local instructions intentionally disable, narrow, or replace a global
+default, follow the repo-local rule for that repository.
+
+Before selecting a workflow, identify the repository or workspace's primary
+purpose: documentation, research, planning, leadership, knowledge management,
+experimentation, enforcement, tooling, implementation, or a mix of those
+surfaces. Then choose the appropriate validation, review, inspection, Git, PR,
+or non-Git workflow from repo-local policy and the task type.
 
 If instructions appear to conflict, resolve them by authority and specificity:
 use the narrowest applicable instruction from the strongest source. If the
@@ -72,15 +78,16 @@ changed?" or "what should we do next?" requests:
 2. Read the target repository's repo-local `AGENTS.md`.
 3. Apply the matching executor adapter. Codex runs must apply
    `docs/tool-adapters/codex.md`.
-4. Select the interaction mode from `docs/repo-readiness.md`: implementation,
+4. Identify the repository or workspace's primary purpose and task type.
+5. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.
-5. Identify the canonical source for the rule, behavior, or state being used.
-6. For policy-sensitive changes, apply the repo-family alignment check in
+6. Identify the canonical source for the rule, behavior, or state being used.
+7. For policy-sensitive changes, apply the repo-family alignment check in
    `docs/repo-readiness.md`.
-7. Confirm command form and execution settings for planned repository commands,
+8. Confirm command form and execution settings for planned repository commands,
    if commands are needed.
-8. Identify the repository's canonical validation, review, or inspection path.
-9. Act only after those checks are clear, or report the blocker, uncertainty,
+9. Identify the repository's canonical validation, review, or inspection path.
+10. Act only after those checks are clear, or report the blocker, uncertainty,
    or missing context.
 
 ## Required Core Invariants


### PR DESCRIPTION
## Summary

- Add an explicit instruction hierarchy to `docs/start-here.md` that distinguishes global playbook defaults from repo-local execution policy.
- Clarify that repo-local instructions override shared defaults for repository-specific behavior and describe how agents should resolve conflicts.
- Rename mandatory startup/core sections and move workflow heuristics under defaults and recommendations.
- Broaden startup language so documentation, research, planning, leadership, and other non-code repositories can use review or inspection paths instead of assuming Git/PR/software validation always applies.

## Rationale

This preserves the playbook's existing philosophy while making the authority model explicit for agents. In particular, it documents the observed behavior where a repository-local rule intentionally disabled Git usage and the agent correctly treated that local rule as stronger than the global Git/PR default.

This PR is ready for review rather than draft because repo-local guidance says isolated docs changes should default to ready after canonical validation passes.

## Validation

- `make check`
- `git diff --check`