### PR TITLE
[codex] Support agent-backed GitHub SSH preflight

### DIFF
--- a/docs/codex-preflight.md
+++ b/docs/codex-preflight.md
@@ -7,11 +7,15 @@ prerequisites before Codex automation fan-out or real repository work begins.
 
 It verifies:
 
-- `ssh-add -l` can reach an agent
-- at least one SSH identity is loaded
 - GitHub SSH authentication succeeds with `ssh -T git@github.com`
 - `gh` is installed and authenticated
 - the playbook repository is reachable through `git ls-remote`
+
+When available, `ssh-add -l` is used only for diagnostic context. It is not a
+readiness gate because some agent-backed flows, including 1Password SSH agent,
+can authenticate to GitHub without listing identities through `ssh-add -l`.
+The authoritative SSH readiness check is actual GitHub SSH authentication via
+`ssh -T git@github.com`.
 
 The script does not install tools, mutate Git state, change credentials, push,
 commit, or update SSH configuration. SSH checks use batch mode and strict host
@@ -32,8 +36,9 @@ cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
 If it exits non-zero, stop and report the failing check and remediation.
 ```
 
-This catches common stale Monday-morning failures, such as an empty SSH agent or
-expired GitHub CLI session, while the task is still cheap to restart.
+This catches common stale Monday-morning failures, such as broken GitHub SSH
+authentication or an expired GitHub CLI session, while the task is still cheap
+to restart.
 
 Set `CODEX_PREFLIGHT_REPO_URL` only when checking a different GitHub repository
 with the same read-only pattern.

--- a/scripts/codex-preflight
+++ b/scripts/codex-preflight
@@ -10,6 +10,10 @@ pass_check() {
     printf 'PASS %s\n' "$1"
 }
 
+info_check() {
+    printf 'INFO %s\n' "$1"
+}
+
 fail_check() {
     printf 'FAIL %s\n' "$1"
     printf '  Remediation: %s\n' "$2"
@@ -28,31 +32,29 @@ require_command() {
     fail_check "$command_name is installed" "$remediation"
 }
 
-require_command "ssh-add" "Install OpenSSH client tools, then rerun this preflight."
-
-ssh_add_output="$(ssh-add -l 2>&1)"
-ssh_add_status="$?"
-
-if [ "$ssh_add_status" -eq 0 ]; then
-    pass_check "ssh-agent is reachable via ssh-add -l"
-    pass_check "at least one SSH identity is loaded"
-else
-    case "$ssh_add_output" in
-        *"The agent has no identities"*|*"no identities"*)
-            pass_check "ssh-agent is reachable via ssh-add -l"
-            fail_check \
-                "at least one SSH identity is loaded" \
-                "Load a private key into the existing agent with ssh-add /path/to/private/key, then rerun this preflight."
-            ;;
-        *)
-            fail_check \
-                "ssh-agent is reachable via ssh-add -l" \
-                "Start or reconnect to ssh-agent, export SSH_AUTH_SOCK if needed, then rerun ssh-add -l."
-            ;;
-    esac
-fi
-
 require_command "ssh" "Install OpenSSH client tools, then rerun this preflight."
+require_command "gh" "Install GitHub CLI from https://cli.github.com/, then rerun this preflight."
+require_command "git" "Install Git, then rerun this preflight."
+
+if command -v ssh-add >/dev/null 2>&1; then
+    ssh_add_output="$(ssh-add -l 2>&1)"
+    ssh_add_status="$?"
+
+    if [ "$ssh_add_status" -eq 0 ]; then
+        pass_check "ssh-add -l listed identities for diagnostic context"
+    else
+        case "$ssh_add_output" in
+            *"The agent has no identities"*|*"no identities"*)
+                info_check "ssh-add -l reported no identities; continuing to GitHub SSH authentication"
+                ;;
+            *)
+                info_check "ssh-add -l was unavailable or inconclusive; continuing to GitHub SSH authentication"
+                ;;
+        esac
+    fi
+else
+    info_check "ssh-add is unavailable; continuing to GitHub SSH authentication"
+fi
 
 ssh_output="$(
     ssh \
@@ -77,11 +79,9 @@ case "$ssh_output" in
     *)
         fail_check \
             "GitHub SSH connectivity works via ssh -T $SSH_TARGET" \
-            "Run ssh -T $SSH_TARGET and resolve the reported SSH auth or known_hosts issue; load a key with ssh-add if needed."
+            "Run ssh -T $SSH_TARGET and resolve the reported GitHub SSH authentication or known_hosts issue."
         ;;
 esac
-
-require_command "gh" "Install GitHub CLI from https://cli.github.com/, then rerun this preflight."
 
 if gh auth status >/dev/null 2>&1; then
     pass_check "gh auth status succeeds"
@@ -90,8 +90,6 @@ else
         "gh auth status succeeds" \
         "Authenticate GitHub CLI with gh auth login, then rerun gh auth status."
 fi
-
-require_command "git" "Install Git, then rerun this preflight."
 
 if GIT_SSH_COMMAND="ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=15" \
     git ls-remote --exit-code "$REPO_URL" HEAD >/dev/null 2>&1; then

--- a/tests/test_codex_preflight.py
+++ b/tests/test_codex_preflight.py
@@ -44,13 +44,15 @@ class CodexPreflightTest(unittest.TestCase):
             "ssh": """
                 batch=0
                 strict=0
+                timeout=0
                 target=0
                 for arg in "$@"; do
                     [ "$arg" = "BatchMode=yes" ] && batch=1
                     [ "$arg" = "StrictHostKeyChecking=yes" ] && strict=1
+                    [ "$arg" = "ConnectTimeout=15" ] && timeout=1
                     [ "$arg" = "git@github.com" ] && target=1
                 done
-                if [ "$batch" -eq 1 ] && [ "$strict" -eq 1 ] && [ "$target" -eq 1 ]; then
+                if [ "$batch" -eq 1 ] && [ "$strict" -eq 1 ] && [ "$timeout" -eq 1 ] && [ "$target" -eq 1 ]; then
                     printf '%s\\n' "Hi test! You've successfully authenticated, but GitHub does not provide shell access." >&2
                     exit 1
                 fi
@@ -65,7 +67,7 @@ class CodexPreflightTest(unittest.TestCase):
             "git": """
                 if [ "$1" = "ls-remote" ]; then
                     case "$GIT_SSH_COMMAND" in
-                        *"BatchMode=yes"*"StrictHostKeyChecking=yes"*) exit 0 ;;
+                        *"BatchMode=yes"*"StrictHostKeyChecking=yes"*"ConnectTimeout=15"*) exit 0 ;;
                     esac
                     exit 128
                 fi
@@ -77,11 +79,12 @@ class CodexPreflightTest(unittest.TestCase):
         result = self.run_preflight(self.fake_success_commands())
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS ssh-add -l listed identities for diagnostic context", result.stdout)
         self.assertIn("PASS GitHub SSH connectivity works", result.stdout)
         self.assertIn("PASS Codex local automation preflight complete", result.stdout)
         self.assertEqual(result.stderr, "")
 
-    def test_empty_ssh_agent_fails_with_load_key_remediation(self) -> None:
+    def test_onepassword_style_empty_ssh_add_still_succeeds_with_github_ssh_auth(self) -> None:
         commands = self.fake_success_commands()
         commands["ssh-add"] = """
             if [ "$1" = "-l" ]; then
@@ -93,10 +96,32 @@ class CodexPreflightTest(unittest.TestCase):
 
         result = self.run_preflight(commands)
 
-        self.assertEqual(result.returncode, 1)
-        self.assertIn("PASS ssh-agent is reachable via ssh-add -l", result.stdout)
-        self.assertIn("FAIL at least one SSH identity is loaded", result.stdout)
-        self.assertIn("ssh-add /path/to/private/key", result.stdout)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "INFO ssh-add -l reported no identities; continuing to GitHub SSH authentication",
+            result.stdout,
+        )
+        self.assertIn("PASS GitHub SSH connectivity works", result.stdout)
+        self.assertIn("PASS Codex local automation preflight complete", result.stdout)
+
+    def test_unavailable_ssh_add_diagnostic_does_not_fail_when_github_ssh_auth_succeeds(self) -> None:
+        commands = self.fake_success_commands()
+        commands["ssh-add"] = """
+            if [ "$1" = "-l" ]; then
+                printf '%s\\n' 'Could not open a connection to your authentication agent.'
+                exit 2
+            fi
+            exit 2
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn(
+            "INFO ssh-add -l was unavailable or inconclusive; continuing to GitHub SSH authentication",
+            result.stdout,
+        )
+        self.assertIn("PASS GitHub SSH connectivity works", result.stdout)
 
     def test_github_ssh_failure_stops_before_gh_checks(self) -> None:
         commands = self.fake_success_commands()
@@ -109,7 +134,27 @@ class CodexPreflightTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("FAIL GitHub SSH connectivity works via ssh -T git@github.com", result.stdout)
-        self.assertNotIn("gh is installed", result.stdout)
+        self.assertIn(
+            "resolve the reported GitHub SSH authentication or known_hosts issue",
+            result.stdout,
+        )
+        self.assertNotIn("gh auth status succeeds", result.stdout)
+
+    def test_gh_auth_status_failure_reports_login_remediation(self) -> None:
+        commands = self.fake_success_commands()
+        commands["gh"] = """
+            if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+                exit 1
+            fi
+            exit 1
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("PASS GitHub SSH connectivity works", result.stdout)
+        self.assertIn("FAIL gh auth status succeeds", result.stdout)
+        self.assertIn("gh auth login", result.stdout)
 
     def test_git_reachability_failure_reports_read_only_check(self) -> None:
         commands = self.fake_success_commands()


### PR DESCRIPTION
## Summary

- Make `ssh -T git@github.com` the authoritative SSH readiness check for `scripts/codex-preflight`.
- Treat `ssh-add -l` as optional diagnostic output so empty or inconclusive agent listings do not fail successful GitHub SSH auth.
- Update preflight docs and tests for 1Password-style agent-backed SSH flows.

## Validation

- `python3 -m unittest tests.test_codex_preflight`
- `sh -n scripts/codex-preflight`
- `make check`
- `./scripts/codex-preflight` passed locally with `ssh-add -l` reporting no identities while GitHub SSH auth succeeded.