### PR TITLE
Clarify local repository state reconciliation

### DIFF
--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -104,6 +104,13 @@ For repository workflows:
    current state.
 8. Treat any source that could not be checked as unknown or unverified.
 
+Before beginning work in an existing local repository or worktree, reconcile
+the local checkout with the repository's current GitHub default branch. Do not
+assume an existing clone or worktree reflects authoritative repository state;
+treat local repositories as cached working copies that may require
+synchronization. This principle intentionally does not prescribe a specific Git
+command or implementation sequence.
+
 When a mandatory trigger is present, verification blocks:
 
 - statements about current PR, issue, branch, commit, CI, mergeability, review,


### PR DESCRIPTION
## Summary

- Clarifies that existing local repositories and worktrees must be reconciled with GitHub's current default branch before work begins.
- Frames local checkouts as cached working copies, while leaving the synchronization implementation unspecified.

## Rationale

`docs/source-first-retrieval.md` already owns the source-of-truth and local-versus-remote evidence model, so this clarification belongs there rather than in a new document or branch/worktree guidance.

## Validation

- `make check`