### PR TITLE
Document safer upstream refreshes

### DIFF
--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -96,13 +96,14 @@ name `upstream` by itself does not make a remote read-only. This setup is
 optional for non-Git destinations or environments without upstream Git access,
 which should continue to use connector, hosted-source, or URL review.
 
-Record completed review progress in a small repository file named
-`upstream-review-baseline.md`. It preserves the canonical upstream repository,
-the exact last reviewed upstream commit, and review date. The baseline means
-"upstream reviewed through this commit," not "all upstream changes through
-this commit were adopted." Keep refresh reports under
+Durable implementation refreshes record review progress in a small repository
+file named `upstream-review-baseline.md`. It preserves the canonical upstream
+repository, the exact last reviewed upstream commit, and review date. The
+baseline means "upstream reviewed through this commit," not "all upstream
+changes through this commit were adopted." Keep refresh reports under
 `refresh-reports/YYYY-MM-DD-upstream-refresh.md`; each report records the
 reviewed range, candidate decisions, local deviations, and resulting baseline.
+Review-report-only work remains conversational and creates neither file.
 
 Routine refreshes compare three distinct surfaces:
 

--- a/distributions/starter/README.md
+++ b/distributions/starter/README.md
@@ -81,6 +81,41 @@ The local work playbook may live on GitHub Enterprise, GitHub.com, or another
 host. The upstream source may live on a different host. Use the fully qualified
 upstream URL; do not infer upstream from the local repository host.
 
+For Git-backed work-local playbook repositories with upstream Git access, keep
+a remote named `upstream` with the canonical fetch URL and an invalid push URL:
+
+```text
+git remote set-url upstream https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+git remote set-url --push upstream DISABLED
+```
+
+Bootstrap should add the remote when absent or normalize it when present, then
+fetch it with pruning and tags. Inspect all existing fetch and push URLs before
+changing them. The invalid push URL makes accidental pushes fail locally; the
+name `upstream` by itself does not make a remote read-only. This setup is
+optional for non-Git destinations or environments without upstream Git access,
+which should continue to use connector, hosted-source, or URL review.
+
+Record completed review progress in a small repository file named
+`upstream-review-baseline.md`. It preserves the canonical upstream repository,
+the exact last reviewed upstream commit, and review date. The baseline means
+"upstream reviewed through this commit," not "all upstream changes through
+this commit were adopted." Keep refresh reports under
+`refresh-reports/YYYY-MM-DD-upstream-refresh.md`; each report records the
+reviewed range, candidate decisions, local deviations, and resulting baseline.
+
+Routine refreshes compare three distinct surfaces:
+
+1. upstream evolution from the recorded baseline to current upstream
+2. local divergence from the baseline to the current local default branch
+3. the candidate delta between the current local and upstream heads
+
+A direct local-versus-upstream diff is not enough because it mixes intentional
+local adaptations with upstream changes introduced since the last review. If
+there is no trustworthy baseline, use the first-refresh path in the prompt:
+inspect local history and content, establish an explicit starting point, and
+record any uncertainty without requiring an exhaustive historical review.
+
 This is not synchronization, enforcement, or automatic promotion. Local
 ownership and workplace context control the final decision.
 

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -51,9 +51,10 @@ content belongs at repository level rather than under `.ai-workflow/`.
 
 Git-backed work-local repositories with upstream Git access should also use a
 protected `upstream` remote. After the first trustworthy review, they should
-record `upstream-review-baseline.md`; completed refreshes should leave a small
-report under `refresh-reports/`. These files record review coverage and local
-decisions, not synchronization or adoption state.
+record `upstream-review-baseline.md` when selected updates are implemented;
+implemented refreshes should leave a small report under `refresh-reports/`.
+Report-only reviews remain ephemeral. These files record review coverage and
+local decisions, not synchronization or adoption state.
 
 Expected work-local playbook skeleton:
 

--- a/distributions/starter/manifest.md
+++ b/distributions/starter/manifest.md
@@ -49,6 +49,12 @@ repositories should retain a reference to the upstream refresh prompt for
 periodic review. The destination itself is the playbook repository, so starter
 content belongs at repository level rather than under `.ai-workflow/`.
 
+Git-backed work-local repositories with upstream Git access should also use a
+protected `upstream` remote. After the first trustworthy review, they should
+record `upstream-review-baseline.md`; completed refreshes should leave a small
+report under `refresh-reports/`. These files record review coverage and local
+decisions, not synchronization or adoption state.
+
 Expected work-local playbook skeleton:
 
 - `README.md`

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -84,6 +84,12 @@ The local playbook and upstream source do not need to share a repository host.
 Resolve upstream from the explicit URL, and ask for an alternate source if that
 URL is unavailable.
 
+For a Git-backed work-local repository with upstream Git access, use a
+protected `upstream` remote whose fetch URL is canonical and whose push URL is
+`DISABLED`. Record the last reviewed upstream commit and review date in
+`upstream-review-baseline.md`, and keep each completed review report under
+`refresh-reports/`. The baseline records review coverage, not adoption.
+
 Classify candidate changes as adopt now, adapt with edits, not applicable, or
 human decision required. Preserve local ownership and workplace context.
 

--- a/distributions/starter/onboarding.md
+++ b/distributions/starter/onboarding.md
@@ -87,8 +87,9 @@ URL is unavailable.
 For a Git-backed work-local repository with upstream Git access, use a
 protected `upstream` remote whose fetch URL is canonical and whose push URL is
 `DISABLED`. Record the last reviewed upstream commit and review date in
-`upstream-review-baseline.md`, and keep each completed review report under
-`refresh-reports/`. The baseline records review coverage, not adoption.
+`upstream-review-baseline.md`, and keep each implemented refresh report under
+`refresh-reports/`. Report-only reviews remain conversational and create
+neither file. The baseline records review coverage, not adoption.
 
 Classify candidate changes as adopt now, adapt with edits, not applicable, or
 human decision required. Preserve local ownership and workplace context.

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -82,7 +82,7 @@ Expected playbook-repository structure should resemble:
 - `docs/review-packet.md`
 - `prompts/upstream-refresh.md`
 - `upstream-review-baseline.md` after an initial baseline is established
-- `refresh-reports/YYYY-MM-DD-upstream-refresh.md` for each completed review
+- `refresh-reports/YYYY-MM-DD-upstream-refresh.md` for each implemented refresh
 - `templates/AGENTS.template.md`
 - `templates/review-packet-template.md`
 
@@ -149,8 +149,8 @@ Work-local playbook repository content should include:
 - `upstream-review-baseline.md`, once a trustworthy baseline is established,
   containing the canonical upstream repository, exact last reviewed upstream
   commit, and review date
-- lightweight refresh reports under `refresh-reports/`, created only when a
-  refresh review occurs
+- lightweight refresh reports under `refresh-reports/`, created only when
+  selected refresh recommendations are implemented
 - `templates/AGENTS.template.md`, pointing adopters to local
   `docs/start-here.md`
 - `templates/review-packet-template.md`

--- a/distributions/starter/prompts/bootstrap-local-starter.md
+++ b/distributions/starter/prompts/bootstrap-local-starter.md
@@ -30,6 +30,43 @@ Before writing files, determine which adoption target is intended:
 
 If the destination is ambiguous, stop and ask which target to use.
 
+## Protected Upstream Remote
+
+For a Git-backed work-local playbook repository, when Git access to the
+canonical upstream is available, configure or normalize a remote named
+`upstream`. This remote is for provenance and review material only. It does not
+change the authority of the local playbook.
+
+Inspect before changing it:
+
+```text
+git remote -v
+git remote get-url --all upstream
+git remote get-url --push --all upstream
+```
+
+If `upstream` is absent, add it. If it exists, inspect and normalize it instead
+of blindly adding another remote. The intended end state is exactly one fetch
+URL for the canonical repository and a separate invalid push URL:
+
+```text
+git remote add upstream https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+git remote set-url upstream https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+git remote set-url --push upstream DISABLED
+git fetch upstream --prune --tags
+```
+
+Use only the applicable add-or-set command. If inspection finds extra fetch or
+push URLs, remove those explicitly with reviewed `git remote set-url --delete`
+commands and re-inspect the result. Do not replace or rename the local
+repository's `origin`. The invalid push URL is intentional: the remote name
+alone is not read-only, so accidental upstream pushes should fail locally.
+
+Do not require this remote for non-Git destinations or when Git access to the
+canonical upstream is unavailable. Preserve the connector, hosted-source, or
+fully qualified URL review path in those cases, and report the unavailable Git
+path without weakening local authority.
+
 ## Destination Outcomes
 
 For a work-local playbook repository, the destination itself becomes the
@@ -44,6 +81,8 @@ Expected playbook-repository structure should resemble:
 - `docs/repo-readiness.md`
 - `docs/review-packet.md`
 - `prompts/upstream-refresh.md`
+- `upstream-review-baseline.md` after an initial baseline is established
+- `refresh-reports/YYYY-MM-DD-upstream-refresh.md` for each completed review
 - `templates/AGENTS.template.md`
 - `templates/review-packet-template.md`
 
@@ -107,9 +146,39 @@ Work-local playbook repository content should include:
 - `prompts/upstream-refresh.md`, describing upstream as source material and
   future improvements to review from
   `https://github.com/ctrl-alt-keith/ai-workflow-playbook`, not blindly sync
+- `upstream-review-baseline.md`, once a trustworthy baseline is established,
+  containing the canonical upstream repository, exact last reviewed upstream
+  commit, and review date
+- lightweight refresh reports under `refresh-reports/`, created only when a
+  refresh review occurs
 - `templates/AGENTS.template.md`, pointing adopters to local
   `docs/start-here.md`
 - `templates/review-packet-template.md`
+
+The baseline means "upstream reviewed through this commit," not "all upstream
+changes through this commit were adopted." Use a small repository file rather
+than a Git tag so local release history remains separate. Do not create or
+advance the baseline until the corresponding review is complete.
+
+For a genuinely new work-local playbook created from the current upstream
+starter, record the exact upstream commit inspected during bootstrap after the
+generated local content has been reviewed. For an existing repository whose
+starting point is uncertain, do not invent a baseline. Leave the baseline
+unestablished and use the first-refresh path in `prompts/upstream-refresh.md`.
+
+Use this lightweight file shape when recording the baseline:
+
+```markdown
+# Upstream Review Baseline
+
+- Canonical upstream repository:
+  `https://github.com/ctrl-alt-keith/ai-workflow-playbook.git`
+- Last reviewed upstream commit: `[full commit SHA]`
+- Review date: `[YYYY-MM-DD]`
+
+This baseline means upstream was reviewed for local applicability through the
+recorded commit. It does not mean every upstream change was adopted.
+```
 
 Project repo notes should capture:
 
@@ -151,6 +220,7 @@ Hard boundaries:
 - Do not modify enforcement controls.
 - Do not create new governance requirements.
 - Do not make settings or process changes on behalf of the team.
+- Do not introduce automatic synchronization or promotion.
 
 Make every suggested workflow change advisory unless the user explicitly
 requests implementation.
@@ -175,6 +245,8 @@ When finished, report:
 - files created or updated
 - source evidence inspected
 - validation commands discovered
+- protected upstream remote status, when applicable
+- baseline status and exact recorded commit, when established
 - any unknowns or assumptions
 - confirmation that no source code, CI/CD, GitHub settings, branch protection,
   `CODEOWNERS`, release automation, enforcement controls, or root `AGENTS.md`

--- a/distributions/starter/prompts/upstream-refresh.md
+++ b/distributions/starter/prompts/upstream-refresh.md
@@ -24,6 +24,24 @@ when local context differs.
   `https://github.com/ctrl-alt-keith/ai-workflow-playbook.git`
 - Requested output: `[review report only | implement recommended updates]`
 
+There are exactly two outcomes:
+
+- **Review report only:** perform an ephemeral, non-mutating review and return
+  the findings to the human. Do not create repository files,
+  `refresh-reports/`, or a branch or pull request. Do not modify the local
+  playbook or update `upstream-review-baseline.md`. The baseline remains
+  unchanged because no durable review artifact has been accepted into the
+  repository.
+- **Implement recommended updates:** after the human chooses selected
+  recommendations, implement those changes, create the durable refresh report,
+  update `upstream-review-baseline.md`, commit the selected updates, report,
+  and baseline together, and open one reviewable pull request.
+
+The workflow is simply: review, human decision, then implementation of the
+selected updates in one pull request. Do not introduce another output mode,
+durable-review-only path, branch, or pull request. If implementation is not
+requested, the review remains conversational and ephemeral.
+
 The routine review range comes from `upstream-review-baseline.md`; do not ask
 for an arbitrary range when a trustworthy baseline exists. If the local
 repository or upstream source is ambiguous, stop and ask for the missing
@@ -173,11 +191,12 @@ not a synchronization cursor, release marker, adoption ledger, or approval.
 Keep it as a normal reviewable file rather than a Git tag so it does not blur
 local release history.
 
-Advance the baseline only after the refresh review and its report are complete.
-The resulting baseline normally equals the upstream head reviewed, including
-when some candidates were adapted, rejected as not applicable, or left for a
-human decision. Unresolved decisions remain visible in the report; they do not
-turn the baseline into an adoption claim.
+Advance the baseline only when the durable refresh report and selected
+implementation changes become part of the same repository change. The
+resulting baseline normally equals the upstream head reviewed, including when
+some candidates were adapted, rejected as not applicable, or left for a human
+decision. Unresolved decisions remain visible in the report; they do not turn
+the baseline into an adoption claim.
 
 ## First Refresh
 
@@ -196,10 +215,12 @@ without trustworthy provenance, or otherwise unreliable.
    current local and upstream content. Document the unknown historical starting
    point and the limits of the review. Do not imply every historical upstream
    commit was individually reviewed.
-5. After that initial review is complete, establish an explicit baseline at the
-   upstream commit actually reviewed so later refreshes can be incremental.
+5. If the human chooses implementation, establish an explicit baseline at the
+   upstream commit reviewed as part of the same repository change as the
+   durable report and selected updates. Otherwise leave the baseline unchanged.
 
-The first refresh establishes a useful forward boundary; it does not require a
+An implemented first refresh establishes a useful forward boundary; an
+ephemeral review leaves the baseline unestablished. Neither path requires a
 permanent audit of all upstream history. Never invent a commit or silently use
 the current upstream head as though a review had already happened.
 
@@ -278,7 +299,7 @@ refresh contract unless the human separately authorizes that work.
 
 ## Durable Refresh Report
 
-Create one lightweight report for each completed review at:
+For the implementation outcome, create one lightweight report at:
 
 `refresh-reports/YYYY-MM-DD-upstream-refresh.md`
 
@@ -323,14 +344,19 @@ Use this report shape:
 - Resulting baseline:
 ```
 
-The report records what was reviewed and decided in this refresh. It does not
-assert that every upstream change was adopted or require tracking every
-upstream change forever.
+The report records what was reviewed and decided in the implemented refresh. It
+does not assert that every upstream change was adopted or require tracking
+every upstream change forever. A review-report-only outcome does not create
+this file.
 
 ## Implementation And Deliverables
 
-Produce the refresh report even when no local content change is selected. If
-repository modifications are requested and tooling is available:
+For **review report only**, return the findings to the human and stop. Do not
+create files, update the baseline, create a branch or pull request, or modify
+the local playbook.
+
+For **implement recommended updates**, after the human selects recommendations
+and when tooling is available:
 
 1. Create an isolated branch or worktree as required by the local repository.
 2. Implement only candidates classified for adoption or adaptation.
@@ -341,9 +367,6 @@ repository modifications are requested and tooling is available:
 6. Commit the selected local updates, report, and baseline together.
 7. Open a reviewable pull request.
 
-For report-only work, do not modify the local playbook or advance the baseline
-unless the human requested durable report and baseline updates.
-
 When finished, report:
 
 - preflight state and fetch results
@@ -351,7 +374,7 @@ When finished, report:
 - candidate classifications and rationale
 - selected adaptations and known local deviations
 - unresolved human decisions
-- report and resulting baseline paths
+- report and resulting baseline paths when implemented
 - pull request, files changed, validation, and residual risks when implemented
 
 ## Boundaries

--- a/distributions/starter/prompts/upstream-refresh.md
+++ b/distributions/starter/prompts/upstream-refresh.md
@@ -11,90 +11,353 @@ workplace or organization playbook repository.
 
 This is an upstream review workflow, not synchronization.
 
-Do not blindly synchronize. Do not overwrite local decisions. Do not assume
-upstream is automatically correct for the local environment. Evaluate
-applicability and intent. Prefer adaptation over copying when local context
-differs.
+The local work playbook remains the daily authority. Upstream remains
+provenance and refresh material. Do not blindly synchronize, overwrite local
+decisions, or assume upstream is automatically correct for the local
+environment. Evaluate applicability and intent. Prefer adaptation over copying
+when local context differs.
 
 ## Inputs
 
 - Local playbook repository: `[local repository URL, owner/name, or path]`
-- Upstream source: `https://github.com/ctrl-alt-keith/ai-workflow-playbook`
-- Review range or period: `[since last refresh, date range, commit range, or recent merged PRs]`
+- Canonical upstream:
+  `https://github.com/ctrl-alt-keith/ai-workflow-playbook.git`
 - Requested output: `[review report only | implement recommended updates]`
 
-If the local repository, upstream source, or review range is ambiguous, stop
-and ask for the missing target.
+The routine review range comes from `upstream-review-baseline.md`; do not ask
+for an arbitrary range when a trustworthy baseline exists. If the local
+repository or upstream source is ambiguous, stop and ask for the missing
+target. If the baseline is absent or untrustworthy, follow the first-refresh
+path below.
 
-## Host Separation
+## Host And Access Separation
 
 Repository identity and repository host are separate. The local playbook
-repository may live on GitHub Enterprise, GitHub.com, or another accessible
-repository host. The upstream source may live on a different host.
+repository may live on GitHub Enterprise, GitHub.com, another repository host,
+or only on a local filesystem. Upstream may live on a different host.
 
-Do not assume the upstream repository exists on the same Git host as the local
-repository. Resolve the upstream source from its fully qualified repository URL.
-If the upstream source cannot be reached, stop and ask for an alternate source
-location.
+For a Git-backed work-local playbook with Git access to upstream, use the
+protected `upstream` remote described below. For a non-Git destination or an
+environment where upstream Git access is unavailable, preserve the existing
+connector, hosted-source, or fully qualified URL review path. Do not make Git
+remote setup a prerequisite for those paths. Record equivalent source
+identities and commit IDs when the available source exposes them.
 
-## Review Process
+If neither the Git remote nor an alternate source can retrieve current
+upstream state, stop and report the source-access blocker. Do not continue from
+memory or imply the clone is current.
 
-1. Inspect the local playbook repository, including its README, local adoption
-   notes, templates, prompts, and any local `AGENTS.md`.
-2. Inspect upstream `https://github.com/ctrl-alt-keith/ai-workflow-playbook`.
-3. Review relevant canonical upstream docs, especially:
-   - `docs/start-here.md`
-   - `docs/source-first-retrieval.md`
-   - `docs/repo-readiness.md`
-   - `docs/engineering-baseline.md`
-   - `docs/review-packet.md`
-4. Review recent merged upstream pull requests in the requested range.
-5. Identify candidate upstream changes that may affect the local playbook.
-6. Classify each candidate:
-   - adopt now
-   - adapt with edits
-   - not applicable
-   - human decision required
+## Protected Upstream Remote
 
-## Evaluation Guidance
+For the Git-backed path, inspect before changing the remote:
 
-For each candidate, consider:
+```text
+git remote -v
+git remote get-url --all upstream
+git remote get-url --push --all upstream
+```
+
+If `upstream` is absent, add it. If it exists, normalize it. The intended end
+state is exactly one canonical fetch URL and one invalid push URL:
+
+```text
+git remote add upstream https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+git remote set-url upstream https://github.com/ctrl-alt-keith/ai-workflow-playbook.git
+git remote set-url --push upstream DISABLED
+```
+
+Use only the applicable add-or-set command. Remove any extra fetch or push URLs
+explicitly with reviewed `git remote set-url --delete` commands, then re-run
+the inspection commands. Do not change the local repository's `origin`. The
+invalid push URL is intentional because the remote name alone does not prevent
+accidental pushes.
+
+## Deterministic Preflight
+
+Before comparing content, inspect and report current state. Prefer direct Git
+commands and preserve command success, failure, and fetched ref updates in the
+report.
+
+1. Inspect the working tree, checkout, and configured remotes:
+
+   ```text
+   git status --short --branch
+   git branch --show-current
+   git rev-parse HEAD
+   git remote -v
+   ```
+
+2. Determine the local repository's default branch and upstream's default
+   branch from remote symbolic refs or current host metadata. Do not assume
+   either branch is named `main`, and do not infer one host's branch from the
+   other:
+
+   ```text
+   git symbolic-ref --quiet --short refs/remotes/origin/HEAD
+   git symbolic-ref --quiet --short refs/remotes/upstream/HEAD
+   git ls-remote --symref origin HEAD
+   git ls-remote --symref upstream HEAD
+   ```
+
+   Use `ls-remote` when a remote-tracking symbolic ref is absent. Relevant
+   repository host or connector metadata is also acceptable; record the source
+   used. Symbolic-ref output such as `origin/main` identifies branch `main`;
+   use the branch component, without the remote prefix, in later placeholders.
+   If the result remains unknown, stop before comparison.
+
+3. Fetch both sources independently. Do not assume an existing clone is
+   current:
+
+   ```text
+   git fetch origin --prune --tags
+   git fetch upstream --prune --tags
+   ```
+
+   Record the result of each fetch separately. A successful upstream fetch
+   does not prove that local `origin` is current, or vice versa.
+
+   If an intentionally local-only Git repository has no `origin`, record the
+   origin fetch as `not configured (local-only)` rather than creating a remote.
+   Identify the local default branch from inspected local documentation or
+   repository state and use `refs/heads/[local-default-branch]` for the local
+   comparisons below. If the local default branch remains ambiguous, stop and
+   ask instead of treating the current branch as authoritative.
+
+4. Resolve and report the exact current heads after fetch, substituting the
+   discovered branch names:
+
+   ```text
+   git rev-parse refs/remotes/origin/[local-default-branch]
+   git rev-parse refs/remotes/upstream/[upstream-default-branch]
+   ```
+
+   Also report the checked-out `HEAD` from step 1 when it differs from the
+   fetched local default-branch head.
+
+5. Read `upstream-review-baseline.md`. Verify that the recorded object exists
+   and is an ancestor of the fetched upstream default branch:
+
+   ```text
+   git cat-file -e [baseline-commit]^{commit}
+   git merge-base --is-ancestor [baseline-commit] refs/remotes/upstream/[upstream-default-branch]
+   ```
+
+   Report object availability and upstream reachability separately. Exit code
+   `0` from `merge-base --is-ancestor` means reachable, `1` means not an
+   ancestor, and any other failure is an inspection error. Do not silently
+   replace an unreachable or invalid baseline.
+
+If the worktree contains unrelated changes, preserve them and do not mix them
+into an implementation. A dirty worktree does not prevent a report-only
+review, but its status must remain visible.
+
+## Baseline Contract
+
+Use a small root repository file named `upstream-review-baseline.md`:
+
+```markdown
+# Upstream Review Baseline
+
+- Canonical upstream repository:
+  `https://github.com/ctrl-alt-keith/ai-workflow-playbook.git`
+- Last reviewed upstream commit: `[full commit SHA]`
+- Review date: `[YYYY-MM-DD]`
+
+This baseline means upstream was reviewed for local applicability through the
+recorded commit. It does not mean every upstream change was adopted.
+```
+
+The baseline means **upstream reviewed through this commit**, not **all
+upstream changes through this commit were adopted**. It is a review boundary,
+not a synchronization cursor, release marker, adoption ledger, or approval.
+Keep it as a normal reviewable file rather than a Git tag so it does not blur
+local release history.
+
+Advance the baseline only after the refresh review and its report are complete.
+The resulting baseline normally equals the upstream head reviewed, including
+when some candidates were adapted, rejected as not applicable, or left for a
+human decision. Unresolved decisions remain visible in the report; they do not
+turn the baseline into an adoption claim.
+
+## First Refresh
+
+Use this path when the baseline file is absent, malformed, unreachable, copied
+without trustworthy provenance, or otherwise unreliable.
+
+1. Inspect current local content, local history, remotes, migration notes, and
+   any provenance references that may identify the local playbook's starting
+   point.
+2. Inspect current upstream content and history relevant to the local
+   playbook. Look for a defensible shared or source commit, but do not assume
+   common Git ancestry exists.
+3. If a trustworthy starting commit is found, record why it is trustworthy and
+   use it as the initial comparison baseline.
+4. If no trustworthy historical baseline exists, perform a snapshot review of
+   current local and upstream content. Document the unknown historical starting
+   point and the limits of the review. Do not imply every historical upstream
+   commit was individually reviewed.
+5. After that initial review is complete, establish an explicit baseline at the
+   upstream commit actually reviewed so later refreshes can be incremental.
+
+The first refresh establishes a useful forward boundary; it does not require a
+permanent audit of all upstream history. Never invent a commit or silently use
+the current upstream head as though a review had already happened.
+
+## Routine Refresh And Three Comparisons
+
+For a trustworthy recorded baseline, keep these comparisons separate. Start
+with summaries such as `--stat` or `--name-status`, then inspect the detailed
+diffs needed for candidate decisions. The examples use a fetched local
+`origin`; for an intentionally local-only repository, substitute the inspected
+`refs/heads/[local-default-branch]` ref described in preflight.
+
+1. **Upstream evolution:** recorded baseline to current upstream default
+   branch.
+
+   ```text
+   git diff --stat [baseline-commit]..refs/remotes/upstream/[upstream-default-branch]
+   git diff --name-status [baseline-commit]..refs/remotes/upstream/[upstream-default-branch]
+   ```
+
+2. **Local divergence:** recorded baseline to current local default branch.
+
+   ```text
+   git diff --stat [baseline-commit]..refs/remotes/origin/[local-default-branch]
+   git diff --name-status [baseline-commit]..refs/remotes/origin/[local-default-branch]
+   ```
+
+3. **Candidate delta:** current local default branch compared with current
+   upstream default branch.
+
+   ```text
+   git diff --stat refs/remotes/origin/[local-default-branch]..refs/remotes/upstream/[upstream-default-branch]
+   git diff --name-status refs/remotes/origin/[local-default-branch]..refs/remotes/upstream/[upstream-default-branch]
+   ```
+
+A direct local-versus-upstream diff alone is insufficient. It mixes intentional
+local adaptations accumulated over time with newly introduced upstream
+changes. Upstream evolution identifies what is new since the last review;
+local divergence preserves the context of local choices; the candidate delta
+shows the current content gap. Use all three before deciding what is relevant.
+
+Inspect relevant canonical upstream docs, especially:
+
+- `docs/start-here.md`
+- `docs/source-first-retrieval.md`
+- `docs/repo-readiness.md`
+- `docs/engineering-baseline.md`
+- `docs/review-packet.md`
+
+Review relevant merged upstream pull requests in the baseline-to-head range
+when hosted PR evidence is available. Do not require tracking every upstream
+change forever.
+
+## Candidate Classification
+
+Classify each candidate upstream change:
+
+- **adopt now:** applicable as written and selected for local adoption
+- **adapt with edits:** useful intent, but local context requires changes
+- **not applicable:** reviewed and deliberately not selected for this local
+  environment
+- **human decision required:** evidence or authority is insufficient for the
+  reviewer to decide
+
+For each candidate, record:
 
 - upstream intent and problem addressed
-- local workplace or organization context
-- existing local decisions and documented deviations
-- whether adopting the change would improve source-first verification,
-  reviewability, validation evidence, or team compatibility
-- whether adaptation is safer than copying
-- whether the change would introduce governance, enforcement, CI/CD, settings,
-  branch protection, `CODEOWNERS`, release automation, or automatic promotion
-  behavior
+- source files, commits, or pull requests inspected
+- existing local decisions and known deviations
+- classification and rationale
+- selected adaptation, if any
+- unresolved evidence or human authority needed
 
-Do not create a requirement to track every upstream change. Preserve local
-ownership.
+Treat governance, enforcement, CI/CD, settings, branch protection,
+`CODEOWNERS`, release automation, and automatic promotion as outside this
+refresh contract unless the human separately authorizes that work.
 
-## Deliverables
+## Durable Refresh Report
 
-Produce a review report with:
+Create one lightweight report for each completed review at:
 
-- upstream changes reviewed
-- recommended actions
-- rationale for each recommendation
-- proposed implementation plan when updates are recommended
-- explicit unknowns or source evidence that could not be inspected
+`refresh-reports/YYYY-MM-DD-upstream-refresh.md`
 
-If repository modifications are requested and tooling is available:
+If more than one refresh completes on the same date, add a short descriptive
+suffix. Do not rewrite older reports or require a perpetual per-change ledger.
 
-1. Create a branch.
-2. Commit only the selected local playbook updates.
-3. Open a reviewable pull request.
-4. Report the PR link, files changed, validation run, and residual risks.
+Use this report shape:
 
-Otherwise, produce a review report only.
+```markdown
+# Upstream Refresh Report: YYYY-MM-DD
+
+## Preflight
+
+- Working-tree status:
+- Configured remotes:
+- Local default branch:
+- Upstream default branch:
+- Checked-out head:
+- Local default-branch head:
+- Upstream head:
+- Recorded baseline:
+- Baseline object available:
+- Baseline reachable from upstream head:
+- Local origin fetch result:
+- Upstream fetch result:
+
+## Review
+
+- Upstream range reviewed: `[baseline]..[upstream head]`
+- Upstream head commit:
+- Local head commit:
+- Candidate classifications and rationale:
+- Selected adaptations:
+- Known local deviations:
+- Unresolved human decisions:
+- Review limitations or first-refresh uncertainty:
+
+## Result
+
+- Files changed, if any:
+- Validation run, if any:
+- Resulting baseline:
+```
+
+The report records what was reviewed and decided in this refresh. It does not
+assert that every upstream change was adopted or require tracking every
+upstream change forever.
+
+## Implementation And Deliverables
+
+Produce the refresh report even when no local content change is selected. If
+repository modifications are requested and tooling is available:
+
+1. Create an isolated branch or worktree as required by the local repository.
+2. Implement only candidates classified for adoption or adaptation.
+3. Preserve known local deviations.
+4. Run the local repository's canonical validation.
+5. Complete the refresh report, then update the baseline to the reviewed
+   upstream head.
+6. Commit the selected local updates, report, and baseline together.
+7. Open a reviewable pull request.
+
+For report-only work, do not modify the local playbook or advance the baseline
+unless the human requested durable report and baseline updates.
+
+When finished, report:
+
+- preflight state and fetch results
+- upstream range and exact heads reviewed
+- candidate classifications and rationale
+- selected adaptations and known local deviations
+- unresolved human decisions
+- report and resulting baseline paths
+- pull request, files changed, validation, and residual risks when implemented
 
 ## Boundaries
 
-Do not introduce automatic synchronization. Do not introduce enforcement
-behavior. Do not overwrite local decisions. Do not create a requirement to
-track every upstream change. Do not duplicate large amounts of upstream
-doctrine.
+Do not introduce automatic synchronization or promotion. Do not overwrite local
+decisions. Do not create enforcement behavior. Do not turn the baseline or
+reports into a governance framework or synchronization ledger. Do not require
+tracking every upstream change forever. Do not duplicate large amounts of
+upstream doctrine.


### PR DESCRIPTION
## Problem

Work-local playbook repositories had review-oriented refresh guidance, but no durable baseline, deterministic preflight, or locally protected upstream remote. A direct local-versus-upstream diff could mix intentional local adaptations with newly introduced upstream changes and make refresh reasoning ambiguous.

## What changed

- Configure or normalize a Git remote named `upstream` with the canonical fetch URL and an intentional `DISABLED` push URL, then fetch with pruning and tags. Existing URLs are inspected first; non-Git and unavailable-Git environments retain connector, hosted-source, and URL review paths.
- Define `upstream-review-baseline.md` as the lightweight record of canonical repository, exact last reviewed upstream commit, and review date. Its meaning is "upstream reviewed through this commit," not "all upstream changes through this commit were adopted."
- Add a deterministic preflight covering working-tree state, remotes, local and upstream default branches and heads, baseline availability/reachability, and separate fetch results for local `origin` and `upstream`.
- Separate upstream evolution, local divergence, and current candidate-delta comparisons before classifying candidates as adopt now, adapt with edits, not applicable, or human decision required.
- Distinguish first refreshes with uncertain provenance from routine baseline-driven refreshes.
- Define exactly two outcomes: an ephemeral, non-mutating review report returned to the human, or durable implementation after human selection with the selected updates, refresh report, and baseline committed together in one PR.
- Define lightweight durable reports under `refresh-reports/` with reviewed range, decisions, rationale, adaptations, local deviations, unresolved human decisions, and resulting baseline.

## Validation

- `make check` — Markdown lint passed for 47 files; all 38 unit tests passed.
- `make scanner-test` — all 38 scanner/unit tests passed.
- `make authoritative-source-check` — no non-authoritative source URLs found.
- Branch remains a clean descendant of current `origin/main`.

## Residual risks and open questions

- The protection is local guidance, not server-side enforcement; deliberate remote reconfiguration can still restore push access.
- Existing multi-URL remotes require reviewed, URL-specific cleanup. The prompt requires inspection and normalization but intentionally does not add an executable migration system.
- No blocking design questions remain. Non-Git, cross-host, and local-only paths are preserved explicitly.