### PR TITLE
Clarify playbook support script scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ This repository should not contain:
 - One-off notes
 - Vendor news or trend commentary
 - Project-specific implementation docs
-- Automation code or orchestration systems that belong in a separate implementation repo
+- Project-specific automation code, orchestration systems, or control planes
+  that belong in a separate implementation repo
+
+Small reusable checks that directly validate or demonstrate playbook guidance
+may live here when they remain narrow, documented, and subordinate to the docs.
 
 If an area grows into implementation, tooling, or automation, it should eventually move to its own repository.
 


### PR DESCRIPTION
## Summary

## What changed

- Clarified README non-scope language so project-specific automation and orchestration systems remain out of scope.
- Added a narrow carveout for small reusable checks that directly validate or demonstrate playbook guidance.

## Why

The repository now intentionally includes documented support scripts such as the authoritative-source scanner and Codex preflight check. The README still read as though all automation/support code belonged elsewhere, which created internal drift with the current repo contents.

## Scope check

- [x] This PR contains one logical change.

## Interaction mode

Implementation.

## Validation

- [x] `make check`
- [x] Manual review

## Source evidence

Inspected README, repo-local AGENTS.md, Makefile/help, workflows, scanner/preflight docs, scripts/tests, and recent commits through `origin/main` at `e365361`.

## Residual risks / follow-ups

Repo-local AGENTS.md still says this repo does not contain implementation code; left unchanged because AGENTS.md updates are a separate authorized work type in the playbook.

## Issue closure

N/A.