### PR TITLE
Fail closed on misleading preflight SSH success output

### DIFF
--- a/tests/test_codex_preflight.py
+++ b/tests/test_codex_preflight.py
@@ -205,6 +205,20 @@ class CodexPreflightTest(unittest.TestCase):
         )
         self.assertNotIn("gh auth status succeeds", result.stdout)
 
+    def test_github_ssh_success_banner_with_unexpected_exit_code_fails_closed(self) -> None:
+        commands = self.fake_success_commands()
+        commands["ssh"] = """
+            printf '%s\\n' "Hi test! You've successfully authenticated, but GitHub does not provide shell access." >&2
+            exit 255
+        """
+
+        result = self.run_preflight(commands)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("FAIL GitHub SSH connectivity works via ssh -T git@github.com", result.stdout)
+        self.assertIn("Resolve SSH authentication for GitHub", result.stdout)
+        self.assertNotIn("gh auth status succeeds", result.stdout)
+
     def test_gh_auth_status_failure_reports_login_remediation(self) -> None:
         commands = self.fake_success_commands()
         commands["gh"] = """


### PR DESCRIPTION
## What I inspected
- Repo-local AGENTS guidance and `scripts/codex-preflight`
- Current test coverage in `tests/test_codex_preflight.py`
- GitHub default branch state on Monday, July 20, 2026
- Local canonical validation via `make check`

## Selected improvement
Add a regression test that fails preflight closed when `ssh -T` prints GitHub's success banner but exits with an unexpected non-success status.

## Why this was the highest-leverage small change
The preflight script is the gate for every automation run. This test protects a subtle but consequential failure mode without changing the shipped script behavior or widening the scope.

## Files touched
- `tests/test_codex_preflight.py`

## Validation
- `make check`