### PR TITLE
[codex] Clarify playbook and enforcement layering

### DIFF
--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -38,7 +38,7 @@ may sharpen over time, but the current conceptual split is:
 | Repository | Conceptual role |
 | --- | --- |
 | `ai-workflow-playbook` | Canonical home for reusable workflow patterns, operating philosophy, interaction modes, review expectations, and promotion guidance. It explains how to work. |
-| `ai-workflow-enforcement` | Mechanical policy and drift enforcement. It should encode checkable workflow rules without becoming the place where the philosophy is invented. |
+| `ai-workflow-enforcement` | Mechanical verification, advisory and validation tooling, drift reporting, and reusable automation for selected playbook guidance. It implements checkable doctrine without independently establishing workflow policy. |
 | `ai-workflow-incubator` | Exploration and staging for emerging patterns before they are promoted into durable playbook guidance or split into their own repository. |
 | `knowledge-vault` | Reviewed retained knowledge. The vault stores the durable notes, summaries, and retained artifacts that have passed through human review. |
 | `knowledge-adapters` | Acquisition and normalization of external sources. Adapters treat incoming material as untrusted input and prepare it for review without declaring it retained knowledge by default. |
@@ -46,8 +46,12 @@ may sharpen over time, but the current conceptual split is:
 
 In short: adapters acquire and normalize, the vault retains reviewed knowledge,
 destinations publish or render, the playbook captures reusable patterns,
-enforcement checks mechanical policy, and the incubator gives unsettled ideas a
-place to mature before promotion.
+enforcement implements selected playbook doctrine mechanically, and the
+incubator gives unsettled ideas a place to mature before promotion. If
+playbook doctrine and enforcement behavior diverge, the playbook is
+authoritative and enforcement should be updated to match. Not every playbook
+rule needs enforcement, and not every enforcement capability should be promoted
+into doctrine.
 
 ## State Boundaries
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -102,9 +102,20 @@ competing audit engine.
 
 ### Enforcement Relationship
 
-The playbook defines the philosophy, operating model, and reusable workflow
-expectations. `ai-workflow-enforcement` defines centralized governance policy,
-read-only audit implementation, and advisory drift reporting.
+The playbook is the canonical source of workflow doctrine: workflow rules,
+engineering philosophy, reusable operating guidance, authority boundaries, and
+human and agent operating models.
+
+`ai-workflow-enforcement` is the mechanical implementation layer for selected
+portions of that doctrine. It owns mechanical verification, advisory and
+validation tooling, read-only audit implementation, drift reporting, and
+reusable automation that enforces or assists existing playbook guidance.
+Enforcement does not independently establish workflow policy.
+
+When enforcement behavior and the playbook diverge, the playbook is
+authoritative and enforcement should be updated to match. Not every playbook
+rule requires mechanical enforcement, and not every enforcement capability
+should become playbook doctrine.
 
 Repo-local governance should exist only when the repository needs local
 rationale, a documented transition, or an explicit exception from central


### PR DESCRIPTION
## Summary

Clarifies the architectural relationship between `ai-workflow-playbook` and `ai-workflow-enforcement` in the existing canonical homes for that concept.

- Updates `docs/repo-readiness.md` to state that the playbook is the canonical source of workflow doctrine and enforcement mechanically implements selected portions of that doctrine.
- Updates `docs/ai-workflow-ecosystem.md` to align the repository role map with that same layering.

## Rationale

This is a wording-only clarification of authority boundaries. It does not introduce new workflow rules, governance behavior, validation gates, or enforcement scope.

## Validation

- `make check`