### PR TITLE
Document runtime connector verification

### DIFF
--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -54,7 +54,10 @@ repository files, checks, comments, or review threads, inspect the GitHub
 artifact through the available connector or source-of-truth tool before giving
 a conclusion. PR receipts, implementation summaries, validation summaries, and
 automation reports are navigation aids, not evidence, when that access is
-available. If connector or source access is unavailable, say so explicitly
+available. Before claiming connector access is unavailable, apply the runtime
+verification rule in
+[`start-here.md`](start-here.md#connector-availability-is-runtime-evidence).
+If verified connector or source access is unavailable, say so explicitly
 before offering any summary-based analysis. Do not imply direct inspection
 happened unless it actually did.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -36,6 +36,31 @@ Keep the current phase and next permitted action legible when they affect human
 review or workflow authority. This is observable workflow state, not a request
 for private reasoning or a universal phase machine.
 
+### Connector availability is runtime evidence
+
+Repository hydration and connector availability answer different questions.
+Hydration retrieves repository instructions and state to establish working
+context. Connector availability describes a current runtime capability.
+Completing hydration neither proves nor disproves that a connector or action is
+available, and it does not authorize assumptions about runtime connector state.
+
+Treat connector availability as runtime evidence, not memory. Before stating
+that a connector is unavailable, an integration is not connected, an action
+cannot be performed because of connector availability, or any equivalent
+claim, do one of the following:
+
+1. Inspect the connector actions currently available.
+2. Attempt the relevant connector operation.
+
+Never explain inability to perform an operation by speculating about connector
+availability. A successful connector invocation in the current conversation is
+positive evidence that the connector remains available; successful use of a
+specific capability is positive evidence that the capability remains
+available. Do not contradict that evidence unless a subsequent connector
+inspection or invocation demonstrates otherwise. Prior use of a different
+action does not establish that a requested read or write capability exists, so
+inspect or attempt the relevant operation before reaching that conclusion.
+
 ## Canonical Ownership
 
 - [`core-model.md`](core-model.md) owns domain-independent operating principles,
@@ -161,6 +186,9 @@ recommendations, and "what changed?" or "what next?" requests:
    review/audit, or orchestration/prompt-authoring.
 6. Identify the canonical source for the rule, behavior, or state being used.
 7. Apply `docs/source-first-retrieval.md` before stateful repository reasoning.
+   When connector capability matters, apply
+   [Connector availability is runtime evidence](#connector-availability-is-runtime-evidence)
+   without changing repository hydration or instruction discovery.
 8. For policy-sensitive changes, apply the repo-family alignment check in
    `docs/repo-readiness.md`.
 9. Confirm command form and execution settings for planned commands.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -162,12 +162,14 @@ Before repo-scoped work:
   [`source-first-retrieval.md`](../source-first-retrieval.md): retrieve or
   revalidate authoritative repository, PR, issue, file, CI, log, artifact, and
   external-state sources before relying on them.
-- Treat a first-party connector's capabilities as unknown until verified; do
-  not infer that a capability is absent because its tool has not been loaded or
-  inspected. Before falling back to a direct service API or authenticated CLI
-  for remote service state, determine whether the connector provides the
-  required capability. Direct APIs and CLIs remain appropriate for verified
-  connector gaps, repository-local workflows, or explicit repository policy.
+- Apply the runtime verification rule in
+  [`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence);
+  do not infer that a connector capability is absent because its tool has not
+  been loaded or inspected. Before falling back to a direct service API or
+  authenticated CLI for remote service state, determine whether the connector
+  provides the required capability. Direct APIs and CLIs remain appropriate
+  for verified connector gaps, repository-local workflows, or explicit
+  repository policy.
 - For policy-sensitive changes, apply the repo-family alignment check in
   [`repo-readiness.md`](../repo-readiness.md#repo-family-policy-alignment)
   before implementation.


### PR DESCRIPTION
## Summary

- distinguish repository hydration from runtime connector capability
- require connector action inspection or an attempted operation before claiming unavailability
- preserve successful same-session connector use as positive evidence unless later runtime evidence contradicts it
- link the generic startup rule from Codex and source-first connector guidance

## Why

Agents can incorrectly infer that a connector or write capability is unavailable after using the connector successfully earlier in the same session. The failure is runtime reasoning, not repository hydration, so the playbook now requires evidence before an unavailable claim.

## Impact

All repositories consuming the shared `start-here` flow inherit the procedural verification rule. Existing repository hydration ordering and repo-local `AGENTS.md` discovery remain unchanged.

## Validation

- `make check`
  - markdownlint-cli2: 0 issues in 0 files
  - unittest: 38 tests passed