### PR TITLE
CAK-70: codify question-typed authority allocation

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -45,6 +45,32 @@ ordinary chat, brainstorming, or conceptual discussion procedural.
   actual outcome instead of assuming the planned effect occurred, then
   reconcile separately owned systems only when their workflows require it.
 
+## Authority Follows The Question
+
+Do not select one universal system of record for a workflow. Classify the
+question first, then retrieve the source that owns that kind of fact:
+
+- Current human direction controls delegated intent and authority; the owning
+  task or planning surface controls recorded intent, priority, sequencing, and
+  acceptance context.
+- The owning repository and its hosted repository state control current files,
+  implementation, review, validation, and merge facts.
+- Canonical shared documentation controls reusable doctrine; repo-local
+  sources control repository-specific contracts and execution behavior.
+- The owning provider or runtime controls current external operational state.
+- Durable artifacts, receipts, reports, and logs answer historical execution
+  questions only within the claims and evidence they preserve; they do not
+  become proof of current mutable state or authority.
+
+Some questions cross these boundaries. Retrieve each applicable owner, keep
+the claims distinct, and reconcile them by owning scope and the applicable
+instruction hierarchy. Recorded planning intent does not override current
+human direction, and one source must not override facts owned by another.
+Availability, convenience, discoverability, integration quality, duplication,
+or durability does not transfer authority. For recovery, reconstruct the
+applicable contract and next action from the durable sources named by the
+owning workflow, then revalidate mutable facts.
+
 ## Protocol Invariants
 
 A reusable workflow protocol is defined by its reviewed semantic invariants,

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -255,9 +255,11 @@ branch, validation, and PR flow before calling them complete.
 
 For questions about repository implementation, GitHub is the authoritative
 hosted source unless repo-local guidance explicitly defines another owner.
-GitHub issues, pull requests, closing keywords, CI, review state, and merge
-state determine whether the repository work is implemented, reviewed,
-validated, or merged.
+GitHub issues, pull requests, closing keywords, hosted CI, hosted review state,
+and merge state determine the corresponding hosted issue, pull request,
+validation, review, and merge facts. Implementation may exist in an inspected
+local worktree before it is represented on GitHub, so implementation existence
+remains a repository-state question rather than a hosted-state inference.
 
 Planning systems such as Linear own their planning facts, including intent,
 acceptance context, assignment, sequencing, and planning status. They do not

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -253,16 +253,17 @@ branch, validation, and PR flow before calling them complete.
 
 ### Issue And Planning Coordination
 
-For repository implementation work, GitHub remains the implementation and
-closure source of truth unless repo-local guidance explicitly defines a
-different system of record. GitHub issues, pull requests, closing keywords, CI,
-review state, and merge state determine whether repo work is complete.
+For questions about repository implementation, GitHub is the authoritative
+hosted source unless repo-local guidance explicitly defines another owner.
+GitHub issues, pull requests, closing keywords, CI, review state, and merge
+state determine whether the repository work is implemented, reviewed,
+validated, or merged.
 
-Planning systems such as Linear are coordination layers by default. Use them to
-track planning intent, status, assignment, sequencing, or stakeholder context,
-but do not treat them as authoritative over repository implementation state
-unless the target repository explicitly says so. The same rule applies to
-similar planning mirrors or boards.
+Planning systems such as Linear own their planning facts, including intent,
+acceptance context, assignment, sequencing, and planning status. They do not
+override repository implementation state, just as GitHub merge state does not
+silently rewrite the planning intent or sequencing that produced the work. The
+same boundary applies to similar planning systems, mirrors, or boards.
 
 When both GitHub and planning identifiers exist, implementation PRs should
 reference both. Keep the GitHub closing keyword tied to the GitHub issue and

--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -19,6 +19,16 @@ issue, branch, commit, validation, runtime, provider, or external API state.
 This guidance describes observable workflow behavior and operational
 safeguards. It does not assume or describe platform internals.
 
+## Authority Selection
+
+Apply the question-typed authority rule in
+[`core-model.md`](core-model.md#authority-follows-the-question) before using the
+evidence hierarchy below. The hierarchy orders evidence for a claim only after
+the source that owns that kind of fact has been identified; it is not a global
+system-of-record ranking. When a question spans planning, repository, runtime,
+or historical evidence boundaries, retrieve each applicable owner and preserve
+their separate claims during reconciliation.
+
 ## Evidence Hierarchy
 
 Prefer evidence in this order when repository state is available:


### PR DESCRIPTION
## Summary

- make source authority explicitly question-typed in the general operating model
- clarify that source-first evidence ordering applies only after the owning source for a claim is identified
- preserve separate authority for planning facts, repository implementation state, and GitHub hosted facts

## Why

CAK-70 found that the current ecosystem already divides authority by question type. This change codifies that existing architecture without introducing a universal system of record, authority registry, workflow state store, or new enforcement mechanism.

Linear: [CAK-70](https://linear.app/ctrl-alt-keith/issue/CAK-70/investigate-authority-allocation-across-planning-implementation-and)

No corresponding GitHub issue was identified, so this PR intentionally has no GitHub closing keyword.

## Authority allocation made explicit

- current human direction: delegated intent and authority
- owning planning surface: recorded intent, priority, sequencing, acceptance context, and planning status
- repository state: current files and local implementation existence
- GitHub hosted state: hosted issues, pull requests, CI, review, and merge facts
- canonical shared and repo-local docs: reusable doctrine and repository-specific contracts
- provider or runtime: current external operational state
- durable artifacts and logs: historical execution claims within the evidence they preserve

Cross-boundary questions retrieve each applicable owner and reconcile by owning scope and instruction hierarchy. Convenience, duplication, integration quality, and durability do not transfer authority.

## Scope

Changed only:

- `docs/core-model.md`
- `docs/source-first-retrieval.md`
- `docs/feature-lifecycle.md`

No adapter, prompt-contract, repo-local `AGENTS.md`, enforcement, automation, schema, or runtime behavior changed.

## Review

An independent read-only Claude review inspected the initial three-file diff and returned `ACCEPT`. Its three low-severity observations were dispositioned:

- clarified that recorded planning intent cannot override current human direction
- retained recovery wording because pause and recovery authority were part of the investigated question set
- retained shared-versus-local ownership wording because CAK-67 already promoted that boundary into the general model

A later post-implementation architecture review found one low-severity wording overstatement in `docs/feature-lifecycle.md`: GitHub hosted state had been described as determining implementation existence. Commit `46729da` narrows that sentence so GitHub controls the corresponding hosted facts while local implementation existence remains a repository-state question.

The previous independent review remains applicable. This bounded clarification preserves the reviewed scope, ownership model, claims, authority boundaries, acceptance criteria, omissions, and delivery topology, so focused re-review is not warranted.

## Validation

- `make check`: passed after the bounded correction
  - Markdown lint: 47 files, 0 issues
  - unit tests: 38 passed
- `git diff --check`: passed

## Authority boundary

This PR is ready for human review. It does not authorize merge or auto-merge.