### PR TITLE
[codex] Clarify repo onboarding automation checks

### DIFF
--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -34,6 +34,9 @@ uses a particular schedule, or currently contains a matching prompt.
   `ka-destinations`, `ai-workflow-playbook`, `ai-workflow-enforcement`,
   `ai-workflow-incubator`, `linode-image-lab`, `lke-image-lab`,
   `linode-backup-lab`, `nexus`, `trusted-network-registry`, and `.github`.
+  `leadership-workbench` is intentionally excluded because the repository is a
+  private, Markdown-only leadership workspace whose current policy does not
+  clearly opt it into mutating branch-cleanup automation.
 - Mode: Mutating only through the owning tool's explicit `--apply` path for
   Git-proven normal cleanup. Stale non-ancestor cleanup remains report-only
   unless explicit human-approved evidence exists in the companion config and
@@ -98,8 +101,8 @@ uses a particular schedule, or currently contains a matching prompt.
 - Automation name: 🔍 AGENTS Drift Detector
 - Automation ID: `agents-drift-detector`
 - Scope / target repositories: `ai-workflow-playbook`,
-  `ai-workflow-enforcement`, `ai-workflow-incubator`, `knowledge-adapters`,
-  `knowledge-vault`, `ka-destinations`, `linode-image-lab`,
+  `ai-workflow-enforcement`, `ai-workflow-incubator`, `leadership-workbench`,
+  `knowledge-adapters`, `knowledge-vault`, `ka-destinations`, `linode-image-lab`,
   `lke-image-lab`, `linode-backup-lab`, `nexus`,
   `trusted-network-registry`, and `.github`, plus the local-only workspace
   `AGENTS.md`.
@@ -127,13 +130,10 @@ uses a particular schedule, or currently contains a matching prompt.
 - Automation name: 🛡️ Workflow Drift Audit
 - Automation ID: `workflow-drift-audit`
 - Scope / target repositories: The `ctrl-alt-keith` workspace guidance and
-  workflow-policy surfaces covered by the enforcement drift scanner config:
-  `ai-workflow-incubator` notes roots, `ai-workflow-playbook/docs`, and the
-  configured organization repositories `.github`,
-  `ai-workflow-incubator`, `ai-workflow-playbook`,
-  `ai-workflow-enforcement`, `linode-image-lab`, `lke-image-lab`,
-  `linode-backup-lab`, `knowledge-adapters`, `knowledge-vault`,
-  `ka-destinations`, `nexus`, and `trusted-network-registry`.
+  workflow-policy surfaces covered by the enforcement drift scanner:
+  `ai-workflow-incubator` notes roots, `ai-workflow-playbook/docs`, and all
+  visible repositories in the `ctrl-alt-keith` GitHub organization, discovered
+  dynamically at runtime.
 - Mode: Report-only advisory scan.
 - Purpose / intent: Invoke the calibrated `ai-workflow-enforcement` drift
   scanner directly and report workflow-policy drift findings.
@@ -141,19 +141,18 @@ uses a particular schedule, or currently contains a matching prompt.
   automation config as runtime state, and generated reports as local-only.
   Do not auto-fix findings or duplicate scanner semantics in prompt text.
 - Canonical execution expectations: Work from the `ai-workflow-enforcement`
-  checkout. Verify the scanner config exists, inspect git status, skip if the
-  working tree would make results ambiguous, record the tested commit SHA, and
-  run `python3 -m enforcement.cli --config examples/drift-scan.json`.
+  checkout. Inspect git status, skip if the working tree would make results
+  ambiguous, record the tested commit SHA, verify `gh` organization access, and
+  run
+  `python3 -m enforcement.cli --notes-root ../ai-workflow-incubator --playbook-root ../ai-workflow-playbook/docs --workspace-root .. --organization ctrl-alt-keith --ignore 'archive/**'`.
   Do not fetch, pull, switch branches, commit, open PRs, modify files, delete
   worktrees, or delete branches.
-- Companion config references: `ai-workflow-enforcement/examples/drift-scan.json`
-  owns scanner roots, repository coverage, ignored paths, and scanner
-  calibration thresholds.
+- Companion config references: None. Repository scope comes from live GitHub
+  organization enumeration, not a local allowlist.
 - Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  and scanner config before comparison. Prompt drift includes mutating
-  repositories, treating advisory scanner findings as failures, changing
-  scanner scope in prompt text instead of the companion config, or creating a
-  secondary drift scanner.
+  before comparison. Prompt drift includes mutating repositories, treating
+  advisory scanner findings as failures, narrowing repository scope with a
+  local allowlist, or creating a secondary drift scanner.
 
 ### 🛡️ Repo Governance Audit
 

--- a/docs/repo-awareness-onboarding-refresh.md
+++ b/docs/repo-awareness-onboarding-refresh.md
@@ -101,6 +101,10 @@ Check at least these surfaces:
   auto-merge policy, and whether ready-for-review PR defaults still make sense
 - required CI and status checks: hosted checks that should be required, checks
   that are intentionally advisory, and checks that remain local-only
+- local automation coverage: active local automation configs, companion
+  allowlists, scheduled validation targets, skip conditions, and whether each
+  relevant surface should include the repository, intentionally exclude it, or
+  require a human decision
 - ownership and review routing: CODEOWNERS expectations, responsible maintainers
   or teams, and repo-local escalation notes where applicable
 - Actions and automation policy: default token permissions, workflow write
@@ -130,7 +134,9 @@ the owning source when a change is needed:
   without becoming canonical policy.
 - Automation allowlists and configuration: local Codex automations, enforcement
   configs, branch-cleanup coverage, drift-scan scope, scheduled validation
-  targets, and org scanners.
+  targets, and org scanners. Inspect active local automation configuration and
+  companion files; do not infer coverage from the filesystem or duplicate live
+  allowlists in playbook prose.
 - Org-level metadata and settings: repository visibility, description, topics,
   default branch, branch protection, required status checks, Actions policy,
   auto-merge policy, security features, Dependabot, installed apps, and access.


### PR DESCRIPTION
**Summary**
- Add a procedural local automation coverage checkpoint to the repo-awareness onboarding refresh.
- Update the maintenance automation registry to include `leadership-workbench` in AGENTS drift detector scope.
- Record Workflow Drift Audit scope as all visible `ctrl-alt-keith` repositories discovered dynamically at runtime.
- Record intentional exclusion for `leadership-workbench` from mutating branch cleanup.

**Local Automation Surface Updated**
- Live local Codex automation `~/.codex/automations/agents-drift-detector/automation.toml` was updated to include `ctrl-alt-keith/leadership-workbench` in read-only AGENTS/playbook drift coverage.
- Live local Codex automation `~/.codex/automations/workflow-drift-audit/automation.toml` now uses direct org enumeration for all visible `ctrl-alt-keith` repositories instead of a companion repository allowlist.
- Paired enforcement PR https://github.com/ctrl-alt-keith/ai-workflow-enforcement/pull/54 removes the explicit repository allowlist from `examples/drift-scan.json`.

**Why Included Or Excluded**
- Included in AGENTS drift coverage because `leadership-workbench` has repo-local execution guidance that should be checked against the playbook.
- Included in workflow-policy drift coverage automatically through visible organization enumeration.
- Excluded from branch cleanup because it is a private, Markdown-only leadership workspace and current policy does not clearly opt it into mutating branch-cleanup automation.

**Playbook Onboarding Language**
- Future repo-awareness/onboarding refreshes now explicitly check active local automation configs, companion allowlists, scheduled validation targets, skip conditions, and whether each relevant surface should include, exclude, or escalate the repository for human decision.
- Workflow Drift Audit guidance now says scope comes from live GitHub organization enumeration, not a local allowlist.

**Paired PRs**
- https://github.com/ctrl-alt-keith/leadership-workbench/pull/4
- https://github.com/ctrl-alt-keith/ai-workflow-enforcement/pull/54

**Validation**
- `make check` passed.
- `git diff --check` passed.
- Parsed `~/.codex/automations/agents-drift-detector/automation.toml` with Python tomllib and verified `ctrl-alt-keith/leadership-workbench` coverage text.
- Parsed `~/.codex/automations/workflow-drift-audit/automation.toml` and verified org enumeration is configured with no `examples/drift-scan.json` or `--organization-repository` dependency.
- Scanner smoke run from the stable automation root passed with org enumeration.
- Merge-tree check against current `origin/main` passed.

**Manual Follow-ups**
- None.