### PR TITLE
Document cross-repo interface contracts and glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The first core module is delivery. Additional workflow families may be added lat
 ## Initial Map
 
 - [`docs/start-here.md`](docs/start-here.md): mandatory startup, core invariants, and adapter-routing contract
+- [`docs/repo-to-repo-interface-contracts.md`](docs/repo-to-repo-interface-contracts.md): lightweight pattern for documenting producer/consumer boundaries
+- [`docs/cross-repo-glossary.md`](docs/cross-repo-glossary.md): qualified cross-repository architecture vocabulary
 - [`docs/ai-workflow-ecosystem.md`](docs/ai-workflow-ecosystem.md): conceptual overview of the repository ecosystem, retained-knowledge boundaries, and architectural direction
 - [`docs/engineering-baseline.md`](docs/engineering-baseline.md): foundational engineering expectations, including validation, source authority, review, merge authority, and ready-for-review defaults
 - [`docs/authoritative-source-check.md`](docs/authoritative-source-check.md): advisory authoritative-source scanner adoption, domain classification, source justifications, and reusable workflow pinning

--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -53,6 +53,12 @@ authoritative and enforcement should be updated to match. Not every playbook
 rule needs enforcement, and not every enforcement capability should be promoted
 into doctrine.
 
+When these or other repositories exchange artifacts, use the lightweight
+[`repo-to-repo interface contract pattern`](repo-to-repo-interface-contracts.md)
+and the qualified terms in the
+[`cross-repo architecture glossary`](cross-repo-glossary.md). Repository-local
+contracts remain authoritative for their domains.
+
 ## State Boundaries
 
 Retained knowledge should move through distinguishable states instead of

--- a/docs/cross-repo-glossary.md
+++ b/docs/cross-repo-glossary.md
@@ -1,0 +1,181 @@
+# Cross-Repo Architecture Glossary
+
+## Purpose
+
+Use these qualifiers when reasoning across repositories. The goal is not one
+universal definition for every domain. It is to prevent humans and AI agents
+from silently treating similar words as identical concepts.
+
+Repository-local contracts remain authoritative. When local usage is narrower
+or intentionally different, name the qualified meaning and link its source.
+
+## Terms
+
+### Trust
+
+Trust is justified reliance within a stated scope; it is not a single
+ecosystem-wide approval bit.
+
+- **Network trust**: permission for a network identity or CIDR to reach a
+  narrowly managed endpoint or rule. It does not establish content or workflow
+  trust.
+- **Workflow trust**: confidence that a bounded process followed its declared
+  inputs, validation, mutation, and cleanup rules. A successful run receipt is
+  evidence for this claim, not proof that its source content is true.
+- **Provenance trust**: confidence in custody and origin claims. Hashes support
+  integrity; they do not by themselves authenticate a producer.
+- **Editorial trust**: reviewed judgment that material is suitable for a
+  retained purpose. A valid source package is candidate material, not editorial
+  approval.
+
+Prefer a qualifier. Avoid saying an artifact is simply “trusted” when the claim
+is only valid, authenticated, reviewed, allowlisted, or retained.
+
+### Trust Boundary
+
+A trust boundary is the point where data or authority changes validation or
+handling requirements.
+
+- **Input trust boundary**: external or cross-repo input is treated as
+  untrusted until the receiving repository validates it.
+- **Mutation trust boundary**: dry-run or planning becomes an explicitly
+  authorized external change.
+- **Editorial trust boundary**: acquired candidate material becomes retained
+  knowledge only after consumer-owned review.
+- **Publication trust boundary**: reviewed or caller-supplied material is sent
+  to an external destination; publication does not transfer editorial or
+  lifecycle ownership to the publisher.
+
+Name the data and authority crossing the boundary, the validator, and what a
+successful crossing does—and does not—authorize.
+
+### Manifest
+
+A manifest is structured metadata describing intended or observed work. Name
+its role because current repositories use several variants.
+
+- **Artifact/package manifest**: authoritative inventory and metadata for a
+  package or artifact set, such as `package.json` in a source package.
+- **Plan manifest**: dry-run description of intended actions.
+- **Run manifest**: structured result and evidence from an executed workflow;
+  some repositories also call this a run receipt.
+- **Deployment manifest**: declarative Kubernetes or GitOps resource document.
+
+Do not assume every manifest is immutable, authoritative for file bytes, a
+receipt, or a deployment declaration.
+
+### Schema Version
+
+A schema version identifies the compatibility rules for a specific serialized
+shape. Name the object it versions: registry schema version, config schema
+version, manifest schema version, or contract version.
+
+A schema version is not automatically the producer release, adapter version,
+API version, or whole interchange contract version. Document incompatible
+change rules and consumer acceptance explicitly. Omit versioning when a simple
+unversioned interface can evolve safely and compatibility is not negotiated.
+
+### Bundle
+
+A bundle is a grouped set of artifacts prepared for a bounded downstream use.
+
+- **Knowledge bundle**: deterministic markdown assembled from normalized
+  adapter output for review, analysis, or publication.
+- **Evidence bundle**: provenance-bearing analytical evidence and related
+  artifacts in `trusted-ai-environment`.
+- **Source package**: the normative term for the sealed acquisition handoff
+  from `knowledge-adapters` to consumers; do not casually rename it a bundle
+  when package integrity and lifecycle semantics matter.
+
+State whether the bundle is sealed, mutable, reviewed, publication-ready, or
+merely candidate material; “bundle” alone promises none of those properties.
+
+### Receipt
+
+A receipt is durable evidence that a bounded operation was planned or
+performed and how it ended.
+
+- **Run/operational receipt**: redacted evidence of requested intent,
+  validation, optional mutation, outcomes, and cleanup.
+- **Publication receipt**: destination-specific evidence of an explicit
+  publication event, such as its status and resulting document URL.
+- **Lane stop receipt**: a worker's completion report used for orchestration;
+  it is navigation and reconciliation evidence, not repository or CI truth.
+
+A receipt is not necessarily a manifest, approval, audit log, retained
+knowledge object, or proof of external truth. State its durability and source
+of truth.
+
+### Contract
+
+A contract is an explicit set of expectations at a boundary.
+
+- **Interchange contract**: shared producer/consumer semantics, artifact shape,
+  compatibility, and failure rules.
+- **Consumer contract**: accepted versions plus consumer-local validation and
+  policy; it must not silently redefine producer-owned semantics.
+- **Execution contract**: repository-local command, validation, or workflow
+  behavior, such as `make check`.
+- **Governance contract**: documented human or agent responsibilities and stop
+  conditions.
+
+Name whether a statement is normative, derived, experimental, or descriptive.
+An example or current implementation is evidence for a contract but is not
+automatically the whole contract.
+
+### Adapter
+
+An adapter translates one interface while preserving an owning boundary.
+
+- **Source adapter**: acquires and normalizes external source material into
+  provider-neutral candidate artifacts.
+- **Tool/executor adapter**: maps shared playbook guidance to executor-specific
+  behavior without redefining the core workflow.
+- **Knowledge adapter repository/component**: use this only for the source-side
+  product role; a downstream publisher is a destination, not a source adapter.
+
+Qualify the term with source, provider, or executor. An adapter does not imply a
+generic plugin system or ownership of both sides of the interface.
+
+### Product
+
+A product is the bounded outcome a repository exists to provide, not every
+resource it touches.
+
+- **Repository product boundary**: owned responsibilities, primary product
+  object, decision filter, and non-goals.
+- **Product object**: the durable or reviewable outcome, such as an operational
+  receipt or publication event.
+- **External provider product**: a third-party service or API; qualify it as a
+  provider product to avoid assigning its lifecycle to the repository.
+
+Infrastructure used during a workflow is not automatically the product or
+repository-owned state.
+
+### Capability
+
+A capability is a named behavior that may affect eligibility, compatibility,
+or execution.
+
+- **Contract capability**: a declared feature of an interchange that a
+  consumer may require or reject, such as collection progress.
+- **Provider capability**: behavior or availability reported or documented by
+  an external provider, such as a region supporting Object Storage.
+- **Repository/tool capability**: behavior implemented by a repository or
+  command.
+- **Agent capability**: an available tool or execution ability; availability
+  is not authorization to use it.
+
+State who declares the capability, how it is verified, and whether it is
+required, optional, or merely observed. A capability flag must not hide an
+incompatible semantic change.
+
+## Usage Guidance
+
+- Prefer qualified phrases in cross-repo docs, issues, prompts, and PRs.
+- Preserve established public names, schema fields, and repository names; add
+  a qualifier or link instead of renaming them in prose-only cleanup.
+- When two repositories use the same word differently, document both meanings
+  and the boundary between them rather than forcing a false universal meaning.
+- Treat this glossary as navigation. Verify current repository contracts and
+  implementation before making ownership, compatibility, or security claims.

--- a/docs/repo-to-repo-interface-contracts.md
+++ b/docs/repo-to-repo-interface-contracts.md
@@ -1,0 +1,149 @@
+# Repo-To-Repo Interface Contracts
+
+## Purpose
+
+Use a small, explicit contract when one repository produces an artifact or
+behavior that another repository consumes. The contract should make ownership,
+compatibility, validation, and failure behavior reviewable without creating a
+central schema repository, shared library, or new approval gate.
+
+This is a documentation pattern, not a required file format. Use only the
+sections that clarify the real interface. A short section in an existing design
+document is enough for a simple integration; a dedicated contract document is
+appropriate when the interface is versioned, security-sensitive, or consumed
+by more than one workflow.
+
+## Evidence Behind The Pattern
+
+The strongest current example is the
+[Trusted Network Registry schema contract](https://github.com/ctrl-alt-keith/trusted-network-registry/blob/main/docs/registry-schema.md)
+and its
+[`linode-image-lab` consumer contract](https://github.com/ctrl-alt-keith/linode-image-lab/blob/main/docs/trusted-registry-firewall-sync.md).
+The producer owns a versioned schema and public-safe fixture. The consumer
+declares the accepted version, carries a compatibility fixture through its real
+validation and planning path, and fails closed on invalid or stale input.
+
+The
+[`knowledge-adapters` Source Package Contract](https://github.com/ctrl-alt-keith/knowledge-adapters/blob/main/docs/source-package-contract.md)
+adds proven patterns for semantic compatibility, required capabilities,
+integrity verification, immutable handoffs, and distinct producer and consumer
+responsibilities. Its
+[`knowledge-vault` consumer contract](https://github.com/ctrl-alt-keith/knowledge-vault/blob/main/docs/source-package-consumer-contract.md)
+keeps consumer policy local while linking back to the producer-owned normative
+contract. The bundle-to-destination and image-lab-to-LKE boundaries are lighter:
+they rely primarily on documented file or container/CLI behavior and local
+consumer validation. They do not yet justify a shared library or centrally
+managed schema.
+
+## Placement And Ownership
+
+- Put the normative artifact shape and producer guarantees in the producer
+  repository, near the implementation, schema, fixture, or command that emits
+  them.
+- Put accepted versions, consumer-specific policy, and integration validation
+  in each consumer repository.
+- Link both sides explicitly and name which side governs shared semantics.
+- Keep transport or orchestration ownership separate when an operator or a
+  third repository moves the artifact between producer and consumer.
+- Put reusable guidance here in the playbook; do not move domain contracts into
+  the playbook.
+
+Ownership of a contract means responsibility for its documented semantics. It
+does not transfer ownership of the consumer's policy, infrastructure, runtime,
+or downstream lifecycle.
+
+## Lightweight Contract Template
+
+Copy or adapt this outline. Delete irrelevant prompts.
+
+```markdown
+# <Interface Name> Contract
+
+Status: <draft, experimental, or stable>; version: <identifier if versioned>
+
+## Purpose And Scope
+What crosses the boundary, why it exists, and where the interface begins and
+ends.
+
+## Participants And Ownership
+- Producer: <repository/component> owns <emission semantics>.
+- Consumer: <repository/component> owns <acceptance and use>.
+- Operator/orchestrator/transport: <only when applicable>.
+- Normative contract home: <producer-owned link or other explicit authority>.
+
+## Inputs And Outputs
+Required and optional inputs; emitted artifacts, API behavior, commands, or
+receipts. State where credentials and destination-specific state belong.
+
+## Shape And Examples
+Link the schema, type, CLI contract, directory layout, media type, or concise
+field table. Link a sanitized fixture or realistic example when one exists.
+
+## Versioning And Compatibility
+How versions are identified; what additive and incompatible change mean; which
+versions or capabilities the consumer accepts; migration or overlap policy.
+
+## Validation Responsibilities
+What the producer validates before emission, what transport preserves, what the
+consumer validates before use, and which fixtures or contract tests exercise
+the boundary.
+
+## Failure Behavior
+Rejection, quarantine, retry, partial-success, stale-input, and fallback
+semantics. Say whether the consumer fails closed or can safely degrade.
+
+## Security And Durability
+Trust classification, secrets and sensitive-data rules, integrity or
+authenticity guarantees, retention, immutability, and cleanup expectations.
+
+## Non-Goals
+Responsibilities this interface deliberately does not acquire.
+```
+
+For a simple file handoff, purpose, owners, input/output shape, validation,
+failure behavior, and non-goals may be the entire contract. Do not add a
+version field merely to complete the template; version only when compatibility
+needs to be negotiated or incompatible evolution must be detectable.
+
+## Compatibility And Change Guidance
+
+- Prefer an explicit artifact or protocol version when a consumer cannot infer
+  compatibility safely. Define whether it versions the envelope, schema,
+  command, or whole interchange.
+- Use required capability declarations when an additive feature cannot be
+  safely ignored. Do not use capability flags as a substitute for a major
+  version when existing semantics change incompatibly.
+- Keep producer fixtures sanitized and realistic. Consumers may vendor a
+  fixture when that creates a deterministic compatibility test; record its
+  source and update it deliberately.
+- Exercise the consumer path that gives the artifact meaning, not only JSON
+  parsing or file existence. Keep tests proportional to interface risk.
+- Reject unsupported or ambiguous input before mutation. Document any safe
+  degraded mode explicitly; do not invent silent fallback behavior.
+- Treat integrity, provenance, and authenticity as separate claims. A checksum
+  can establish byte integrity without authenticating the producer or approving
+  the content.
+- Coordinate incompatible changes across repositories, but keep each change in
+  its owning repository and PR. Land producer support before consumer opt-in
+  when ordering matters; preserve an overlap window when practical.
+
+## Review Questions
+
+- Does the contract describe the interface that exists, with links to current
+  evidence, rather than a hoped-for abstraction?
+- Are producer, consumer, and transport responsibilities distinct?
+- Can the consumer detect unsupported or stale input before unsafe use?
+- Are security, durability, and failure claims no stronger than implementation
+  and validation evidence?
+- Are optional fields, capabilities, and version rules proportionate to the
+  integration?
+- Would a solo operator know which repository to change and which checks to
+  run?
+
+## Intentional Non-Automation
+
+This pattern does not require a central registry of contracts, a shared schema
+package, cross-repository test orchestration, synchronized releases, or a new
+CI gate. Those mechanisms add coordination and failure surfaces. Introduce one
+only after repeated interfaces demonstrate a concrete need that repository-
+local schemas, fixtures, links, and validation cannot meet.

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -9,10 +9,6 @@ acting.
 ## Read Order
 
 - `docs/engineering-baseline.md` -> foundational engineering expectations
-- `docs/repo-to-repo-interface-contracts.md` -> lightweight producer/consumer
-  contract pattern for cross-repository interfaces
-- `docs/cross-repo-glossary.md` -> qualified meanings for overloaded
-  architecture terms across repositories
 - `docs/source-first-retrieval.md` -> retrieve and revalidate authoritative
   state before stateful repository reasoning
 - `docs/repo-readiness.md` -> interaction mode, governance operating model,
@@ -30,6 +26,16 @@ acting.
 - `docs/maintenance-automations.md` -> recurring Codex maintenance automation
   expectations
 - `docs/prompts.md` -> reusable prompt templates
+
+## Conditional Guidance
+
+Read these only when the work involves multiple repositories,
+cross-repository interfaces, or architectural terminology:
+
+- `docs/repo-to-repo-interface-contracts.md` -> lightweight producer/consumer
+  contract pattern for cross-repository interfaces
+- `docs/cross-repo-glossary.md` -> qualified meanings for overloaded
+  architecture terms across repositories
 
 ## Instruction Hierarchy
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -9,6 +9,10 @@ acting.
 ## Read Order
 
 - `docs/engineering-baseline.md` -> foundational engineering expectations
+- `docs/repo-to-repo-interface-contracts.md` -> lightweight producer/consumer
+  contract pattern for cross-repository interfaces
+- `docs/cross-repo-glossary.md` -> qualified meanings for overloaded
+  architecture terms across repositories
 - `docs/source-first-retrieval.md` -> retrieve and revalidate authoritative
   state before stateful repository reasoning
 - `docs/repo-readiness.md` -> interaction mode, governance operating model,


### PR DESCRIPTION
## Summary

- add a lightweight, optional repo-to-repo interface contract pattern
- add a cross-repository glossary for overloaded architecture terms
- keep both guides discoverable from the README and ecosystem overview, and
  route them from `start-here.md` only as conditional guidance for cross-repo
  or architecture work

## Evidence examined

- `trusted-network-registry` producer schema, public-safe fixture posture, and version rules
- `linode-image-lab` Trusted Network Registry consumer contract, compatibility fixture, real planning-path validation, stale-input handling, and fail-closed behavior
- `knowledge-adapters` Source Package Contract, including ownership, semantic compatibility, required capabilities, integrity, lifecycle, and immutable handoff rules
- `knowledge-vault` consumer and promotion contracts, including consumer-local policy and the distinction between structural validity, provenance, trust, and editorial retention
- `knowledge-adapters` bundle-to-destination design and `ka-destinations` publication boundary and receipts
- `linode-image-lab` product/receipt boundary and the current `lke-image-lab` placeholder plan Job, scenario, receipt, and manifest contract checks
- current repository boundaries and default branches from GitHub; no open `ai-workflow-playbook` PR overlapped this work when implementation began

## Canonical location

`ai-workflow-playbook` is the canonical home because this is reusable workflow and architecture guidance. Domain-specific contracts, schemas, fixtures, consumer acceptance policy, and validation remain in their producer and consumer repositories.

## Proposed pattern

The pattern starts from the strongest existing example: producer-owned schema and fixture, consumer-declared compatibility, a fixture exercised through the meaningful consumer path, and explicit fail-closed behavior. It adds optional prompts proven by the source-package contract for capabilities, integrity, durability, and separate transport responsibilities.

The template covers purpose, participants and ownership, inputs and outputs, shape and examples, versioning and compatibility, validation responsibilities, failure behavior, security and durability, and non-goals. Sections are deliberately optional; simple integrations should remain simple and unversioned when safe.

## Terminology decisions

The glossary distinguishes rather than collapses legitimate variants, including:

- network, workflow, provenance, and editorial trust
- input, mutation, editorial, and publication trust boundaries
- artifact/package, plan, run, and deployment manifests
- knowledge bundles, evidence bundles, and sealed source packages
- operational, publication, and lane-stop receipts
- interchange, consumer, execution, and governance contracts
- source and executor adapters
- contract, provider, repository/tool, and agent capabilities

It recommends qualifiers and links rather than renaming repositories, schemas, or public fields.

## Validation

- `make check`
  - Markdown lint: 0 errors
  - unit tests: 26 passed
- `git diff --cached --check`

## Intentionally deferred

- no centralized contract or schema registry
- no shared cross-repository library
- no cross-repository CI orchestration or new mandatory gate
- no mandatory version or capability fields for integrations that do not need them
- no rewrites of existing interfaces or ownership assignments
- no schema, repository, or public-interface renames

Those additions would create coordination cost and bureaucracy without current evidence of repeated need. Repository-local schemas, fixtures, documentation links, and validation remain the preferred mechanism for a solo operator.
