### PR TITLE
Clarify executable prompt boundaries

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -68,11 +68,13 @@ Use this template only when the intended interaction mode is direct
 implementation. For review or orchestration, use the matching template instead.
 Apply the reasoning-selection guidance in
 [`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
-to the bounded task. The first block below is operator metadata, not part of the
-executable prompt. Emit the two blocks consecutively without an intervening
-heading or explanation.
+to the bounded task. The first block below is operator metadata for the human
+or operator. It is not part of the executable prompt and should not be copied
+into the downstream agent. Copy or deliver only the second block. Emit the two
+blocks consecutively with no intervening heading or explanation.
 
 ```text
+Operator metadata (do not include in prompt)
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:
@@ -181,11 +183,13 @@ Required inputs:
 
 Apply the reasoning-selection guidance in
 [`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
-to the bounded task. The first block below is operator metadata, not part of the
-executable prompt. Emit the two blocks consecutively without an intervening
-heading or explanation.
+to the bounded task. The first block below is operator metadata for the human
+or operator. It is not part of the executable prompt and should not be copied
+into the downstream agent. Copy or deliver only the second block. Emit the two
+blocks consecutively with no intervening heading or explanation.
 
 ```text
+Operator metadata (do not include in prompt)
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:
@@ -290,11 +294,13 @@ Required inputs:
 
 Apply the reasoning-selection guidance in
 [`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
-to the bounded task. The first block below is operator metadata, not part of the
-executable prompt. Emit the two blocks consecutively without an intervening
-heading or explanation.
+to the bounded task. The first block below is operator metadata for the human
+or operator. It is not part of the executable prompt and should not be copied
+into the downstream agent. Copy or deliver only the second block. Emit the two
+blocks consecutively with no intervening heading or explanation.
 
 ```text
+Operator metadata (do not include in prompt)
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:


### PR DESCRIPTION
## Summary

- clarify that the first block is human/operator metadata and must not be copied into downstream execution
- label the metadata block `Operator metadata (do not include in prompt)`
- apply identical wording to the Codex Implementation Task, Orchestration Handoff, and PR Review templates

## Rationale

The existing ordering guidance did not explicitly tell operators to copy or deliver only the executable second block, which made accidental inclusion of reasoning metadata more likely.

## Compatibility

The executable prompt blocks are unchanged. This only clarifies the existing two-block presentation and strengthens the operator-only label.

## Validation

- `make check`
  - markdownlint-cli2: 0 issues in 47 files
  - unit tests: 38 passed
