### PR TITLE
Ignore local worktrees in source scanner

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -43,6 +43,17 @@ OFFICIAL_GITHUB_PATH_MARKERS = (
 )
 SAME_ORG_GITHUB_OWNERS = {"ctrl-alt-keith"}
 KNOWN_THIRD_PARTY_SUFFIXES = ("stackoverflow.com", "medium.com", "dev.to")
+IGNORED_MARKDOWN_PATH_PARTS = (
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    ".worktrees",
+    "node_modules",
+    "vendor",
+)
 JUSTIFICATION_RE = re.compile(
     r"\b("
     r"source justification|source exception|"
@@ -211,6 +222,14 @@ def markdown_sources(paths: list[Path]) -> list[tuple[str, str]]:
     return sources
 
 
+def is_scannable_markdown_path(path: Path) -> bool:
+    return not any(part in IGNORED_MARKDOWN_PATH_PARTS for part in path.parts)
+
+
+def all_markdown_files(root: Path = Path(".")) -> list[Path]:
+    return sorted(path for path in root.glob("**/*.md") if is_scannable_markdown_path(path))
+
+
 def dedupe(findings: list[dict[str, object]]) -> list[dict[str, object]]:
     by_domain: dict[str, dict[str, object]] = {}
     for finding in findings:
@@ -287,7 +306,7 @@ def main() -> int:
         sources.append(("PR body", body))
 
     if args.all_markdown:
-        markdown_files = sorted(Path(".").glob("**/*.md"))
+        markdown_files = all_markdown_files()
     else:
         pull_request = payload.get("pull_request", {})
         base_ref = (

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -244,6 +244,28 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
         )
         self.assertIn("location: docs/example.md:2", result.stdout)
 
+    def test_cli_all_markdown_ignores_worktree_markdown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            docs_dir = root / "docs"
+            worktree_docs_dir = root / ".worktrees" / "feature" / "docs"
+            docs_dir.mkdir()
+            worktree_docs_dir.mkdir(parents=True)
+            (docs_dir / "example.md").write_text(
+                "REST retry behavior source: https://medium.com/source-doc",
+                encoding="utf-8",
+            )
+            (worktree_docs_dir / "example.md").write_text(
+                "REST retry behavior source: https://medium.com/worktree-doc",
+                encoding="utf-8",
+            )
+
+            result = self.run_scanner_cli(["--all-markdown"], cwd=root)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("https://medium.com/source-doc", result.stdout)
+        self.assertNotIn("https://medium.com/worktree-doc", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- exclude local implementation/cache directories from authoritative-source scanner all-markdown discovery
- add regression coverage for markdown under .worktrees/ so local task worktrees do not produce stale duplicate advisory findings

## Staff-engineering lane
Inspected repo-local AGENTS.md, playbook startup/validation guidance, live open PRs/issues, recent commits, main branch workflow status, Makefile targets, workflows, and scanner tests. Selected this change because repo-local .worktrees/ are now the standard implementation path, and scanning them during --all-markdown can confuse advisory source reports with stale or duplicate markdown from unrelated work.

## Validation
- make check

## Follow-up out of scope
- Broader scanner ignore configurability; this PR keeps the default source filter narrow and local.