### PR TITLE
Prevent nested Markdown fences in Codex prompts

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -12,6 +12,13 @@ Use lint-safe placeholders such as `[repository]`, `[validation_path]`, or
 backticked tokens in Markdown templates. Angle-bracket placeholders can be
 interpreted as inline HTML by Markdown tooling.
 
+When rendering a complete Codex prompt inside a Markdown code fence, never
+nest another Markdown code fence inside it. If the prompt needs an embedded
+YAML, JSON, shell, Markdown, or other example, represent the example with
+indentation and prefer plain text over Markdown formatting. Optimize the
+finished prompt for reliable copy/paste across ChatGPT clients without changing
+its meaning or execution.
+
 ## Quick Navigation
 
 - [Codex Implementation Task](#codex-implementation-task)


### PR DESCRIPTION
## Summary

- document that complete Codex prompts must not contain nested Markdown code fences
- direct prompt authors to indent embedded examples and prefer plain text within fenced prompts
- optimize generated prompts for reliable copy/paste across ChatGPT clients

## Rationale

Nested fences can terminate an outer prompt block early or render inconsistently across clients. Keeping complete prompts to one fence preserves their meaning while making them easier to copy and execute unchanged.

## Impact

This is a formatting guideline only. It does not change prompt semantics or execution.

## Validation

- `make check`
  - markdownlint-cli2: 0 errors
  - scanner unit tests: 27 passed