### PR TITLE
Clarify Codex connector discovery

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -122,6 +122,12 @@ Before repo-scoped work:
   [`source-first-retrieval.md`](../source-first-retrieval.md): retrieve or
   revalidate authoritative repository, PR, issue, file, CI, log, artifact, and
   external-state sources before relying on them.
+- Treat a first-party connector's capabilities as unknown until verified; do
+  not infer that a capability is absent because its tool has not been loaded or
+  inspected. Before falling back to a direct service API or authenticated CLI
+  for remote service state, determine whether the connector provides the
+  required capability. Direct APIs and CLIs remain appropriate for verified
+  connector gaps, repository-local workflows, or explicit repository policy.
 - For policy-sensitive changes, apply the repo-family alignment check in
   [`repo-readiness.md`](../repo-readiness.md#repo-family-policy-alignment)
   before implementation.


### PR DESCRIPTION
## Summary

- clarify that first-party connector capabilities must be verified before fallback
- preserve direct API and CLI use for genuine connector gaps, repository-local workflows, and explicit repository policy

## Rationale

An observed Codex run treated an unloaded connector tool as evidence that the connector lacked the required capability. This adds a narrow discovery rule at the existing Codex source-first startup seam without changing connector-first policy or documenting connector-specific capabilities.

## Validation

- `make check`
- `git diff --check`
