### PR TITLE
Add initial Claude Code adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Repo-local rules take precedence only for repo-specific behavior.
 - This playbook builds on the engineering baseline defined in
   `docs/engineering-baseline.md`.
 - Codex runs must apply `docs/tool-adapters/codex.md` as part of startup.
+- Claude runs must apply `docs/tool-adapters/claude.md` as part of startup.
 - For general workflow rules, refer to the playbook documents instead of
   duplicating them here. Use `docs/core-model.md`,
   `docs/feature-lifecycle.md`, `docs/alignment-checkpoints.md`, and

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/alignment-checkpoints.md`](docs/alignment-checkpoints.md): pause points and branch/PR rules
 - [`docs/review-packet.md`](docs/review-packet.md): standard human review packet
 - [`docs/knowledge-ingestion-patterns.md`](docs/knowledge-ingestion-patterns.md): reusable patterns for provenance-aware ingestion and retained-knowledge governance boundaries
-- [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md)
+- [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md) and Claude runs must apply [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md)
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
 - [`docs/maintenance-automations.md`](docs/maintenance-automations.md):

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -115,7 +115,8 @@ scoped analysis, review, planning, advice, prompting, or mutation.
 - `docs/core-model.md` -> general operating principles and roles
 - the target repository's `AGENTS.md` -> repo-local execution authority
 - `docs/tool-adapters/<executor>.md` -> executor-specific deltas when a matching
-  adapter exists; Codex runs must read `docs/tool-adapters/codex.md`
+  adapter exists; Codex runs must read `docs/tool-adapters/codex.md` and Claude
+  runs must read `docs/tool-adapters/claude.md`
 - `docs/engineering-baseline.md` -> foundational engineering expectations
 - `docs/source-first-retrieval.md` -> repository triggers, retrieval ordering,
   verification gates, and recovery
@@ -180,7 +181,8 @@ recommendations, and "what changed?" or "what next?" requests:
 1. Read this page and `docs/core-model.md`.
 2. Read the target repository's repo-local `AGENTS.md`.
 3. Apply the matching executor adapter. Codex runs must apply
-   `docs/tool-adapters/codex.md`.
+   `docs/tool-adapters/codex.md`; Claude runs must apply
+   `docs/tool-adapters/claude.md`.
 4. Identify the repository or workspace's primary purpose.
 5. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -1,216 +1,150 @@
 # Claude Adapter
 
-This adapter records Claude Code-specific deltas on top of the core playbook.
-Use it with [`start-here.md`](../start-here.md),
-[`core-model.md`](../core-model.md),
+Claude Code-specific deltas on top of the core playbook. Use with
+[`start-here.md`](../start-here.md), [`core-model.md`](../core-model.md),
 [`source-first-retrieval.md`](../source-first-retrieval.md),
-[`repo-readiness.md`](../repo-readiness.md), and the target repo's `AGENTS.md`;
-do not treat it as a second copy of those rules.
-
-This adapter intentionally does not mirror the Codex adapter. Where the two
-executors share behavior, the shared rule stays in its canonical playbook doc
-and this file only records what is genuinely different for Claude Code. Where an
-analogous Codex concept has no Claude equivalent, such as Codex's writable-root
-sandbox or its argv/`shell=false` execution toggle, this adapter says so instead
-of restating the Codex mechanics.
-
-## Claude-Specific Quirks
-
-- Claude Code loads its instruction and permission context from files and
-  settings rather than from a single prompt; instruction discovery below is the
-  most important delta to get right for repositories that standardize on
-  `AGENTS.md`.
-- Claude 4.x models fire tool calls, including `Bash`, in parallel and can be
-  aggressive about it. Keep parallel calls to independent, non-mutating
-  inspection; do not parallelize mutating Git operations or overlapping worktree
-  changes.
-- Claude can produce fluent summaries that still require source inspection and
-  human judgment on scope, tradeoffs, and completion. Apply
-  [`source-first-retrieval.md`](../source-first-retrieval.md) before stateful
-  conclusions.
+[`repo-readiness.md`](../repo-readiness.md), and the target repo's `AGENTS.md`.
+Record only what differs for Claude Code here; shared rules stay in their
+canonical docs.
 
 ## Instruction Discovery And Precedence
 
-Claude Code natively auto-loads `CLAUDE.md` memory at session start: a
-project-level `CLAUDE.md` or `.claude/CLAUDE.md` in the working directory, a
-user-level `~/.claude/CLAUDE.md`, and any files those import. This repository
-family instead treats repo-local `AGENTS.md` as the canonical repository
-execution layer, and the startup contract in
-[`start-here.md`](../start-here.md#required-repository-startup-contract) requires
-reading the target repository's `AGENTS.md`.
+Claude Code auto-loads `CLAUDE.md` memory at session start (project `CLAUDE.md`
+or `.claude/CLAUDE.md`, user `~/.claude/CLAUDE.md`, and their imports). It does
+not guarantee that repo-local `AGENTS.md` is ingested, yet `AGENTS.md` is the
+canonical repository execution layer the startup contract requires. Therefore:
 
-Because Claude's automatic memory loading is `CLAUDE.md`-centric and does not
-guarantee that `AGENTS.md` is ingested, Claude must explicitly read the target
-repository's `AGENTS.md` to satisfy the startup contract. Do not assume
-auto-loaded memory already covers repo-local execution policy.
-
-- Do not fork or duplicate `AGENTS.md` (or shared playbook doctrine) into a
-  `CLAUDE.md`. Canonical ownership stays with `AGENTS.md` and the shared docs;
-  duplicating it creates a competing instruction copy that can drift. See
+- Explicitly read the target repository's `AGENTS.md`; do not assume auto-loaded
+  memory covers repo-local policy.
+- Do not fork `AGENTS.md` or shared doctrine into a `CLAUDE.md`. If a `CLAUDE.md`
+  exists, keep it a thin pointer to `docs/start-here.md` and the repo's
+  `AGENTS.md`, not a second policy source. See
   [`repo-readiness.md`](../repo-readiness.md#agentsmd-responsibilities).
-- If a `CLAUDE.md` is used in a repository, keep it a thin pointer to
-  `docs/start-here.md` and the repo's `AGENTS.md`, not a second policy source.
-- Claude's memory files and settings are a transport for instructions, not a new
-  authority layer. The Repository Instruction Hierarchy in
-  [`start-here.md`](../start-here.md#repository-instruction-hierarchy) still
-  governs: the human's explicit task, then repo-local `AGENTS.md`, then this
-  adapter, then shared playbook defaults. A user-level `~/.claude/CLAUDE.md`
-  carries operator context and does not override repo-local policy.
+- Memory files are a transport for instructions, not an authority layer. The
+  [Repository Instruction Hierarchy](../start-here.md#repository-instruction-hierarchy)
+  governs; a user-level `~/.claude/CLAUDE.md` is operator context and does not
+  override repo-local policy.
 
-## Interaction Mode And Permission Behavior
+## Interaction Mode And Permission Mode
 
-Apply the interaction-mode preflight in
-[`repo-readiness.md`](../repo-readiness.md#interaction-mode-preflight) first.
-Claude Code's permission modes map onto those modes but do not replace them:
+These are two separate axes. The playbook interaction mode (implementation,
+review/audit, orchestration/prompt-authoring) expresses intent and authority;
+select it first via the
+[interaction-mode preflight](../repo-readiness.md#interaction-mode-preflight).
+Claude Code's permission mode (`default`, `plan`, `acceptEdits`,
+`bypassPermissions`) controls execution capability. Choose the permission mode
+from the task's actual tool requirements and blast radius, not by inferring it
+from the interaction mode.
 
-- Plan mode analyzes and plans without mutating the repository, which fits
-  review/audit and orchestration/prompt-authoring. For ctrl-alt-keith
-  workflows, ambiguous repository tasks default to review/audit or
-  orchestration/prompt-authoring, so prefer plan mode until the human explicitly
-  asks Claude to implement, commit, push, or open the PR.
-- Default mode implements with per-action approval and suits implementation
-  mode with a human in the loop.
-- `acceptEdits` suits bounded implementation once scope and approach are agreed.
-- `bypassPermissions` should be avoided for repository mutation with real blast
-  radius.
+- Review/audit work usually needs read-only shell such as `git status`,
+  `git diff`, `gh pr view`, and `make check`. Choose a mode that permits those
+  reads while withholding write/mutation approval; do not assume `plan` mode is
+  the right default merely because the interaction mode is review/audit.
+- For implementation, prefer per-action approval (`default`); reserve broader
+  auto-approval (`acceptEdits`) for bounded, already-agreed scope.
+- Verified evaluation: permission rules are checked `deny` -> `ask` -> `allow`,
+  first match wins. This is approval/prompting behavior, not an authorization
+  boundary.
+- `bypassPermissions` skips approval prompts; Anthropic documents it for use
+  only in isolated environments such as containers or VMs. Do not use it for
+  repository work with meaningful blast radius, and do not treat repository-level
+  `deny` rules as a sufficient safety boundary under it.
 
-A permission approval is capability, not authority
-([`core-model.md`](../core-model.md#authority-and-transitions)). Being allowed
-to run a tool does not authorize merge, release, tag, destructive, or
-externally visible actions; those remain human-gated (see
-[Delivery And Stop Conditions](#delivery-and-stop-conditions)). Deny rules in
-settings are evaluated first
-and hold even under `bypassPermissions`, so prefer explicit deny rules for
-push, merge, and destructive operations over relying on interactive prompts.
+Approval is capability, not authority
+([`core-model.md`](../core-model.md#authority-and-transitions)). Being allowed to
+run a tool does not authorize merge, release, tag, destructive, or externally
+visible actions; those remain human-gated (see
+[Delivery And Stop Conditions](#delivery-and-stop-conditions)).
 
-## Sandbox And Command Execution
+## Command Execution
 
-Claude Code does not use Codex's `workspace-write` writable-root sandbox. The
-Codex adapter's `effective-sandbox-check`, `writable_roots`, and temp-root
-exclusion mechanics do not apply to Claude and are not reproduced here.
-Isolation for Claude comes from the permission model and the working directory
-or Git worktree, not from writable-root configuration. Keep durable workflow
-artifacts in the repo-local paths named by
+Claude runs shell commands through the `Bash` tool in a persistent shell
+session, so it cannot select the argv / `shell=false` execution some executors
+offer. Still follow the
+[command-form rule](../repo-readiness.md#command-form-and-intent-visibility):
+run ordinary repository operations in direct, single-purpose form (`git status`,
+`gh pr view <n>`, `make check`), and do not wrap them in extra `bash -lc`,
+aliases, or compound-shell layers that hide intent. Claude 4.x issues `Bash`
+calls in parallel; keep parallel calls to independent read-only inspection and
+never parallelize mutating Git or overlapping worktree operations.
+
+Isolation comes from the permission model and the working directory or Git
+worktree, not from a writable-root sandbox. Keep durable artifacts in the
+repo-local paths in
 [`repo-readiness.md`](../repo-readiness.md#repo-local-workflow-state); use OS
 temp locations only for short-lived process-local files.
 
-Claude runs shell commands through the `Bash` tool as a persistent shell
-session, so it cannot toggle the native argv / `shell=false` execution that the
-Codex adapter describes; that specific Codex instruction does not transfer. The
-shared intent from
-[`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility)
-still holds: run ordinary repository operations in direct, single-purpose form
-such as `git status`, `gh pr view <n>`, and `make check`, and do not bury them
-in extra `bash -lc`, alias, or compound-shell layers that hide operational
-intent. Use shell composition only when it is genuinely required, and keep the
-wrapped command narrow enough to stay reviewable.
+## Worktrees And Subagents
 
-## Worktrees And Worker Isolation
-
-The one-repository, one-branch, one-worktree, one-PR rule and the
-`<repo>/.worktrees/` placement are owned by
-[`repo-readiness.md`](../repo-readiness.md#pr-readiness) and repo-local
-`AGENTS.md`; apply them unchanged. Claude's native worktree pattern, a separate
-checkout per branch created from an existing commit, fits this directly. Create
+Apply the one-repository, one-branch, one-worktree, one-PR rule and
+`<repo>/.worktrees/` placement from
+[`repo-readiness.md`](../repo-readiness.md#pr-readiness) unchanged; create
 repo-changing worktrees with direct `git worktree add` naming the full
-`.worktrees/<task-name>` path, and reuse a worktree only when it clearly belongs
-to the same active task.
+`.worktrees/<task-name>` path.
 
-Claude subagents (the `Task` tool) run in a separate context window with a
-self-contained prompt and report a summary back to the orchestrator; they do not
-inherit the parent conversation. This matches the standalone-worker-prompt
-requirement in
-[`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md)
-natively, so Claude does not need the Codex caveat about avoiding
-"fork this conversation." Give each subagent a complete envelope: repository and
-working directory, interaction mode and deliverable, goal, scope and exclusions,
-source evidence or retrieval instructions, validation path, and stop conditions.
-Worker authority stops at the assigned envelope; a worker must not merge, enable
+Claude subagents (`Task` tool) run in a separate context window and do not
+inherit the parent conversation, so give each one a complete, self-contained
+envelope: repository and working directory, interaction mode and deliverable,
+goal, scope and exclusions, source evidence or retrieval instructions,
+validation path, and stop conditions (this is the standalone-worker requirement
+in
+[`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md)).
+Worker authority stops at the envelope; a worker must not merge, enable
 auto-merge, update other branches, or continue into downstream reconciliation
-unless the human explicitly authorizes that step.
+unless the human authorizes that step.
 
-## Context Compaction And Conversation Recovery
+## Context Compaction And Recovery
 
-Claude Code auto-compacts the conversation before the context window fills and
-also supports manual `/compact` and session resume (`--resume`, `--continue`,
-and the resume picker). Compaction replaces earlier turns with a summary, and a
-resumed session keeps the model it was using when the transcript was saved.
-
-Treat compacted or resumed conversation as navigation, not authority. This is
-the same durable-continuity rule the playbook already states in
-[`core-model.md`](../core-model.md#durable-continuity) and
-[`source-first-retrieval.md`](../source-first-retrieval.md); compaction and
-resume simply make it operationally important for Claude. After a compaction or
-resume, re-retrieve authoritative repository, PR, issue, CI, and file state
-before relying on it rather than trusting the summarized context.
+Claude Code auto-compacts before the context window fills and supports `/compact`
+and session resume (`--resume`, `--continue`). Compaction replaces earlier turns
+with a summary. Treat compacted or resumed conversation as navigation, not
+authority: after either, re-retrieve authoritative repository, PR, issue, CI, and
+file state before relying on it, per
+[`source-first-retrieval.md`](../source-first-retrieval.md) and
+[durable continuity](../core-model.md#durable-continuity).
 
 ## Connectors
 
 Claude reaches remote services, including GitHub, through MCP servers. Apply the
-runtime-evidence rule in
-[`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence):
-inspect the available connector actions or attempt the operation before claiming
-a capability is unavailable, and treat a successful call as positive evidence
-that the capability remains available. For GitHub PR and issue work, prefer
-connector-first inspection per
-[`review-packet.md`](../review-packet.md#direct-pr-inspection) and
-[`source-first-retrieval.md`](../source-first-retrieval.md); direct `git` and
-`gh` supplement that inspection and remain appropriate for verified connector
-gaps or repo-local workflows.
+[runtime-evidence rule](../start-here.md#connector-availability-is-runtime-evidence):
+inspect available connector actions or attempt the operation before claiming a
+capability is unavailable, and treat a successful call as evidence it remains
+available. For GitHub PR and issue work, prefer connector-first inspection per
+[`review-packet.md`](../review-packet.md#direct-pr-inspection); direct `git` and
+`gh` supplement it and remain appropriate for verified connector gaps or
+repo-local workflows.
 
 ## Reasoning And Model Configuration
 
 When a material prompt uses the product-neutral reasoning class in
-[`prompt-contracts.md`](../prompt-contracts.md) (`light`, `medium`, or `high`),
-the Claude representation is an extended-thinking budget together with model
-selection, chosen from the bounded task shape. Concrete model names and thinking
-budgets are adapter configuration and attempt-receipt metadata; they are not the
-semantic meaning of the reasoning class.
-
-- Preserve whether the reasoning class and each required capability are
-  mandatory or advisory. If the available Claude surface cannot satisfy a
-  mandatory class or capability without weakening a guarantee, the attempt fails
-  closed rather than silently downgrading.
-- A model change alone does not justify a prompt rewrite; preserve existing
-  behavior and settings first, then make surgical changes tied to an observed
-  failure.
-
-The full Codex operator-metadata rendering (the `Light | Medium | High` block)
-is the Codex representation of that reasoning class and is not reproduced here.
-A product-neutral Claude rendering of reasoning-selection guidance is deferred
-until it is needed; see the shared owner in
-[`prompt-contracts.md`](../prompt-contracts.md).
+[`prompt-contracts.md`](../prompt-contracts.md) (`light`, `medium`, `high`), the
+Claude representation is an extended-thinking budget plus model selection chosen
+for the bounded task. Concrete model names and thinking budgets are adapter
+configuration and attempt-receipt metadata, not the meaning of the class.
+Preserve whether the class and each capability are mandatory or advisory; if the
+available Claude surface cannot meet a mandatory requirement without weakening a
+guarantee, fail closed rather than silently downgrade. A model change alone does
+not justify a prompt rewrite; preserve existing behavior first, then make
+surgical changes tied to an observed failure.
 
 ## Local GitHub And Environment Preflight
 
-`scripts/codex-preflight` verifies local GitHub SSH authentication, `gh`
-authentication, and playbook repository reachability. Those checks are
-executor-neutral GitHub and environment readiness, not Codex mechanics, so a
-Claude automation run benefits from the same preflight. When Claude drives
+`scripts/codex-preflight` checks local GitHub SSH auth, `gh` auth, and repository
+reachability — executor-neutral environment readiness. When Claude drives
 repository automation or worker fan-out, run it first and stop on a non-zero
 exit:
 
 ```text
-Before starting repository work, run:
-
 cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
 ./scripts/codex-preflight
-
-If it exits non-zero, stop and report the failing check and remediation.
 ```
-
-Claude does not need a separate preflight script; a duplicate would fork
-canonical executable behavior, which the engineering baseline prohibits. The
-future rename of this shared check is tracked as deferred work in the pull
-request that introduced this adapter.
 
 ## Delivery And Stop Conditions
 
 Follow the PR readiness, validation, and delivery rules in
-[`repo-readiness.md`](../repo-readiness.md) and repo-local `AGENTS.md`. When
-reporting completion for implementation work, include the PR link when one was
-opened or updated, files changed, validation results, and any known blockers or
-residual risks.
+[`repo-readiness.md`](../repo-readiness.md) and repo-local `AGENTS.md`. On
+completion, report the PR link when one was opened or updated, files changed,
+validation results, and known blockers or residual risks.
 
 Pause and ask for human input when the repository, branch, or worktree context
 appears wrong, the scope is ambiguous or has shifted, required source state
@@ -220,9 +154,8 @@ permissions-sensitive.
 
 ## References
 
-Claude Code behavior described in this adapter is drawn from the official
-Anthropic documentation, including
-[Claude Code memory](https://docs.claude.com/en/docs/claude-code/memory),
-[permissions](https://docs.claude.com/en/docs/claude-code/sdk/sdk-permissions),
+Behavioral claims above are grounded in official Anthropic documentation,
+including [memory](https://docs.claude.com/en/docs/claude-code/memory),
+[permissions](https://code.claude.com/docs/en/permissions),
 [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
-[common workflows](https://docs.claude.com/en/docs/claude-code/common-workflows).
+[worktrees](https://code.claude.com/docs/en/worktrees).

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -1,0 +1,228 @@
+# Claude Adapter
+
+This adapter records Claude Code-specific deltas on top of the core playbook.
+Use it with [`start-here.md`](../start-here.md),
+[`core-model.md`](../core-model.md),
+[`source-first-retrieval.md`](../source-first-retrieval.md),
+[`repo-readiness.md`](../repo-readiness.md), and the target repo's `AGENTS.md`;
+do not treat it as a second copy of those rules.
+
+This adapter intentionally does not mirror the Codex adapter. Where the two
+executors share behavior, the shared rule stays in its canonical playbook doc
+and this file only records what is genuinely different for Claude Code. Where an
+analogous Codex concept has no Claude equivalent, such as Codex's writable-root
+sandbox or its argv/`shell=false` execution toggle, this adapter says so instead
+of restating the Codex mechanics.
+
+## Claude-Specific Quirks
+
+- Claude Code loads its instruction and permission context from files and
+  settings rather than from a single prompt; instruction discovery below is the
+  most important delta to get right for repositories that standardize on
+  `AGENTS.md`.
+- Claude 4.x models fire tool calls, including `Bash`, in parallel and can be
+  aggressive about it. Keep parallel calls to independent, non-mutating
+  inspection; do not parallelize mutating Git operations or overlapping worktree
+  changes.
+- Claude can produce fluent summaries that still require source inspection and
+  human judgment on scope, tradeoffs, and completion. Apply
+  [`source-first-retrieval.md`](../source-first-retrieval.md) before stateful
+  conclusions.
+
+## Instruction Discovery And Precedence
+
+Claude Code natively auto-loads `CLAUDE.md` memory at session start: a
+project-level `CLAUDE.md` or `.claude/CLAUDE.md` in the working directory, a
+user-level `~/.claude/CLAUDE.md`, and any files those import. This repository
+family instead treats repo-local `AGENTS.md` as the canonical repository
+execution layer, and the startup contract in
+[`start-here.md`](../start-here.md#required-repository-startup-contract) requires
+reading the target repository's `AGENTS.md`.
+
+Because Claude's automatic memory loading is `CLAUDE.md`-centric and does not
+guarantee that `AGENTS.md` is ingested, Claude must explicitly read the target
+repository's `AGENTS.md` to satisfy the startup contract. Do not assume
+auto-loaded memory already covers repo-local execution policy.
+
+- Do not fork or duplicate `AGENTS.md` (or shared playbook doctrine) into a
+  `CLAUDE.md`. Canonical ownership stays with `AGENTS.md` and the shared docs;
+  duplicating it creates a competing instruction copy that can drift. See
+  [`repo-readiness.md`](../repo-readiness.md#agentsmd-responsibilities).
+- If a `CLAUDE.md` is used in a repository, keep it a thin pointer to
+  `docs/start-here.md` and the repo's `AGENTS.md`, not a second policy source.
+- Claude's memory files and settings are a transport for instructions, not a new
+  authority layer. The Repository Instruction Hierarchy in
+  [`start-here.md`](../start-here.md#repository-instruction-hierarchy) still
+  governs: the human's explicit task, then repo-local `AGENTS.md`, then this
+  adapter, then shared playbook defaults. A user-level `~/.claude/CLAUDE.md`
+  carries operator context and does not override repo-local policy.
+
+## Interaction Mode And Permission Behavior
+
+Apply the interaction-mode preflight in
+[`repo-readiness.md`](../repo-readiness.md#interaction-mode-preflight) first.
+Claude Code's permission modes map onto those modes but do not replace them:
+
+- Plan mode analyzes and plans without mutating the repository, which fits
+  review/audit and orchestration/prompt-authoring. For ctrl-alt-keith
+  workflows, ambiguous repository tasks default to review/audit or
+  orchestration/prompt-authoring, so prefer plan mode until the human explicitly
+  asks Claude to implement, commit, push, or open the PR.
+- Default mode implements with per-action approval and suits implementation
+  mode with a human in the loop.
+- `acceptEdits` suits bounded implementation once scope and approach are agreed.
+- `bypassPermissions` should be avoided for repository mutation with real blast
+  radius.
+
+A permission approval is capability, not authority
+([`core-model.md`](../core-model.md#authority-and-transitions)). Being allowed
+to run a tool does not authorize merge, release, tag, destructive, or
+externally visible actions; those remain human-gated (see
+[Delivery And Stop Conditions](#delivery-and-stop-conditions)). Deny rules in
+settings are evaluated first
+and hold even under `bypassPermissions`, so prefer explicit deny rules for
+push, merge, and destructive operations over relying on interactive prompts.
+
+## Sandbox And Command Execution
+
+Claude Code does not use Codex's `workspace-write` writable-root sandbox. The
+Codex adapter's `effective-sandbox-check`, `writable_roots`, and temp-root
+exclusion mechanics do not apply to Claude and are not reproduced here.
+Isolation for Claude comes from the permission model and the working directory
+or Git worktree, not from writable-root configuration. Keep durable workflow
+artifacts in the repo-local paths named by
+[`repo-readiness.md`](../repo-readiness.md#repo-local-workflow-state); use OS
+temp locations only for short-lived process-local files.
+
+Claude runs shell commands through the `Bash` tool as a persistent shell
+session, so it cannot toggle the native argv / `shell=false` execution that the
+Codex adapter describes; that specific Codex instruction does not transfer. The
+shared intent from
+[`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility)
+still holds: run ordinary repository operations in direct, single-purpose form
+such as `git status`, `gh pr view <n>`, and `make check`, and do not bury them
+in extra `bash -lc`, alias, or compound-shell layers that hide operational
+intent. Use shell composition only when it is genuinely required, and keep the
+wrapped command narrow enough to stay reviewable.
+
+## Worktrees And Worker Isolation
+
+The one-repository, one-branch, one-worktree, one-PR rule and the
+`<repo>/.worktrees/` placement are owned by
+[`repo-readiness.md`](../repo-readiness.md#pr-readiness) and repo-local
+`AGENTS.md`; apply them unchanged. Claude's native worktree pattern, a separate
+checkout per branch created from an existing commit, fits this directly. Create
+repo-changing worktrees with direct `git worktree add` naming the full
+`.worktrees/<task-name>` path, and reuse a worktree only when it clearly belongs
+to the same active task.
+
+Claude subagents (the `Task` tool) run in a separate context window with a
+self-contained prompt and report a summary back to the orchestrator; they do not
+inherit the parent conversation. This matches the standalone-worker-prompt
+requirement in
+[`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md)
+natively, so Claude does not need the Codex caveat about avoiding
+"fork this conversation." Give each subagent a complete envelope: repository and
+working directory, interaction mode and deliverable, goal, scope and exclusions,
+source evidence or retrieval instructions, validation path, and stop conditions.
+Worker authority stops at the assigned envelope; a worker must not merge, enable
+auto-merge, update other branches, or continue into downstream reconciliation
+unless the human explicitly authorizes that step.
+
+## Context Compaction And Conversation Recovery
+
+Claude Code auto-compacts the conversation before the context window fills and
+also supports manual `/compact` and session resume (`--resume`, `--continue`,
+and the resume picker). Compaction replaces earlier turns with a summary, and a
+resumed session keeps the model it was using when the transcript was saved.
+
+Treat compacted or resumed conversation as navigation, not authority. This is
+the same durable-continuity rule the playbook already states in
+[`core-model.md`](../core-model.md#durable-continuity) and
+[`source-first-retrieval.md`](../source-first-retrieval.md); compaction and
+resume simply make it operationally important for Claude. After a compaction or
+resume, re-retrieve authoritative repository, PR, issue, CI, and file state
+before relying on it rather than trusting the summarized context.
+
+## Connectors
+
+Claude reaches remote services, including GitHub, through MCP servers. Apply the
+runtime-evidence rule in
+[`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence):
+inspect the available connector actions or attempt the operation before claiming
+a capability is unavailable, and treat a successful call as positive evidence
+that the capability remains available. For GitHub PR and issue work, prefer
+connector-first inspection per
+[`review-packet.md`](../review-packet.md#direct-pr-inspection) and
+[`source-first-retrieval.md`](../source-first-retrieval.md); direct `git` and
+`gh` supplement that inspection and remain appropriate for verified connector
+gaps or repo-local workflows.
+
+## Reasoning And Model Configuration
+
+When a material prompt uses the product-neutral reasoning class in
+[`prompt-contracts.md`](../prompt-contracts.md) (`light`, `medium`, or `high`),
+the Claude representation is an extended-thinking budget together with model
+selection, chosen from the bounded task shape. Concrete model names and thinking
+budgets are adapter configuration and attempt-receipt metadata; they are not the
+semantic meaning of the reasoning class.
+
+- Preserve whether the reasoning class and each required capability are
+  mandatory or advisory. If the available Claude surface cannot satisfy a
+  mandatory class or capability without weakening a guarantee, the attempt fails
+  closed rather than silently downgrading.
+- A model change alone does not justify a prompt rewrite; preserve existing
+  behavior and settings first, then make surgical changes tied to an observed
+  failure.
+
+The full Codex operator-metadata rendering (the `Light | Medium | High` block)
+is the Codex representation of that reasoning class and is not reproduced here.
+A product-neutral Claude rendering of reasoning-selection guidance is deferred
+until it is needed; see the shared owner in
+[`prompt-contracts.md`](../prompt-contracts.md).
+
+## Local GitHub And Environment Preflight
+
+`scripts/codex-preflight` verifies local GitHub SSH authentication, `gh`
+authentication, and playbook repository reachability. Those checks are
+executor-neutral GitHub and environment readiness, not Codex mechanics, so a
+Claude automation run benefits from the same preflight. When Claude drives
+repository automation or worker fan-out, run it first and stop on a non-zero
+exit:
+
+```text
+Before starting repository work, run:
+
+cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
+./scripts/codex-preflight
+
+If it exits non-zero, stop and report the failing check and remediation.
+```
+
+Claude does not need a separate preflight script; a duplicate would fork
+canonical executable behavior, which the engineering baseline prohibits. The
+future rename of this shared check is tracked as deferred work in the pull
+request that introduced this adapter.
+
+## Delivery And Stop Conditions
+
+Follow the PR readiness, validation, and delivery rules in
+[`repo-readiness.md`](../repo-readiness.md) and repo-local `AGENTS.md`. When
+reporting completion for implementation work, include the PR link when one was
+opened or updated, files changed, validation results, and any known blockers or
+residual risks.
+
+Pause and ask for human input when the repository, branch, or worktree context
+appears wrong, the scope is ambiguous or has shifted, required source state
+cannot be retrieved, more than one valid path depends on human judgment, or the
+next step is merge, release, tag, destructive, externally visible, or
+permissions-sensitive.
+
+## References
+
+Claude Code behavior described in this adapter is drawn from the official
+Anthropic documentation, including
+[Claude Code memory](https://docs.claude.com/en/docs/claude-code/memory),
+[permissions](https://docs.claude.com/en/docs/claude-code/sdk/sdk-permissions),
+[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
+[common workflows](https://docs.claude.com/en/docs/claude-code/common-workflows).

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -58,15 +58,18 @@ visible actions; those remain human-gated (see
 
 ## Command Execution
 
-Claude runs shell commands through the `Bash` tool in a persistent shell
-session, so it cannot select the argv / `shell=false` execution some executors
-offer. Still follow the
+Claude executes Bash commands as separate processes. In the main session,
+working-directory changes may carry over within the project or explicitly added
+directories, but shell environment changes such as `export`, `source`, aliases,
+and virtual-environment activation do not persist between calls; subagent
+working-directory changes do not persist. Keep commands self-contained and
+follow the
 [command-form rule](../repo-readiness.md#command-form-and-intent-visibility):
 run ordinary repository operations in direct, single-purpose form (`git status`,
-`gh pr view <n>`, `make check`), and do not wrap them in extra `bash -lc`,
-aliases, or compound-shell layers that hide intent. Claude 4.x issues `Bash`
-calls in parallel; keep parallel calls to independent read-only inspection and
-never parallelize mutating Git or overlapping worktree operations.
+`gh pr view <n>`, `make check`) rather than wrapping them in extra `bash -lc`,
+aliases, or compound-shell layers that hide intent. Claude may issue independent
+tool calls in parallel; keep parallel calls to independent read-only inspection
+and never parallelize mutating Git or overlapping worktree operations.
 
 Isolation comes from the permission model and the working directory or Git
 worktree, not from a writable-root sandbox. Keep durable artifacts in the
@@ -82,12 +85,13 @@ Apply the one-repository, one-branch, one-worktree, one-PR rule and
 repo-changing worktrees with direct `git worktree add` naming the full
 `.worktrees/<task-name>` path.
 
-Claude subagents (`Task` tool) run in a separate context window and do not
-inherit the parent conversation, so give each one a complete, self-contained
-envelope: repository and working directory, interaction mode and deliverable,
-goal, scope and exclusions, source evidence or retrieval instructions,
-validation path, and stop conditions (this is the standalone-worker requirement
-in
+Non-fork Claude subagents (`Task` tool) start with a separate context and do not
+receive the parent conversation history or files the parent previously read, so
+give each one a complete, self-contained envelope rather than relying on implicit
+conversational context: repository and working directory, interaction mode and
+deliverable, goal, scope and exclusions, source evidence or retrieval
+instructions, validation path, and stop conditions (this is the standalone-worker
+requirement in
 [`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md)).
 Worker authority stops at the envelope; a worker must not merge, enable
 auto-merge, update other branches, or continue into downstream reconciliation
@@ -157,5 +161,6 @@ permissions-sensitive.
 Behavioral claims above are grounded in official Anthropic documentation,
 including [memory](https://docs.claude.com/en/docs/claude-code/memory),
 [permissions](https://code.claude.com/docs/en/permissions),
+[the tools reference](https://code.claude.com/docs/en/tools-reference),
 [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
 [worktrees](https://code.claude.com/docs/en/worktrees).

--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -31,6 +31,7 @@ DEFAULT_OFFICIAL_SUFFIXES = (
     "developers.google.com",
     "firebase.google.com",
     "developers.openai.com",
+    "claude.com",
     "developer.atlassian.com",
     "docs.atlassian.com",
     "support.atlassian.com",

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -98,6 +98,21 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
 
                 self.assertEqual(findings, [])
 
+    def test_claude_docs_are_allowed_by_default(self) -> None:
+        urls = [
+            "https://docs.claude.com/en/docs/claude-code/memory",
+            "https://docs.claude.com/en/docs/claude-code/sub-agents",
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                findings = scanner.scan_text(
+                    "docs/example.md",
+                    f"Claude Code CLI source: {url}",
+                )
+
+                self.assertEqual(findings, [])
+
     def test_openai_developer_docs_are_allowed_by_default(self) -> None:
         findings = scanner.scan_text(
             "docs/example.md",


### PR DESCRIPTION
## Summary

Adds `docs/tool-adapters/claude.md`, a focused Claude Code executor adapter, and
wires it into the startup contract (`start-here.md` read order + startup step 3),
the README map, and repo-local `AGENTS.md`. Adds `claude.com` to the
authoritative-source allowlist (docs.claude.com is Anthropic's
provider-authoritative docs domain) so the adapter can cite official references,
with a covering test. No Codex files were rewritten; no preflight was renamed.

## Why (smallest correct first step)

The repo already has a documented adapter surface and `start-here.md` already
generically supports `docs/tool-adapters/<executor>.md`, so the minimal
first-class step is a single new adapter plus one parallel discovery line in each
place that already names Codex. The adapter records only genuine Claude Code
deltas and routes everything shared back to its canonical doc, so it deliberately
does not mirror `codex.md`. It touches six files, adds no new abstraction layer,
and preserves canonical ownership and the startup contract.

## Claude-specific findings

- Instruction discovery/precedence: Claude Code natively auto-loads `CLAUDE.md`
  (project, `.claude/`, `~/.claude/`, imports), not `AGENTS.md`. Since this repo
  makes `AGENTS.md` the canonical repo-local layer, Claude must explicitly read
  `AGENTS.md`, and any `CLAUDE.md` must be a thin pointer, not a fork.
- Interaction mode vs permission mode are separate axes: the playbook
  interaction mode expresses intent/authority; the Claude permission mode
  (`default`/`plan`/`acceptEdits`/`bypassPermissions`) controls execution
  capability and must be chosen from the task's actual tool requirements and
  blast radius, not inferred from the interaction mode. Verified rule evaluation
  is `deny` -> `ask` -> `allow` (approval behavior, not an authorization
  boundary); `bypassPermissions` is documented for isolated environments only and
  repo-level `deny` rules are not treated as a safety boundary under it. Approval
  is capability, not authority.
- Context compaction + resume (`/compact`, `--resume`/`--continue`) make the
  existing durable-continuity / source-first rule operationally important:
  re-retrieve authoritative state after compaction.
- Subagents run in an isolated context window with a self-contained prompt — this
  matches the standalone-worker-prompt rule natively, so Claude needs no
  Codex-style "don't fork the conversation" caveat.
- Reasoning class maps to extended-thinking budget + model selection (adapter
  config / receipt metadata), fail-closed if a mandatory class cannot be met.

## Codex-specific findings (should stay in `codex.md`)

The `workspace-write` writable-roots sandbox and `effective-sandbox-check`, the
argv/`shell=false` execution toggle, `codex-safe-rm`, GPT-5.6 Sol posture and
model/tier/reasoning knobs, and the Light/Medium/High operator-metadata rendering
are all genuinely Codex-surface-specific and were not generalized or copied.

## Shared guidance (eventually executor-neutral, deferred here)

The reasoning-class to product-neutral mapping is already owned by
`prompt-contracts.md`; a product-neutral rendering of reasoning-selection (today
only expressed as Codex operator metadata) is the main candidate for future
extraction. Worktree isolation, PR readiness, interaction modes, and source-first
retrieval are already shared and correctly routed to, so no extraction was needed
now.

## Preflight recommendation

`scripts/codex-preflight` is not Codex-specific in substance — it checks GitHub
SSH auth, `gh` auth, and repo reachability, i.e. executor-neutral
GitHub/environment readiness. A Claude run benefits from the identical check. The
smallest correct step is therefore to reuse it as-is (the adapter points Claude
at it) rather than fork a near-identical `claude-preflight`, which would duplicate
canonical executable behavior. Renaming it to a shared `repo-preflight` (with
backward-compatible `CODEX_PREFLIGHT_*` env aliases) is preferable eventually but
is a churny rename touching script, doc, tests, Makefile, and README — deferred,
not done here.

## Deferred work (separate PRs)

1. Rename `codex-preflight` to a shared `repo-preflight` with `CODEX_PREFLIGHT_*`
   aliases plus doc/test updates.
2. Extract a product-neutral reasoning-selection rendering shared by Codex and
   Claude.
3. Generalize `prompts.md` templates that currently hard-reference `codex.md`
   once a second executor representation exists.

## Revision (second push)

- Corrected the permission section: removed the unsupported claim that `deny`
  rules hold under `bypassPermissions`; now states only the verified
  `deny` -> `ask` -> `allow` evaluation and advises against `bypassPermissions`
  for repository work with meaningful blast radius (grounded in Anthropic's
  isolated-environment guidance).
- Separated the playbook interaction mode (intent/authority) from the Claude
  permission mode (execution capability); permission mode is selected from the
  task's tool requirements and blast radius rather than mapped from plan mode.
- Concision pass: adapter trimmed from ~228 to 166 lines by removing
  PR-rationale prose, Codex contrasts that do not change Claude execution, and
  restated shared doctrine; the Claude-specific deltas are preserved.

## Validation

- `make check` passes: markdownlint clean across 48 files, 40 unit tests pass
  (including a new `claude.com` allowlist test).
- `make authoritative-source-check` reports no non-authoritative source URLs.
