### PR TITLE
Codify the autonomous maintenance layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md)
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
-- [`docs/maintenance-automations.md`](docs/maintenance-automations.md): reusable operating rules plus reference inventory notes for recurring Codex maintenance automation
+- [`docs/maintenance-automations.md`](docs/maintenance-automations.md):
+  autonomous maintenance layer responsibilities, capability classes, authority
+  and evidence boundaries, and local-configuration separation
 - [`docs/codex-preflight.md`](docs/codex-preflight.md): read-only local prerequisite check for Codex automation startup
 - [`docs/workstation-maintenance.md`](docs/workstation-maintenance.md): manual-only local workstation maintenance procedures, including Codex log cleanup
 - [`docs/prompts.md`](docs/prompts.md): reusable prompt templates, including the standard Codex task prompt format

--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -70,6 +70,42 @@ and the qualified terms in the
 [`cross-repo architecture glossary`](cross-repo-glossary.md). Repository-local
 contracts remain authoritative for their domains.
 
+## Autonomous Maintenance Layer
+
+The ecosystem includes an **autonomous maintenance layer** that performs
+recurring, bounded inspection, maintenance, and improvement across independent
+repositories. It is a first-class architectural capability rather than a
+particular repository, scheduler, or automation inventory.
+
+The layer closes the feedback loop between canonical expectations and current
+repository state:
+
+```text
+Canonical doctrine and contracts
+        ↓
+Human and AI executors
+        ↓
+Autonomous repositories
+        ↓
+Autonomous maintenance layer
+        ↓
+Evidence and review-ready proposals
+        ↓
+Human approval for consequential transitions
+```
+
+This layer keeps independently owned repositories convergent without requiring
+one shared runtime implementation. It can detect drift, perform narrowly
+bounded reversible hygiene, and prepare focused changes. Repository-local
+authority, canonical validation, explicit producer/consumer contracts, and
+human approval boundaries continue to control.
+
+Exact schedules, automation identifiers, workstation paths, credentials,
+notification routes, and scheduler implementations are local operational
+configuration. The architectural responsibilities, authority classes,
+evidence contract, and self-review expectations live in
+[`maintenance-automations.md`](maintenance-automations.md).
+
 ## State Boundaries
 
 Retained knowledge should move through distinguishable states instead of
@@ -120,7 +156,8 @@ checking, rendering, and reuse without making the underlying knowledge opaque.
 ### Human-In-The-Loop Governance
 
 Automation can acquire, normalize, summarize, compare, and suggest. Humans
-still own retention decisions, promotion decisions, and governance boundaries.
+still own retention decisions, promotion decisions, governance boundaries, and
+consequential or irreversible transitions.
 
 Pull requests are the normal review surface for durable changes. That keeps
 model-assisted operations visible in diffs, validation output, review notes,
@@ -180,8 +217,9 @@ The preferred path is:
 4. promote the reusable lesson
 5. tighten mechanical enforcement only after the rule is stable enough to check
 
-Schemas and automation should follow durable patterns, not lead them before the
-workflow is understood.
+Schemas and automation implementations should follow durable patterns, not lead
+them before the workflow is understood. The autonomous maintenance layer may
+surface repeated gaps, but it does not promote its own findings into doctrine.
 
 ### Solo Operator Scaling Direction
 
@@ -210,6 +248,9 @@ Repo-local sovereignty remains the default. Discovery should be report-only
 before mutation, and cross-repo changes should be decomposed into separately
 reviewable repository PRs rather than bundled into mega-changes. Avoid standing
 centralized control planes, unbounded autonomy, and premature standardization.
+The autonomous maintenance layer supports this sovereignty by coordinating
+recurring convergence through repository-owned validation and review surfaces,
+not by taking ownership of repository implementations.
 
 Promote new workflow abstractions only after repeated evidence from real repo
 work shows that they reduce review or coordination burden without becoming

--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -73,9 +73,9 @@ contracts remain authoritative for their domains.
 ## Autonomous Maintenance Layer
 
 The ecosystem includes an **autonomous maintenance layer** that performs
-recurring, bounded inspection, maintenance, and improvement across independent
-repositories. It is a first-class architectural capability rather than a
-particular repository, scheduler, or automation inventory.
+recurring, bounded inspection, maintenance, and improvement across independently
+governed repositories. It is a first-class architectural capability rather
+than a particular repository, scheduler, or automation inventory.
 
 The layer closes the feedback loop between canonical expectations and current
 repository state:
@@ -85,7 +85,7 @@ Canonical doctrine and contracts
         ↓
 Human and AI executors
         ↓
-Autonomous repositories
+Independently governed repositories
         ↓
 Autonomous maintenance layer
         ↓
@@ -96,9 +96,9 @@ Human approval for consequential transitions
 
 This layer keeps independently owned repositories convergent without requiring
 one shared runtime implementation. It can detect drift, perform narrowly
-bounded reversible hygiene, and prepare focused changes. Repository-local
-authority, canonical validation, explicit producer/consumer contracts, and
-human approval boundaries continue to control.
+bounded hygiene under mechanically verifiable safety predicates, and prepare
+focused changes. Repository-local authority, canonical validation, explicit
+producer/consumer contracts, and human approval boundaries continue to control.
 
 Exact schedules, automation identifiers, workstation paths, credentials,
 notification routes, and scheduler implementations are local operational

--- a/docs/cross-repo-glossary.md
+++ b/docs/cross-repo-glossary.md
@@ -170,6 +170,22 @@ State who declares the capability, how it is verified, and whether it is
 required, optional, or merely observed. A capability flag must not hide an
 incompatible semantic change.
 
+### Autonomous Maintenance Layer
+
+The **autonomous maintenance layer** is the ecosystem capability that performs
+recurring, bounded inspection, maintenance, and improvement across independent
+repositories.
+
+It may produce findings, review-ready proposals, or narrowly scoped reversible
+hygiene. It does not own canonical doctrine, repository-local policy,
+producer/consumer semantics, merge decisions, or consequential transitions.
+Its scheduler and enabled automation inventory are local configuration; its
+authority boundaries and evidence contract are architectural doctrine.
+
+Use this governed term for the layer. Use “automation” or “job” only for a
+specific implementation within it. Do not use “autonomous” to imply unrestricted
+mutation authority.
+
 ## Usage Guidance
 
 - Prefer qualified phrases in cross-repo docs, issues, prompts, and PRs.

--- a/docs/cross-repo-glossary.md
+++ b/docs/cross-repo-glossary.md
@@ -173,14 +173,17 @@ incompatible semantic change.
 ### Autonomous Maintenance Layer
 
 The **autonomous maintenance layer** is the ecosystem capability that performs
-recurring, bounded inspection, maintenance, and improvement across independent
-repositories.
+recurring, bounded inspection, maintenance, and improvement across independently
+governed repositories.
 
-It may produce findings, review-ready proposals, or narrowly scoped reversible
-hygiene. It does not own canonical doctrine, repository-local policy,
-producer/consumer semantics, merge decisions, or consequential transitions.
-Its scheduler and enabled automation inventory are local configuration; its
-authority boundaries and evidence contract are architectural doctrine.
+It may produce findings, review-ready proposals, or bounded hygiene under
+mechanically verifiable safety predicates. Bounded hygiene may include cleanup
+that is not literally reversible and therefore needs recovery evidence or a
+documented recovery path where practical. The layer does not own canonical
+doctrine, repository-local policy, producer/consumer semantics, merge decisions,
+or consequential transitions. Its scheduler and enabled automation inventory
+are local configuration; its authority boundaries and evidence contract are
+architectural doctrine.
 
 Use this governed term for the layer. Use “automation” or “job” only for a
 specific implementation within it. Do not use “autonomous” to imply unrestricted

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -3,10 +3,10 @@
 ## Purpose
 
 The **autonomous maintenance layer** is the ecosystem capability that performs
-recurring, bounded inspection, maintenance, and improvement across otherwise
-independent repositories. It shortens the half-life of repository entropy by
-turning drift and maintenance needs into durable evidence, reversible hygiene,
-or review-ready proposals.
+recurring, bounded inspection, maintenance, and improvement across independently
+governed repositories. It shortens the half-life of repository entropy by
+turning drift and maintenance needs into durable evidence, bounded hygiene, or
+review-ready proposals.
 
 This layer is part of the ecosystem architecture, not merely a scheduler
 convenience. Without it, independently owned repositories tend to diverge from
@@ -26,7 +26,7 @@ Canonical doctrine and contracts
         ↓
 Human and AI executors
         ↓
-Autonomous repositories
+Independently governed repositories
         ↓
 Autonomous maintenance layer
         ↓
@@ -110,8 +110,10 @@ behavior and authority. Typical purposes include:
   examples, and documentation when deletion is demonstrably safe
 
 Maintenance may produce a review-ready change or perform narrowly bounded,
-reversible hygiene. It must stop when safety depends on interpretation,
-unverified state, or a broader product decision.
+mechanically justified hygiene. Branch deletion and safe surface removal are
+cleanup operations, not inherently reversible actions. The capability must stop
+when safety depends on interpretation, incomplete evidence, uncertain
+ownership, or a broader product decision.
 
 ### Periodic Engineering Investment
 
@@ -141,10 +143,14 @@ runs:
   Evidence includes the diff, rationale, canonical validation result, residual
   risk, and any source uncertainty. Human review remains the acceptance and
   merge boundary.
-- **Perform reversible hygiene**: execute only an explicitly documented,
-  narrowly scoped operation whose safety predicates can be verified before
-  mutation. Evidence records the predicate, action, outcome, and preserved or
-  escalated cases. Ambiguity causes a skip, not a guessed correction.
+- **Perform bounded hygiene**: execute only an explicitly documented, narrowly
+  scoped operation whose safety predicates can be mechanically verified before
+  mutation. The operation may include safe cleanup that is not literally
+  reversible. Evidence records the predicates, relevant pre-mutation state or
+  identifiers when recovery may be needed, action, outcome, and preserved or
+  escalated cases. Use a documented recovery path where one is practical. Stop
+  and escalate when safety depends on interpretation, incomplete evidence, or
+  uncertain ownership.
 
 No class silently crosses an irreversible or consequential approval boundary.
 An automation that needs broader authority must stop and return evidence for a
@@ -244,7 +250,7 @@ periodic review. Inspect for:
 - capability gaps that leave important doctrine or repository risks unchecked
 
 Preserve intentional differences between read-only inspection, proposal work,
-reversible hygiene, and repository-specific validation. The goal is coherent
+bounded hygiene, and repository-specific validation. The goal is coherent
 coverage, not identical prompts or implementations.
 
 Health review may recommend consolidating responsibilities, clarifying a

--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -1,450 +1,285 @@
-# Maintenance Automations
+# Autonomous Maintenance Layer
 
-Codex maintenance automations are part of the orchestration model: they keep
-recurring checks visible, bounded, and reviewable without turning the playbook
-into an automation implementation repo.
+## Purpose
 
-This document owns reusable policy, canonical prompt intent, and governance
-expectations for maintenance automation. It does not own executable automation
-state. Active local automation configuration under
-`~/.codex/automations/*/automation.toml`, plus companion config files
-referenced by those automations, remains the discovery and inspection source
-for live automation state, current prompt/config content, schedules,
-enablement, execution paths, and operator-controlled runtime fields.
+The **autonomous maintenance layer** is the ecosystem capability that performs
+recurring, bounded inspection, maintenance, and improvement across otherwise
+independent repositories. It shortens the half-life of repository entropy by
+turning drift and maintenance needs into durable evidence, reversible hygiene,
+or review-ready proposals.
 
-Workspace-level automation outputs follow the shared workspace convention:
-`scratch/` is for temporary and disposable working material, `logs/` is for
-durable operational logs and automation run records, and `history/` is for
-durable important artifacts or documents without another natural repository
-home. Under `logs/`, use the producer ID as the first directory:
-`logs/<producer-id>/<run-artifact>`. Here, `<producer-id>` is the stable
-automation ID for recurring automations or the canonical producer/tool ID for
-durable non-automation producers. Keep one producer's chronology together even
-when it operates across several repositories; put repository names in
-filenames, artifact metadata, or a per-run directory instead of making
-repositories the primary grouping.
+This layer is part of the ecosystem architecture, not merely a scheduler
+convenience. Without it, independently owned repositories tend to diverge from
+canonical doctrine, governance, documentation, workflow, and configuration
+expectations between human review cycles.
 
-For an ordinary run that emits one report, prefer a deterministic readable
-name such as
-`logs/<producer-id>/<YYYY-MM-DD>-<short-description>.<ext>`. When one run
-emits separate artifacts for several repositories, prefer
-`logs/<producer-id>/<YYYY-MM-DD>/<repository-name>.<ext>`. Do not introduce
-a date directory when a run normally emits only one or a few files. Keep
-repo-local outputs in their canonical repository locations when one exists.
-Automation prompts must create the selected producer or per-run output
-directory before writing and must not create run artifacts directly in the
-root of `logs/`.
+The governed term is **autonomous maintenance layer**. “Autonomous” describes
+recurring execution within a bounded authority envelope. It does not mean
+unrestricted operation or authority to cross consequential approval boundaries.
 
-## Automation Intent Registry
+## Architectural Position
 
-The registry below records intended prompt semantics and drift-handling
-expectations for known maintenance automations. Update registry entries only
-when durable intended semantics, governance expectations, scope, or companion
-ownership changes. Do not use registry rows as a live conformance log,
-operational audit ledger, or runtime observation store.
+The layer closes a continuous feedback loop:
 
-Registry entries are canonical only for intended semantics, governance
-expectations, and reconciliation guidance. They are normalized summaries
-of intended behavior, not raw TOML mirrors. They are not executable automation
-state and must not be treated as proof that an automation exists, is enabled,
-uses a particular schedule, or currently contains a matching prompt.
+```text
+Canonical doctrine and contracts
+        ↓
+Human and AI executors
+        ↓
+Autonomous repositories
+        ↓
+Autonomous maintenance layer
+        ↓
+Evidence and review-ready proposals
+        ↓
+Human approval for consequential transitions
+```
 
-### 🧹 Delete Merged Repo Branches
+Doctrine and contracts define expected behavior. Executors perform explicit
+work. Repositories retain local authority over implementation, validation, and
+change acceptance. The autonomous maintenance layer periodically checks those
+surfaces, performs only work within its declared authority, and returns
+inspectable evidence to repository and human review paths.
 
-- Automation name: 🧹 Delete merged repo branches
-- Automation ID: `delete-merged-repo-branches`
-- Scope / target repositories: `knowledge-adapters`, `knowledge-vault`,
-  `ka-destinations`, `ai-workflow-playbook`, `ai-workflow-enforcement`,
-  `ai-workflow-incubator`, `linode-image-lab`, `lke-image-lab`,
-  `linode-backup-lab`, `nexus`, `trusted-network-registry`, and `.github`.
-  `leadership-workbench` is intentionally excluded because the repository is a
-  private, Markdown-only leadership workspace whose current policy does not
-  clearly opt it into mutating branch-cleanup automation.
-- Mode: Mutating only through the owning tool's explicit `--apply` path for
-  Git-proven normal cleanup. Stale non-ancestor cleanup remains report-only
-  unless explicit human-approved evidence exists in the companion config and
-  the owning tool validates it.
-- Purpose / intent: Keep local and remote branch refs tidy by delegating
-  cleanup decisions to `enforcement.branch_cleanup`, while reporting preserved,
-  blocked, failed, and stale refs.
-- Canonical prompt intent summary: Read the playbook startup guidance,
-  maintenance automation guidance, and branch-cleanup tool guidance before
-  running. Use only configured target repositories. Treat the enforcement tool
-  output as authoritative for cleanup classifications and never recreate branch
-  cleanup or stale-validation policy in prompt text.
-- Canonical execution expectations: Use direct Git and Python commands from
-  the `ai-workflow-enforcement` checkout. Refresh the enforcement checkout and
-  configured target repositories only through the safe local refresh rule
-  below. Run bounded normal cleanup with
-  `python3 -m enforcement.branch_cleanup --config <branch-cleanup-config> --apply --retry-normal-cleanup --max-apply-passes 3`,
-  then run stale/non-ancestor audit with
-  `python3 -m enforcement.branch_cleanup --config <branch-cleanup-config> --audit-stale --audit-github-prs`.
-  Save durable JSON stale-audit reports under workspace `logs/`. Report
-  deleted, preserved, skipped, blocked, failed, stale-candidate, and human-review
-  refs from tool output.
-- Companion config references:
-  `~/.codex/automations/delete-merged-repo-branches/branch-cleanup.json`
-  owns target repositories, protected branches, and stale approval evidence.
-  `ai-workflow-enforcement/docs/branch-cleanup.md` owns tool behavior.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  and companion config before comparison. Reconcile prompt content to the
-  intended semantics and safe local refresh rule below only when explicitly
-  directed. Do not copy stale approval entries, runtime state, raw config,
-  operational findings, or run records into the playbook.
+The feedback loop is architectural even when its scheduler, runtime, prompts,
+tools, and cadence vary by machine or operator.
 
-### 🧠 Staging Vs Canon Audit
+## Responsibilities And Non-Responsibilities
 
-- Automation name: 🧠 Staging vs Canon Audit
-- Automation ID: `staging-vs-canon-audit`
-- Scope / target repositories: The `ctrl-alt-keith` workspace guidance layer,
-  including `ai-workflow-playbook`, repo-local `AGENTS.md` files,
-  `ai-workflow-incubator` staging/reference material, and local workspace
-  routing guidance.
-- Mode: Report-only read-only audit.
-- Purpose / intent: Detect documentation drift, accidental authority,
-  shadow-canonical guidance, stale staging material, and repo-level
-  duplication of canonical workflow rules.
-- Canonical prompt intent summary: Treat `ai-workflow-playbook` as canonical
-  reusable guidance, repo-local `AGENTS.md` files as repository execution
-  layers, and `ai-workflow-incubator` as private noncanonical staging. Audit
-  only inside the workspace boundary and treat sibling repositories as
-  independent units.
-- Canonical execution expectations: Stay read-only. Do not fetch, pull,
-  checkout, merge, rebase, reset, or modify refs. Ignore generated,
-  dependency, cache, virtualenv, and tool-managed paths. Classify findings as
-  remove, trim, keep, defer, or promotion candidate, and report repository
-  freshness only as context when it can be checked without mutation.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes any change that makes staging
-  material canonical, mixes repository findings as one shared working tree, or
-  permits repository, automation, or workspace mutation.
+The autonomous maintenance layer owns:
 
-### 🔍 AGENTS Drift Detector
+- recurring inspection for doctrine, governance, documentation, workflow,
+  configuration, repository-scope, and automation drift
+- bounded maintenance whose safety predicates and stop conditions are explicit
+- focused improvement proposals when a repository has a high-leverage gap
+- durable evidence for findings, actions, validation, skips, and uncertainty
+- review-ready repository changes when correction is authorized
+- periodic review of the maintenance layer itself
 
-- Automation name: 🔍 AGENTS Drift Detector
-- Automation ID: `agents-drift-detector`
-- Scope / target repositories: `ai-workflow-playbook`,
-  `ai-workflow-enforcement`, `ai-workflow-incubator`, `leadership-workbench`,
-  `knowledge-adapters`, `knowledge-vault`, `ka-destinations`, `linode-image-lab`,
-  `lke-image-lab`, `linode-backup-lab`, `nexus`,
-  `trusted-network-registry`, and `.github`, plus the local-only workspace
-  `AGENTS.md`.
-- Mode: Report-only audit.
-- Purpose / intent: Audit repo-local `AGENTS.md` guidance and local
-  workspace-routing guidance against the canonical playbook.
-- Canonical prompt intent summary: Treat `ai-workflow-playbook` as canonical
-  reusable workflow guidance, each repo-local `AGENTS.md` as the repository
-  execution layer, the workspace `AGENTS.md` as local-only routing guidance,
-  and `ai-workflow-incubator` as private noncanonical staging.
-- Canonical execution expectations: For each repository, fetch `origin main`
-  and inspect current `origin/main` state without modifying files or branches.
-  Mark repositories blocked when `origin/main` cannot be fetched or inspected.
-  Inspect the local workspace `AGENTS.md` as local-only guidance. Compare
-  repo-local guidance against the playbook and relevant workspace-routing
-  guidance; report High/Medium findings separately from Low-only observations.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes treating the workspace `AGENTS.md`
-  as canonical repository policy, auditing local working trees instead of
-  fetched `origin/main`, inventing missing repo details, or allowing mutation.
+It does not own:
 
-### 🛡️ Workflow Drift Audit
+- canonical doctrine, repository-local policy, or producer/consumer semantics
+- a repository's implementation decisions, validation contract, or acceptance
+  decision
+- silent correction of ambiguous state
+- merge, release, publication, migration, credential, permission, or other
+  consequential transitions without explicit human authorization
+- a standing mandate to normalize every repository or eliminate intentional
+  differences
+- the live scheduler inventory or machine-specific runtime configuration
 
-- Automation name: 🛡️ Workflow Drift Audit
-- Automation ID: `workflow-drift-audit`
-- Scope / target repositories: The `ctrl-alt-keith` workspace guidance and
-  workflow-policy surfaces covered by the enforcement drift scanner:
-  `ai-workflow-incubator` notes roots, `ai-workflow-playbook/docs`, and all
-  visible repositories in the `ctrl-alt-keith` GitHub organization, discovered
-  dynamically at runtime.
-- Mode: Report-only advisory scan.
-- Purpose / intent: Invoke the calibrated `ai-workflow-enforcement` drift
-  scanner directly and report workflow-policy drift findings.
-- Canonical prompt intent summary: Treat the scanner as advisory, local
-  automation config as runtime state, and generated reports as local-only.
-  Do not auto-fix findings or duplicate scanner semantics in prompt text.
-- Canonical execution expectations: Work from the `ai-workflow-enforcement`
-  checkout. Inspect git status, skip if the working tree would make results
-  ambiguous, record the tested commit SHA, verify `gh` organization access, and
-  run
-  `python3 -m enforcement.cli --notes-root ../ai-workflow-incubator --playbook-root ../ai-workflow-playbook/docs --workspace-root .. --organization ctrl-alt-keith --ignore 'archive/**'`.
-  Save durable local report artifacts under workspace `logs/`.
-  Do not fetch, pull, switch branches, commit, open PRs, modify files, delete
-  worktrees, or delete branches.
-- Companion config references: None. Repository scope comes from live GitHub
-  organization enumeration, not a local allowlist.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes mutating repositories, treating
-  advisory scanner findings as failures, narrowing repository scope with a
-  local allowlist, or creating a secondary drift scanner.
+Recurring findings can reveal a missing or unclear canonical contract. The
+layer should report that pattern for doctrine or contract work rather than
+repairing the same symptom indefinitely or promoting its own prompt into
+shadow canon.
 
-### 🛡️ Repo Governance Audit
+## Capability Model
 
-- Automation name: 🛡️ Repo Governance Audit
-- Automation ID: `repo-governance-audit`
-- Scope / target repositories: All visible repositories in the
-  `ctrl-alt-keith` GitHub organization, discovered dynamically at runtime.
-- Mode: Report-only advisory scan.
-- Purpose / intent: Invoke the centralized `ai-workflow-enforcement`
-  repository settings audit directly across visible organization repositories
-  and report hosted governance drift.
-- Canonical prompt intent summary: Use the merged `main` state of
-  `ai-workflow-enforcement` as the audit implementation source. Enumerate
-  repositories with `gh`; do not use a hard-coded allowlist as the source of
-  repository scope. Report drift, unknowns, stale local/source-ref drift, and
-  audit/runtime failures without remediation.
-- Canonical execution expectations: Inspect the enforcement checkout, update
-  local `main` only through safe local refresh, confirm it matches
-  `origin/main`, record the tested commit SHA, verify `gh` organization
-  access, and run
-  `python3 -m enforcement.repo_settings_audit --repo ctrl-alt-keith/<repo> --source-ref main --output-format json`
-  for each visible repository. Save durable local report artifacts under
-  workspace `logs/`. Do not pass `--fail-on-drift`, mutate hosted settings,
-  commit, push, open PRs, delete branches, delete worktrees, or edit automation
-  config.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes hard-coded repository scope,
-  hosted remediation, failure-on-drift behavior, stale local source ambiguity,
-  or unsafe local refresh semantics.
+Describe maintenance capabilities by purpose and cadence class. The categories
+below are architectural capability families, not a permanent inventory of
+individual jobs.
 
-### 🔎 Org PR And Issue Scan
+### Periodic Inspection And Drift Detection
 
-- Automation name: 🔎 Org PR and Issue Scan
-- Automation ID: `org-pr-issue-scan`
-- Scope / target repositories: All visible repositories in the
-  `ctrl-alt-keith` GitHub organization, discovered by the owning enforcement
-  scanner.
-- Mode: Report-only inventory scan.
-- Purpose / intent: Report current open pull requests and open issues across
-  visible organization repositories.
-- Canonical prompt intent summary: Use the owning `ai-workflow-enforcement`
-  scanner directly, keep generated reports local-only, and treat the result as
-  inventory rather than remediation.
-- Canonical execution expectations: Work from the `ai-workflow-enforcement`
-  checkout. Inspect git status, skip if the working tree would make results
-  ambiguous, record the tested commit SHA, verify `gh` organization access,
-  and run `python3 -m enforcement.org_pr_issue_scan --org ctrl-alt-keith`.
-  Save durable local report artifacts under workspace `logs/`. Do not fetch,
-  pull, switch branches, commit, open PRs, modify files, delete worktrees,
-  delete branches, or create, edit, close, label, assign, or comment on GitHub
-  issues or pull requests.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes recreating scanner behavior in
-  prompt text, mutating GitHub issues or pull requests, omitting skipped or
-  inaccessible repositories, or treating inventory as remediation.
+Inspection capabilities compare current source state with an owning contract or
+policy and produce findings without assuming correction authority. Typical
+purposes include:
 
-### 🧪 Knowledge-Adapters Weekly Chaos-All Validation
+- identifying oversized operational memory and proposing compact replacements
+  without silently rewriting retained state
+- detecting drift in repository guidance, canonical doctrine, governance,
+  documentation, workflows, configuration, provider-facing policy, and
+  repository inventory
+- comparing staging or experimental guidance with canonical sources
+- reviewing the automation fleet for accidental divergence while preserving
+  intentional specialization
 
-- Automation name: 🧪 knowledge-adapters weekly chaos-all validation
-- Automation ID: `knowledge-adapters-weekly-chaos-all-validation`
-- Scope / target repositories: `knowledge-adapters`.
-- Mode: Report-only scheduled validation.
-- Purpose / intent: Run exhaustive validation for `knowledge-adapters` and
-  report the result.
-- Canonical prompt intent summary: Refresh the target repository from current
-  `origin/main` only when safe, run the canonical exhaustive validation command,
-  report the tested commit SHA, and summarize failures with the smallest useful
-  follow-up when validation fails.
-- Canonical execution expectations: Use the safe local refresh rule below.
-  Run `make chaos-all`. Do not modify files, open PRs, or run live-service or
-  credential-dependent checks.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes underspecified or unsafe refresh
-  behavior, mutation, PR creation, live-service checks, or replacing
-  `make chaos-all` with a narrower validation command.
+Inspection is normally read-only. A finding should identify the checked source,
+expected authority, observed difference, scope, and any skipped or unknown
+state.
 
-### 🛰️ Region Policy Drift Review
+### Periodic Repository Maintenance
 
-- Automation name: 🛰️ Region Policy Drift Review
-- Automation ID: `region-policy-drift-review`
-- Scope / target repositories: Single execution root in `linode-image-lab`.
-  `ai-workflow-playbook` is a source to rehydrate from, not a second
-  automation workspace root.
-- Mode: Report-only scheduled drift review. Local artifact regeneration,
-  validation, and diff inspection are allowed only inside the checked-out
-  repository state being reviewed.
-- Purpose / intent: Detect drift in the checked-in
-  `linode-image-lab` region policy artifact workflow and recommend whether a
-  PR or playbook guidance update is warranted.
-- Canonical prompt intent summary: Use GitHub as the source of truth, keep the
-  automation single-rooted so the runner starts one job, and treat detached or
-  ephemeral worktree execution as normal for this report-only job. Rehydrate
-  from the playbook startup guidance, `linode-image-lab/AGENTS.md`, and the
-  documented region-policy commands in `linode-image-lab/README.md`.
-  Read playbook guidance from a sibling checkout when available, or from
-  `ctrl-alt-keith/ai-workflow-playbook` current GitHub `main` when the sibling
-  checkout is not present in the automation workspace.
-  Verify current `main`, regenerate and validate `policy/region-policy.toml`,
-  run the repository's canonical validation entrypoint when available, then
-  inspect the resulting artifact diff. Report the verified main commit,
-  validation status, new and removed provider regions, capability changes,
-  generated group changes, image-replication helper group changes, provider
-  override changes, stale or removable
-  `provider_overrides.image_replication_excluded_regions` entries, and whether
-  a PR is warranted.
-- Canonical execution expectations: Prefer the documented
-  `linode-image-lab region-policy ...` commands, and use the repo-local
-  `PYTHONPATH=src python3 -m linode_image_lab.cli region-policy ...`
-  equivalent when the package command is unavailable in the automation
-  environment. If regeneration succeeds and the artifact diff is empty, report
-  no drift without an extra external web research pass. Use official Linode
-  documentation only when the regenerated artifact, repository assumptions, or
-  provider override status creates a concrete ambiguity that repository sources
-  cannot resolve. Do not mutate provider resources, run live provider
-  operations, read `LINODE_TOKEN`, create summary or memory files, open a PR,
-  or update playbook guidance unless explicitly asked.
-- Companion config references: None.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes using local repository state as the
-  source of truth instead of current GitHub state, adding multiple automation
-  workspace roots that cause one run per repository, treating detached worktree
-  execution as an implementation-mode problem, omitting regeneration,
-  validation, canonical validation, or diff inspection, dropping reported drift
-  categories, doing unnecessary external research after an empty artifact diff,
-  reading provider credentials, mutating provider resources, creating local
-  report or memory files, opening PRs without explicit instruction, or treating
-  observed drift as automatic authorization to update playbook guidance.
+Maintenance capabilities reduce known entropy while preserving repository
+behavior and authority. Typical purposes include:
 
-### 🗜️ Compact Memory
+- removing branches only when the owning cleanup contract proves they are safe
+  to delete, while escalating ambiguous ancestry or ownership
+- reconciling documentation with verified implemented behavior
+- removing obsolete or redundant code, configuration, dependencies, scripts,
+  examples, and documentation when deletion is demonstrably safe
 
-- Automation name: 🗜️ Compact Memory
-- Automation ID: `compact-memory`
-- Scope / target repositories: Active Codex automation memory files matching
-  `~/.codex/automations/*/memory.md`.
-- Mode: Report-only proposal.
-- Purpose / intent: Identify oversized automation memory files and propose
-  compact replacements that preserve durable operational state.
-- Canonical prompt intent summary: Treat 25 KiB as the default oversized
-  threshold. Preserve automation purpose, durable decisions, active risks,
-  unresolved TODOs or blockers, and recent operational state while reducing
-  repetitive historical run detail.
-- Canonical execution expectations: Inspect active `memory.md` files only.
-  Do not mutate memory files, automation configs, repositories, branches, or
-  working trees. Do not create archive copies or `memory.*.md` siblings under
-  `~/.codex/automations/*/`. Do not introduce scripts, enforcement tools, or
-  automatic rewriters. If preservation is explicitly requested for a rewrite,
-  use an archive location outside active automation directories.
-- Companion config references: None. Active `memory.md` files are inspected
-  data for the report, not repository-owned companion config.
-- Reconciliation / drift handling: Freshly inspect the active `automation.toml`
-  before comparison. Prompt drift includes automatic memory mutation,
-  repository mutation, archive sibling creation inside active automation
-  directories, or discarding durable state.
+Maintenance may produce a review-ready change or perform narrowly bounded,
+reversible hygiene. It must stop when safety depends on interpretation,
+unverified state, or a broader product decision.
 
-## Guidance Layers
+### Periodic Engineering Investment
 
-- Follow the authority boundary in
-  [`start-here.md`](start-here.md#core-invariants).
-- Live local automation configuration is authoritative for discovered
-  automation inventory, current runtime prompt/config state, schedules,
-  enablement state, execution environment, model selection, runtime IDs,
-  local environment config paths, and platform-managed state.
-- This playbook is authoritative for intended semantics, governance
-  expectations, source-first inspection requirements, safe refresh rules,
-  drift review expectations, and canonical prompt intent.
-- Workspace-level routing guidance may live in a local-only workspace
-  `AGENTS.md`. It can describe multi-repository boundaries, scratch usage,
-  command form, and how to enter target repositories, but it is noncanonical
-  and must not define repository branch, commit, PR, or validation policy.
-- Repo-local execution guidance belongs in each repository's `AGENTS.md`; see
-  [`repo-readiness.md`](repo-readiness.md#agentsmd-responsibilities).
-- Drift review should compare repo-local `AGENTS.md` files against the playbook
-  and any relevant workspace-routing guidance, while comparing workspace-level
-  routing guidance against reusable playbook expectations and observed
-  repo-local execution patterns. Do not require the workspace file to duplicate
-  repo-only rules.
+Investment capabilities look for one focused improvement rather than broad
+repository redesign. Typical purposes include:
 
-## Prompt Drift Review
+- selecting and implementing one high-leverage improvement per active
+  repository
+- identifying the most valuable test gap and preparing a focused correction
+- running exhaustive, stress, or chaos-oriented validation where the
+  repository's risk and validation contract justify recurring verification
 
-Automation prompt/config alignment is a source-first workflow:
+These capabilities do not create an evergreen backlog mandate. Each run must
+justify its selected scope against current repository evidence and leave
+unselected opportunities as findings rather than absorbing them into the same
+change.
 
-1. Inspect active local automation config first:
-   `~/.codex/automations/*/automation.toml` and companion config files
-   referenced by those automations.
-2. Compare the live prompt/config semantics against this registry's canonical
-   intended semantics and the operating rules below.
-3. Classify semantic drift separately from runtime/operator state. Prompt
-   content that changes the intended behavior, safety predicates, authority
-   boundaries, or skip conditions is semantic drift. Schedules, enablement,
-   model choice, execution environment, timestamps, execution history,
-   connector metadata, opaque platform IDs, and other runtime fields are not
-   repository-doc drift.
-4. Reconcile only intended prompt/content drift when explicitly directed.
-   Preserve runtime and operator-controlled fields in the live automation
-   platform/configuration unless the human explicitly asks to change that live
-   state.
+## Authority And Evidence Classes
 
-For repository changes, update this registry only with intent-oriented facts:
-automation name, stable local ID when it is human meaningful, scope, mode,
-purpose, expected prompt semantics, companion config references, and
-drift-handling expectations. Do not copy raw `automation.toml` files, full
-prompt dumps, schedules, enablement state, execution logs, timestamps,
-connector metadata, secrets, tokens, runtime snapshots, opaque runtime IDs, or
-platform-managed state into the repository.
+Every recurring capability declares one of these authority classes before it
+runs:
 
-## Operating Rules
+- **Observe and report**: read current sources and produce findings. Evidence
+  identifies inspected sources, tested refs or versions when relevant, scope,
+  results, skips, unknowns, and failures. No repository or hosted state changes.
+- **Propose review-ready changes**: create a bounded branch and pull request.
+  Evidence includes the diff, rationale, canonical validation result, residual
+  risk, and any source uncertainty. Human review remains the acceptance and
+  merge boundary.
+- **Perform reversible hygiene**: execute only an explicitly documented,
+  narrowly scoped operation whose safety predicates can be verified before
+  mutation. Evidence records the predicate, action, outcome, and preserved or
+  escalated cases. Ambiguity causes a skip, not a guessed correction.
 
-- Name recurring automations by purpose so their intent is clear in schedules,
-  reports, and follow-up.
-- Automation prompts that touch repositories should state the interaction mode
-  from [`repo-readiness.md`](repo-readiness.md#interaction-mode-preflight).
-- Automation prompts intended for another agent or tool should be complete,
-  self-contained, and ready to paste by default. If an automation prompt update
-  asks to add or incorporate new guidance, provide the full updated prompt
-  unless the human explicitly asks for a delta, patch, diff, or targeted edit.
-- Report-only is the default for audits and validation checks.
-- Mutating automations must be bounded, conservative, and skip on uncertainty.
-- Automation prompts should delegate reusable safety predicates to owning tools
-  when such tools exist, and should not duplicate full implementation logic in
-  prompt text.
-- When an authoritative module, CLI, reusable workflow, or Makefile target
-  already exists, invoke it directly. Do not build secondary audit/check
-  engines around it.
-- Wrapper or helper artifacts must stay orchestration-only or report-only and
-  non-authoritative. They may enumerate targets, call canonical commands, cache
-  raw outputs, collate results, and summarize reports, but they must not fork
-  parser behavior, reinterpret core semantics, or duplicate validation logic.
-- Audit prompt/config alignment from the active local automation configuration
-  files, not only from this registry. Use the registry to orient the review,
-  then inspect the owning `automation.toml` prompt/config and any companion
-  config files before classifying or correcting an automation.
-- When automations use local checkouts for advisory diagnostics, canonical
-  tool execution, or scheduled validation, they may refresh a checkout only
-  when the checkout exists, the working tree is clean, the checkout is on the
-  expected default branch, the branch tracks the expected upstream, and the
-  update can be completed with `git fetch` plus `git pull --ff-only`. If the
-  checkout is dirty, detached, on a feature branch, has unpushed work, lacks
-  upstream tracking, or cannot fast-forward cleanly, do not modify it; report
-  the local state as stale or blocked instead. Safe local refresh is not
-  hosted remediation. Do not switch branches to normalize state, use
-  `merge --ff-only` as a `pull --ff-only` fallback, reset, rebase, stash,
-  force checkout, delete branches, force-clean, or discard work.
-- When repository additions, removals, renames, archived state, visibility, or
-  coverage expectations change, refresh automation scope through the
-  repo-awareness and onboarding procedure in
-  [`repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md)
-  instead of editing prompt allowlists in isolation.
-- Skipped work should be reported with reasons, not hidden as a clean pass.
-- Automations must not replace repo validation, pull request review, or human
-  approval gates.
+No class silently crosses an irreversible or consequential approval boundary.
+An automation that needs broader authority must stop and return evidence for a
+separate human-authorized action.
 
-## Configuration Notes
+Evidence should live in the owning repository's normal review surface when a
+repository change is proposed. Report-only or cross-repository runs should use
+the workspace's designated durable operational-record location. Runtime output
+paths and notification routing remain local configuration.
 
-- Entries describe known maintenance automation intent at the time durable
-  guidance was last updated; they are not a live inventory or conformance
-  report.
-- This document summarizes behavior, intent, and drift-handling expectations;
-  it does not replicate full prompt bodies or local configuration.
-- Treat automation configuration, run state, schedules, and logs as local
-  operational state, not canonical workflow guidance.
-- Detailed automation configuration should remain in local configuration files,
-  not in the playbook.
-- When local automation configuration is human-maintained, follow the TOML
-  readability guidance in
-  [`engineering-baseline.md`](engineering-baseline.md#human-maintained-toml-readability).
-- Do not expose secrets, local-only paths, raw prompts containing private
-  context, or environment-specific details in the playbook.
+## Repository Autonomy
+
+The layer preserves repository autonomy by applying shared expectations through
+each repository's own authority surfaces:
+
+- repo-local `AGENTS.md` controls repository-specific execution
+- the repository's canonical validation command controls local readiness
+- each change remains one repository, one branch, one worktree, and one pull
+  request when that workflow applies
+- repository owners and human reviewers decide whether a proposal is accepted
+- intentional local differences remain valid when they are explicit and do not
+  violate a governing cross-repository contract
+
+Cross-repository inspection may enumerate and compare repositories, but
+mutation must remain decomposed into independently reviewable repository
+changes. The layer coordinates convergence; it does not turn the fleet into one
+shared working tree or centralized implementation.
+
+## Shared Evolution Versus Shared Implementation
+
+Recurring maintenance changes the economics of duplication because it can keep
+small conventions, documentation, governance, and bounded implementation
+patterns aligned across repositories. This can make independent implementations
+cheaper to operate when their ownership and validation need to remain local.
+
+That benefit has limits:
+
+- semantic integration seams still require explicit owners, versioned
+  contracts when compatibility must be negotiated, and producer/consumer
+  validation
+- automation is not a substitute for an interface contract
+- similar code in multiple repositories does not automatically justify a
+  shared library
+- recurring repair is not evidence that drift is harmless
+
+Choose a shared library only when stable shared semantics, centralized
+ownership, compatibility needs, or maintenance economics justify the added
+coupling. Keep implementations independent when repository-local ownership,
+release cadence, failure isolation, or small surface area is more valuable and
+recurring convergence can keep the bounded pattern aligned.
+
+If the same finding repeatedly crosses a semantic boundary, requires coordinated
+releases, or risks incompatible producer/consumer behavior, recurring
+convergence is insufficient. Define or strengthen the formal cross-repository
+contract instead; see
+[`repo-to-repo-interface-contracts.md`](repo-to-repo-interface-contracts.md).
+
+## Architecture Versus Local Configuration
+
+Canonical playbook doctrine owns:
+
+- the existence and purpose of the autonomous maintenance layer
+- its responsibility and non-responsibility boundaries
+- its authority classes, stop conditions, and evidence contract
+- its relationship to doctrine, executors, repositories, contracts, and human
+  approval
+- its self-review and drift expectations
+
+Local operational configuration owns unless a later, explicit contract promotes
+a detail:
+
+- exact execution times and weekdays
+- scheduler product and execution runtime
+- workstation paths and machine-specific credentials
+- local automation identifiers
+- notification routing
+- per-machine concurrency settings
+- the enabled job inventory, exact prompt content, and runtime history
+
+Active local configuration is authoritative for live inventory, schedules,
+enablement, runtime prompts, paths, and operator-controlled fields. It is not
+canonical doctrine. Canonical docs should describe capability purposes and
+safety contracts rather than mirror runtime configuration.
+
+## Maintenance-Layer Health
+
+The autonomous maintenance layer can drift and therefore requires its own
+periodic review. Inspect for:
+
+- overlapping or contradictory responsibilities
+- duplicated checks whose semantics have diverged
+- stale assumptions about repository scope or ownership
+- accidental coupling to one scheduler, workstation, or execution order
+- authority creep or weakened stop conditions
+- recurring findings that indicate a missing canonical contract
+- automations that repeatedly edit the same surfaces or undo one another
+- capability gaps that leave important doctrine or repository risks unchecked
+
+Preserve intentional differences between read-only inspection, proposal work,
+reversible hygiene, and repository-specific validation. The goal is coherent
+coverage, not identical prompts or implementations.
+
+Health review may recommend consolidating responsibilities, clarifying a
+canonical contract, retiring stale capabilities, or changing local runtime
+configuration. Changes to doctrine or repository state still follow their
+normal review paths.
+
+## Operating Contract
+
+- Retrieve authoritative repository, provider, contract, and runtime state
+  before classifying drift or acting.
+- Declare scope, authority class, safety predicates, stop conditions, and
+  evidence destination before mutation.
+- Invoke an owning module, CLI, workflow, or validation entrypoint directly
+  when one already defines the behavior. Orchestration may enumerate targets,
+  invoke canonical commands, and collate results; it must not fork semantics.
+- Treat skipped, inaccessible, stale, and ambiguous state as reportable results,
+  not clean passes.
+- Keep report-only work read-only and proposal work review-ready.
+- Preserve human approval for consequential or irreversible transitions.
+- Revisit repository scope through the repository-awareness procedure instead
+  of treating a local filesystem or stale allowlist as authoritative; see
+  [`repo-awareness-onboarding-refresh.md`](repo-awareness-onboarding-refresh.md).
+- Do not let recurring automation replace canonical validation, pull-request
+  review, explicit interface contracts, or repository-local authority.
+
+## Relationship To Other Guidance
+
+- [`ai-workflow-ecosystem.md`](ai-workflow-ecosystem.md) places the layer in the
+  ecosystem architecture.
+- [`repo-readiness.md`](repo-readiness.md) owns interaction modes, repository
+  isolation, validation, and governance posture.
+- [`orchestration-and-parallelism.md`](orchestration-and-parallelism.md) owns
+  worker-lane and reconciliation rules.
+- [`repo-to-repo-interface-contracts.md`](repo-to-repo-interface-contracts.md)
+  owns producer/consumer compatibility boundaries.
+- [`source-first-retrieval.md`](source-first-retrieval.md) owns evidence
+  ordering and source verification.

--- a/docs/repo-to-repo-interface-contracts.md
+++ b/docs/repo-to-repo-interface-contracts.md
@@ -127,6 +127,24 @@ needs to be negotiated or incompatible evolution must be detectable.
   its owning repository and PR. Land producer support before consumer opt-in
   when ordering matters; preserve an overlap window when practical.
 
+## Recurring Convergence Is Not Compatibility
+
+The autonomous maintenance layer can keep documentation, governance,
+conventions, and bounded implementation patterns aligned across repositories.
+That recurring convergence can reduce the maintenance cost of independent
+implementations, but it does not establish semantic compatibility.
+
+Use a formal producer/consumer contract when a repository consumes another
+repository's artifact or behavior and must detect incompatible evolution.
+Automation may inspect both sides, update fixtures, and propose coordinated
+changes, but the interface still needs explicit ownership, compatibility rules,
+and validation in the producer and consumer paths.
+
+Repeated automated repair at an integration seam is evidence that the contract
+may be missing or too weak. It is not a reason to accept permanent drift, and it
+does not by itself justify extracting similar implementations into a shared
+library.
+
 ## Review Questions
 
 - Does the contract describe the interface that exists, with links to current

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -23,9 +23,12 @@ acting.
   matching adapter exists
 - `docs/authoritative-source-check.md` -> advisory source scanner workflow
 - `docs/repo-awareness-onboarding-refresh.md` -> repository inventory refresh
-- `docs/maintenance-automations.md` -> autonomous maintenance layer,
-  capability classes, authority boundaries, and evidence expectations
 - `docs/prompts.md` -> reusable prompt templates
+
+The ecosystem includes an autonomous maintenance layer for recurring, bounded
+inspection, maintenance, and improvement. Its full doctrine is conditional;
+ordinary repository work does not need to hydrate it unless the task touches
+that layer.
 
 ## Conditional Guidance
 
@@ -38,6 +41,20 @@ cross-repository interfaces, or architectural terminology:
   contract pattern for cross-repository interfaces
 - `docs/cross-repo-glossary.md` -> qualified meanings for overloaded
   architecture terms across repositories
+
+Read `docs/maintenance-automations.md` when work involves any of these surfaces:
+
+- recurring automation design or review
+- automation prompt authoring
+- fleet-wide maintenance
+- governance or drift automation
+- scheduled inspection or correction
+- architecture analysis of the autonomous maintenance layer
+- changes to automation authority, evidence, scope, or safety contracts
+
+Ordinary repository implementation, review, issue triage, and “what changed?”
+work do not require the full maintenance doctrine unless the task also touches
+one of those surfaces.
 
 ## Instruction Hierarchy
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -23,8 +23,8 @@ acting.
   matching adapter exists
 - `docs/authoritative-source-check.md` -> advisory source scanner workflow
 - `docs/repo-awareness-onboarding-refresh.md` -> repository inventory refresh
-- `docs/maintenance-automations.md` -> recurring Codex maintenance automation
-  expectations
+- `docs/maintenance-automations.md` -> autonomous maintenance layer,
+  capability classes, authority boundaries, and evidence expectations
 - `docs/prompts.md` -> reusable prompt templates
 
 ## Conditional Guidance
@@ -32,6 +32,8 @@ acting.
 Read these only when the work involves multiple repositories,
 cross-repository interfaces, or architectural terminology:
 
+- `docs/ai-workflow-ecosystem.md` -> repository roles, autonomous maintenance,
+  state boundaries, and architectural direction
 - `docs/repo-to-repo-interface-contracts.md` -> lightweight producer/consumer
   contract pattern for cross-repository interfaces
 - `docs/cross-repo-glossary.md` -> qualified meanings for overloaded


### PR DESCRIPTION
## Summary

Close an architectural gap in the playbook by modeling recurring repository inspection, maintenance, and improvement as a first-class ecosystem capability.

The governed term is **autonomous maintenance layer**. The updated doctrine defines:

- its architectural position between independently governed repositories and human approval
- responsibility and non-responsibility boundaries
- purpose-based capability families for inspection, maintenance, and engineering investment
- three authority and evidence classes: observe and report, propose review-ready changes, and perform bounded hygiene
- repository-local-authority and human-approval safeguards
- periodic health review for drift within the layer itself

Bounded hygiene operates only under explicit, mechanically verifiable safety predicates. It records relevant pre-mutation state or identifiers when recovery may be needed, uses a documented recovery path where practical, and may include safe cleanup that is not literally reversible. Ambiguous evidence, ownership, or interpretation causes a stop and escalation.

The prior partial per-automation registry is removed. It mixed canonical intent with local IDs, paths, repository lists, and runtime assumptions, leaving the playbook as an incomplete fleet catalog. The replacement keeps architecture and reusable operating contracts canonical while leaving live inventory in its owning operational configuration.

## Startup routing

The playbook keeps compact awareness of the autonomous maintenance layer in `docs/start-here.md`, but the full maintenance doctrine is now conditional. Agents read it for recurring automation design or review, prompt authoring, fleet-wide maintenance, governance or drift automation, scheduled inspection or correction, layer architecture analysis, or changes to automation authority, evidence, scope, or safety contracts.

Ordinary repository implementation, review, issue triage, and “what changed?” work no longer hydrate the full maintenance document unless the task touches that layer. Repo-local `AGENTS.md`, the matching executor adapter, source-first retrieval, repo readiness, and canonical validation requirements remain unchanged.

## Architecture boundaries

Exact schedules, weekdays, scheduler products, workstation paths, credentials, local automation IDs, notification routing, per-machine concurrency, enabled-job inventory, prompt content, and runtime history remain local operational configuration.

The change also distinguishes **shared evolution from shared implementation**:

- recurring automation may keep conventions, documentation, governance, and bounded implementation patterns aligned
- semantic integration seams still require explicit owners, compatibility contracts, and producer/consumer validation
- automation is not a substitute for an interface contract
- repeated repair at an integration seam may indicate a missing or weak contract
- similar code does not automatically require extraction into a shared library

## Validation

- `make check` — passed; Markdown lint reported 0 errors and all 27 unit tests passed
- `make authoritative-source-check` — passed; no non-authoritative source URLs found
- `git diff --check` — passed

## Deliberate follow-up kept out of scope

Three live local automation prompts still reference the old maintenance-inventory framing. Their runtime configuration was intentionally not changed in this doctrine task. A separate operational consistency review should update those references after this architecture is accepted, while preserving their schedules and other operator-controlled fields.