### PR TITLE
[codex] Add Codex preflight readiness script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
 - [`docs/maintenance-automations.md`](docs/maintenance-automations.md): reusable operating rules plus reference inventory notes for recurring Codex maintenance automation
+- [`docs/codex-preflight.md`](docs/codex-preflight.md): read-only local prerequisite check for Codex automation startup
 - [`docs/workstation-maintenance.md`](docs/workstation-maintenance.md): manual-only local workstation maintenance procedures, including Codex log cleanup
 - [`docs/prompts.md`](docs/prompts.md): reusable prompt templates, including the standard Codex task prompt format
 

--- a/docs/codex-preflight.md
+++ b/docs/codex-preflight.md
@@ -1,0 +1,39 @@
+# Codex Preflight
+
+## Purpose
+
+`scripts/codex-preflight` is a small read-only check for stale local/session
+prerequisites before Codex automation fan-out or real repository work begins.
+
+It verifies:
+
+- `ssh-add -l` can reach an agent
+- at least one SSH identity is loaded
+- GitHub SSH authentication succeeds with `ssh -T git@github.com`
+- `gh` is installed and authenticated
+- the playbook repository is reachable through `git ls-remote`
+
+The script does not install tools, mutate Git state, change credentials, push,
+commit, or update SSH configuration. SSH checks use batch mode and strict host
+key checking so a missing `known_hosts` entry fails instead of being added by
+the preflight.
+
+## Usage
+
+At the start of a Codex automation prompt, add a short preflight step before
+delegating workers or touching repositories:
+
+```text
+Before starting repository work, run:
+
+cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
+./scripts/codex-preflight
+
+If it exits non-zero, stop and report the failing check and remediation.
+```
+
+This catches common stale Monday-morning failures, such as an empty SSH agent or
+expired GitHub CLI session, while the task is still cheap to restart.
+
+Set `CODEX_PREFLIGHT_REPO_URL` only when checking a different GitHub repository
+with the same read-only pattern.

--- a/scripts/codex-preflight
+++ b/scripts/codex-preflight
@@ -1,0 +1,105 @@
+#!/usr/bin/env sh
+# Keep this script POSIX sh compatible; it is intended for prompt preflight use.
+
+set -u
+
+REPO_URL="${CODEX_PREFLIGHT_REPO_URL:-git@github.com:ctrl-alt-keith/ai-workflow-playbook.git}"
+SSH_TARGET="${CODEX_PREFLIGHT_GITHUB_SSH_TARGET:-git@github.com}"
+
+pass_check() {
+    printf 'PASS %s\n' "$1"
+}
+
+fail_check() {
+    printf 'FAIL %s\n' "$1"
+    printf '  Remediation: %s\n' "$2"
+    exit 1
+}
+
+require_command() {
+    command_name="$1"
+    remediation="$2"
+
+    if command -v "$command_name" >/dev/null 2>&1; then
+        pass_check "$command_name is installed"
+        return
+    fi
+
+    fail_check "$command_name is installed" "$remediation"
+}
+
+require_command "ssh-add" "Install OpenSSH client tools, then rerun this preflight."
+
+ssh_add_output="$(ssh-add -l 2>&1)"
+ssh_add_status="$?"
+
+if [ "$ssh_add_status" -eq 0 ]; then
+    pass_check "ssh-agent is reachable via ssh-add -l"
+    pass_check "at least one SSH identity is loaded"
+else
+    case "$ssh_add_output" in
+        *"The agent has no identities"*|*"no identities"*)
+            pass_check "ssh-agent is reachable via ssh-add -l"
+            fail_check \
+                "at least one SSH identity is loaded" \
+                "Load a private key into the existing agent with ssh-add /path/to/private/key, then rerun this preflight."
+            ;;
+        *)
+            fail_check \
+                "ssh-agent is reachable via ssh-add -l" \
+                "Start or reconnect to ssh-agent, export SSH_AUTH_SOCK if needed, then rerun ssh-add -l."
+            ;;
+    esac
+fi
+
+require_command "ssh" "Install OpenSSH client tools, then rerun this preflight."
+
+ssh_output="$(
+    ssh \
+        -T \
+        -o BatchMode=yes \
+        -o StrictHostKeyChecking=yes \
+        -o ConnectTimeout=15 \
+        "$SSH_TARGET" 2>&1
+)"
+ssh_status="$?"
+
+case "$ssh_output" in
+    *"successfully authenticated"*)
+        if [ "$ssh_status" -eq 0 ] || [ "$ssh_status" -eq 1 ]; then
+            pass_check "GitHub SSH connectivity works via ssh -T $SSH_TARGET"
+        else
+            fail_check \
+                "GitHub SSH connectivity works via ssh -T $SSH_TARGET" \
+                "Resolve SSH authentication for GitHub, then rerun ssh -T $SSH_TARGET."
+        fi
+        ;;
+    *)
+        fail_check \
+            "GitHub SSH connectivity works via ssh -T $SSH_TARGET" \
+            "Run ssh -T $SSH_TARGET and resolve the reported SSH auth or known_hosts issue; load a key with ssh-add if needed."
+        ;;
+esac
+
+require_command "gh" "Install GitHub CLI from https://cli.github.com/, then rerun this preflight."
+
+if gh auth status >/dev/null 2>&1; then
+    pass_check "gh auth status succeeds"
+else
+    fail_check \
+        "gh auth status succeeds" \
+        "Authenticate GitHub CLI with gh auth login, then rerun gh auth status."
+fi
+
+require_command "git" "Install Git, then rerun this preflight."
+
+if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15" \
+    git ls-remote --exit-code "$REPO_URL" HEAD >/dev/null 2>&1; then
+    pass_check "playbook repository is reachable with git ls-remote"
+else
+    fail_check \
+        "playbook repository is reachable with git ls-remote" \
+        "Confirm GitHub SSH access and repository permission, then rerun git ls-remote $REPO_URL HEAD."
+fi
+
+printf 'PASS Codex local automation preflight complete\n'

--- a/tests/test_codex_preflight.py
+++ b/tests/test_codex_preflight.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "codex-preflight"
+
+
+class CodexPreflightTest(unittest.TestCase):
+    def run_preflight(self, commands: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = Path(tmp)
+            for name, body in commands.items():
+                path = bin_dir / name
+                path.write_text("#!/bin/sh\n" + textwrap.dedent(body), encoding="utf-8")
+                path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            return subprocess.run(
+                [str(SCRIPT_PATH)],
+                check=False,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+    def fake_success_commands(self) -> dict[str, str]:
+        return {
+            "ssh-add": """
+                if [ "$1" = "-l" ]; then
+                    printf '%s\\n' '256 SHA256:test-key comment (ED25519)'
+                    exit 0
+                fi
+                exit 2
+            """,
+            "ssh": """
+                batch=0
+                strict=0
+                target=0
+                for arg in "$@"; do
+                    [ "$arg" = "BatchMode=yes" ] && batch=1
+                    [ "$arg" = "StrictHostKeyChecking=yes" ] && strict=1
+                    [ "$arg" = "git@github.com" ] && target=1
+                done
+                if [ "$batch" -eq 1 ] && [ "$strict" -eq 1 ] && [ "$target" -eq 1 ]; then
+                    printf '%s\\n' "Hi test! You've successfully authenticated, but GitHub does not provide shell access." >&2
+                    exit 1
+                fi
+                exit 255
+            """,
+            "gh": """
+                if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+                    exit 0
+                fi
+                exit 1
+            """,
+            "git": """
+                if [ "$1" = "ls-remote" ]; then
+                    case "$GIT_SSH_COMMAND" in
+                        *"BatchMode=yes"*"StrictHostKeyChecking=yes"*) exit 0 ;;
+                    esac
+                    exit 128
+                fi
+                exit 1
+            """,
+        }
+
+    def test_success_path_accepts_github_ssh_auth_exit_one(self) -> None:
+        result = self.run_preflight(self.fake_success_commands())
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS GitHub SSH connectivity works", result.stdout)
+        self.assertIn("PASS Codex local automation preflight complete", result.stdout)
+        self.assertEqual(result.stderr, "")
+
+    def test_empty_ssh_agent_fails_with_load_key_remediation(self) -> None:
+        commands = self.fake_success_commands()
+        commands["ssh-add"] = """
+            if [ "$1" = "-l" ]; then
+                printf '%s\\n' 'The agent has no identities.'
+                exit 1
+            fi
+            exit 2
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("PASS ssh-agent is reachable via ssh-add -l", result.stdout)
+        self.assertIn("FAIL at least one SSH identity is loaded", result.stdout)
+        self.assertIn("ssh-add /path/to/private/key", result.stdout)
+
+    def test_github_ssh_failure_stops_before_gh_checks(self) -> None:
+        commands = self.fake_success_commands()
+        commands["ssh"] = """
+            printf '%s\\n' 'git@github.com: Permission denied (publickey).' >&2
+            exit 255
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("FAIL GitHub SSH connectivity works via ssh -T git@github.com", result.stdout)
+        self.assertNotIn("gh is installed", result.stdout)
+
+    def test_git_reachability_failure_reports_read_only_check(self) -> None:
+        commands = self.fake_success_commands()
+        commands["git"] = """
+            if [ "$1" = "ls-remote" ]; then
+                exit 128
+            fi
+            exit 1
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("PASS gh auth status succeeds", result.stdout)
+        self.assertIn("FAIL playbook repository is reachable with git ls-remote", result.stdout)
+        self.assertIn("git ls-remote git@github.com:ctrl-alt-keith/ai-workflow-playbook.git HEAD", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/codex-preflight`, a read-only POSIX shell preflight for local Codex automation readiness.
- Check ssh-agent reachability, loaded SSH identities, GitHub SSH auth, GitHub CLI auth, and read-only playbook repo reachability.
- Document lightweight prompt usage and cover behavior with mocked tests so CI does not require live SSH or GitHub state.

## Rationale

This catches stale local/session prerequisites before Codex automation fan-out or repository work begins, especially after idle sessions where SSH identities or GitHub CLI auth may no longer be ready.

## Validation

- `sh -n scripts/codex-preflight`
- `python3 -m unittest tests.test_codex_preflight`
- `make check`

## Notes

A live local run of `./scripts/codex-preflight` in this session failed at `at least one SSH identity is loaded`, with the intended remediation to load a key via `ssh-add /path/to/private/key`. That confirms the stale-session failure mode without requiring network-dependent CI tests.