### PR TITLE
Document enforcement-backed Codex cleanup

### DIFF
--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -53,6 +53,17 @@ authoritative and enforcement should be updated to match. Not every playbook
 rule needs enforcement, and not every enforcement capability should be promoted
 into doctrine.
 
+### Enforcement Control Ownership
+
+For reviewed operational controls such as
+[`codex-safe-rm`](https://github.com/ctrl-alt-keith/ai-workflow-enforcement/blob/main/docs/codex-safe-rm.md),
+`ai-workflow-enforcement` owns the helper implementation, threat model,
+installation and verification mechanisms, Codex rule fixtures, and tests.
+`ai-workflow-playbook` owns the behavioral guidance, workflow expectations,
+delegation boundaries, and operator guidance for using that control. Link to
+the enforcement documentation for mechanics instead of copying implementation
+details into the playbook.
+
 When these or other repositories exchange artifacts, use the lightweight
 [`repo-to-repo interface contract pattern`](repo-to-repo-interface-contracts.md)
 and the qualified terms in the

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -174,6 +174,36 @@ Codex-specific application:
   keep the wrapped operation narrow enough for review and approval surfaces to
   see the intended action.
 
+### Enforcement-Backed Recursive Cleanup
+
+Direct `rm` and `rm -rf` remain approval-gated. When recursive cleanup is
+appropriate and every target is already known to be a disposable directory
+beneath the current repository worktree, prefer the reviewed enforcement
+control:
+
+```sh
+/Users/keith/.local/bin/codex-safe-rm -rf -- TARGET [TARGET ...]
+```
+
+The control validates the fixed invocation grammar and every operand, enforces
+containment beneath the invocation working directory, rejects `.git`, prevents
+symlink escape, rejects top-level files and symlinks, and safely ignores missing
+directories. The implementation, threat model, installation and verification
+workflow, rule fixture, and tests belong to
+[`ai-workflow-enforcement`](https://github.com/ctrl-alt-keith/ai-workflow-enforcement/blob/main/docs/codex-safe-rm.md);
+do not reproduce those mechanics in the playbook.
+
+The control establishes invocation and containment safety. It does not decide
+whether a directory is disposable. Do not use it to bypass approval when a
+target is uncertain, valuable, or part of a broader destructive operation.
+Human judgment still owns what may be deleted.
+
+Installation, verification, and activation through Codex rules are separate
+operator steps. The presence of this guidance does not make the helper a
+prerequisite for every Codex workflow. If the reviewed control is unavailable
+or not activated, keep recursive removal approval-gated rather than substituting
+an unreviewed wrapper.
+
 ## GitHub And PR Evidence
 
 - Before repo- or PR-dependent work, verify GitHub access instead of relying on
@@ -254,9 +284,12 @@ Codex should continue without pausing when the scope is clear, the repo context
 matches the task, required sources are available, validation can run, and no
 human-gated decision is next.
 
-Do not use autonomy to widen scope, reinterpret intent, or take ownership of
-merge, release, tag, destructive, security-sensitive, permissions-sensitive, or
-policy-interpretation decisions.
+Routine cleanup of known disposable repo-local directories through the reviewed
+`codex-safe-rm` control is an enforcement-backed operation within this lane; it
+is not an arbitrary destructive command. This does not delegate the decision
+that a target is disposable. Do not use autonomy to widen scope, reinterpret
+intent, or take ownership of merge, release, tag, uncertain deletion,
+security-sensitive, permissions-sensitive, or policy-interpretation decisions.
 
 ## Stop Conditions
 


### PR DESCRIPTION
## Summary

Document the merged `codex-safe-rm` enforcement control in the canonical Codex workflow guidance without duplicating its implementation documentation.

- Add enforcement-backed recursive-cleanup guidance to the Codex adapter.
- Keep direct `rm` and `rm -rf` approval-gated.
- Define the reviewed helper's operational guarantees and human-judgment boundary.
- Treat routine cleanup of known disposable repo-local directories through the helper as an enforcement-backed autonomous-lane operation.
- Clarify playbook-versus-enforcement ownership for reviewed operational controls.
- Document installation, verification, and Codex-rule activation as separate operator steps.

## Scope decisions

`docs/codex-preflight.md` remains unchanged. Its universal preflight checks GitHub/session readiness; adding helper verification there would risk making an optional cleanup control look like a prerequisite for every Codex workflow.

`docs/repo-readiness.md` remains unchanged because its existing canonical-tool delegation guidance already provides the reusable workflow rule. The Codex-specific behavior belongs in the adapter.

Implementation mechanics, installer behavior, metadata, rule definitions, and tests remain owned and documented by `ai-workflow-enforcement`; the playbook links to that source.

## Files changed

- `docs/tool-adapters/codex.md`
- `docs/ai-workflow-ecosystem.md`

## Validation

- `make check`
  - markdownlint-cli2: 45 files, 0 errors
  - Python tests: 27 passed
- `make authoritative-source-check`: no non-authoritative source URLs found
- `git diff --check`: passed
- Duplication review: only the two intentional `codex-safe-rm` guidance/ownership references are present in playbook docs