### PR TITLE
Document GPT-5.6 Sol Codex posture

### DIFF
--- a/docs/authoritative-source-check.md
+++ b/docs/authoritative-source-check.md
@@ -55,18 +55,20 @@ allowlisting mixed surfaces such as blogs, communities, marketplaces, marketing
 sites, support forums, or generic corporate roots when only a documentation
 subdomain or developer portal is authoritative.
 
-The scanner includes narrow Google and Atlassian documentation domains because
-they are common adoption targets:
+The scanner includes narrow Google, OpenAI, and Atlassian documentation domains
+because they are common adoption targets:
 
 - Google: `cloud.google.com`, `developers.google.com`, and
   `firebase.google.com`.
+- OpenAI: `developers.openai.com`, its developer and API documentation portal.
 - Atlassian: `developer.atlassian.com`, `docs.atlassian.com`, and
   `support.atlassian.com`.
 
-These defaults do not imply that `google.com`, `atlassian.com`, `blog.google`,
-`community.atlassian.com`, or other mixed/community domains are authoritative.
-Caller repositories can still add more narrow `official_domains` when their
-public API surface depends on another provider-controlled documentation domain.
+These defaults do not imply that `google.com`, `openai.com`, `atlassian.com`,
+`blog.google`, `community.atlassian.com`, or other corporate, marketing,
+mixed, or community domains are authoritative. Caller repositories can still
+add more narrow `official_domains` when their public API surface depends on
+another provider-controlled documentation domain.
 
 Same-organization GitHub repository links are intentionally treated as project
 references for this playbook's repositories. They are useful for local project

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -28,6 +28,7 @@ implementation. For review or orchestration, use the matching template instead.
 ```text
 Role:
 - You are implementing a scoped repository change in [repository].
+- Work layer: implementation.
 
 Goal:
 - [desired outcome]
@@ -43,14 +44,13 @@ Context:
 - Working directory: [working_directory]
 - Relevant background: [short context]
 - GitHub issues or planning references: [none or identifiers]
+- Dependencies: [none or required predecessors, inputs, or services]
 
 Retrieval:
 - Read `ai-workflow-playbook/docs/start-here.md`, the target repo's
   `AGENTS.md`, and any required tool adapter before acting.
 - Retrieve or revalidate authoritative repository, issue, PR, file, CI, log, or
   artifact state before relying on it.
-- Treat summaries, completion reports, memory, and pasted descriptions as
-  navigation, not proof of current source state.
 - Stop broad search once the target files, constraints, validation path, and
   delivery expectation are clear.
 
@@ -78,6 +78,10 @@ Validation:
 Delivery:
 - [branch, commit, push, and PR expectation, or explicit exclusion]
 - Include a concise summary, validation results, and residual risks.
+
+Permissions and completion boundary:
+- Authorized actions: [local edits, validation, commit, push, PR, or narrower]
+- Completion ends at: [validated artifact, review packet, draft PR, or other]
 
 Stop rules:
 - Stop before merge, release, tag, destructive, externally visible, or
@@ -124,6 +128,7 @@ Required inputs:
 ```text
 Role:
 - You are a downstream agent completing a bounded task for [repository].
+- Work layer: [research, design, implementation, review, or coordination]
 
 Goal:
 - [clear user-visible outcome]
@@ -144,12 +149,12 @@ Inputs:
 - Interaction mode: [implementation, review/audit, or orchestration]
 - Validation path: [validation_path]
 - Delivery expectation: [delivery_expectation]
+- Dependencies: [none or required predecessors, inputs, or services]
 
 Retrieval:
 - Read the shared playbook startup guidance and repo-local `AGENTS.md` first.
-- Inspect only the files, issues, PRs, docs, or artifacts needed for the goal.
-- Retrieve authoritative source state before relying on it; treat summaries and
-  completion reports as navigation only.
+- Retrieve authoritative state from only the files, issues, PRs, docs, or
+  artifacts needed for the goal; treat summaries as navigation only.
 - Stop once the target surface, constraints, validation path, and delivery
   expectation are clear.
 
@@ -175,6 +180,10 @@ Validation:
 Delivery:
 - [branch, commit, push, PR, review packet, or report expectation]
 - Include summary, validation, source evidence, and residual risks.
+
+Permissions and completion boundary:
+- Authorized actions: [read-only inspection, local edits, delivery, or narrower]
+- Completion ends at: [artifact, review packet, PR, report, or other]
 
 Stop rules:
 - Stop before merge, release, tag, destructive, externally visible, or

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -16,6 +16,48 @@ a second copy of those rules.
 - Small tasks stay small when they extend an existing documented seam and avoid
   new abstractions unless clearly required.
 
+## GPT-5.6 Sol Posture
+
+GPT-5.6 Sol is the flagship GPT-5.6 role for complex reasoning and coding, not
+a universal replacement for lower-cost or latency-sensitive model roles. For
+Codex work using Sol, prefer a compact, outcome-oriented task envelope that:
+
+- names the current work layer for a long task: research, design,
+  implementation, review, or coordination
+- states observable success criteria, constraints, dependencies, permissions,
+  stop conditions, and the boundary of completion
+- points to the governing playbook and repo-local sources instead of copying
+  their doctrine into the prompt
+- requires validation output or other direct evidence before completion is
+  claimed
+
+Do not add generic instructions such as "think step by step," "be thorough,"
+or "minimize tool calls." Describe the outcome and evidence that matter. A
+changed model string or a successful tool call is progress evidence, not proof
+that the task is complete.
+
+### Model And Prompt Updates
+
+A model upgrade does not by itself justify a prompt rewrite. Preserve the
+existing prompt and behavior first, establish a representative baseline, and
+make only surgical prompt changes tied to an observed failure. When the
+variables can be evaluated separately, do not change the model, prompt,
+reasoning effort, tool behavior, and workflow at the same time.
+
+Preserve the prior effective reasoning effort as the first migration baseline.
+Treat reasoning effort as execution configuration rather than prompt prose,
+then tune it against representative tasks. Do not recommend a global increase
+or compensate for a configuration mismatch by bloating the prompt.
+
+Keep Pro mode, persisted reasoning, programmatic tool calling, explicit prompt
+caching, and multi-agent execution outside the baseline migration. Evaluate
+each optional feature separately only when the workload shape and measured
+results justify it. Preserve behavior and settings before optimizing.
+
+This posture is derived from OpenAI's current
+[GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+and [GPT-5.6 Sol model reference](https://developers.openai.com/api/docs/models/gpt-5.6-sol).
+
 ## Startup Deltas
 
 Before repo-scoped work:

--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -30,6 +30,7 @@ DEFAULT_OFFICIAL_SUFFIXES = (
     "cloud.google.com",
     "developers.google.com",
     "firebase.google.com",
+    "developers.openai.com",
     "developer.atlassian.com",
     "docs.atlassian.com",
     "support.atlassian.com",

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -98,6 +98,23 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
 
                 self.assertEqual(findings, [])
 
+    def test_openai_developer_docs_are_allowed_by_default(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "OpenAI API source: https://developers.openai.com/api/docs/guides/latest-model",
+        )
+
+        self.assertEqual(findings, [])
+
+    def test_broad_openai_domain_still_warns(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "OpenAI API source: https://openai.com/news/example",
+        )
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["domain"], "openai.com")
+
     def test_google_and_atlassian_community_domains_still_warn(self) -> None:
         findings = scanner.scan_text(
             "docs/example.md",


### PR DESCRIPTION
## Summary

- add a compact GPT-5.6 Sol prompting and execution posture to the Codex adapter
- preserve prompts and reasoning settings as migration baselines, with surgical tuning based on representative evidence
- keep optional Sol features separate from baseline migration
- tighten reusable implementation and orchestration envelopes while preserving source-first, validation, permission, delivery, and stop boundaries

## Rationale

Capture the durable Codex-specific changes introduced by Sol without creating a second prompt family or duplicating core playbook doctrine.

## Validation

- `make check`
  - markdownlint: 0 errors
  - unit tests: 23 passed
- `git diff --check`
