### PR TITLE
Strengthen repository operating mode after hydration

### DIFF
--- a/docs/orchestration-and-parallelism.md
+++ b/docs/orchestration-and-parallelism.md
@@ -98,6 +98,12 @@ results in a pull request. When delegated work will modify a repository, the
 default expected deliverable is a reviewable pull request unless another
 artifact is explicitly requested.
 
+Every delegated repository implementation prompt must explicitly identify the
+target repository, even when the repository appears obvious from the working
+directory or conversational context. Repository identity is part of the task's
+scope and authority boundary; do not leave it implicit or rely on inherited
+context to supply it.
+
 Include:
 
 - repository and working directory

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -201,6 +201,18 @@ recommendations, and "what changed?" or "what next?" requests:
 ### Required Repository Invariants
 
 - `ai-workflow-playbook` is the canonical source for reusable workflow rules.
+- Successful repository hydration is a mode transition, not only an
+  information-retrieval event. After the required repository startup contract
+  succeeds, repository operating mode remains active for the rest of the
+  repository work. Plans, reviews, implementation prompts, validation
+  summaries, completion reports, and other artifacts must continue to use the
+  repository-native conventions established by the governing repository
+  sources without requiring the human to restate them. This invariant does not
+  freeze a specific template or layout; the canonical artifact conventions may
+  evolve. Repository operating mode ends only when the interaction clearly
+  leaves repository work or the human explicitly requests a different artifact
+  style. Moving to another repository requires applying that repository's
+  startup contract before assuming its native conventions.
 - `docs/prompt-contracts.md` and its versioned machine-readable companions own
   shared prompt-contract meaning; implementing repositories own operational
   schemas, hydration, rendering, receipts, and validation code.


### PR DESCRIPTION
## Summary

- define successful repository hydration as a persistent repository operating-mode transition
- require repository-native artifact conventions to remain the default until repository work clearly ends or the human requests another style
- require delegated repository implementation prompts to name the target repository explicitly

## Canonical ownership

The hydration invariant is in `docs/start-here.md` under **Required Repository Invariants** because that document owns the repository startup contract and the effects of completing it.

The explicit repository-identity invariant is in `docs/orchestration-and-parallelism.md` under **Worker Envelope** because that section owns the semantic requirements for self-contained delegated repository work.

The rules are not duplicated into `docs/prompts.md`, `docs/source-first-retrieval.md`, `docs/prompt-contracts.md`, executor adapters, or repo-local `AGENTS.md` files. Those surfaces respectively provide reusable templates, evidence retrieval, versioned material-prompt semantics, executor mappings, and repository-specific execution policy; duplicating the invariants there would create competing owners and drift. Existing prompt templates already carry a repository field, so no template change is needed.

## Why

Hydration was successfully making repository information available, but the startup contract did not state that hydration also establishes a durable repository operating mode. Later artifacts could therefore regress to generic conversational formatting. This change makes persistence of repository-native conventions an explicit semantic invariant without freezing any particular artifact layout.

Explicit repository identity in delegated implementation prompts prevents scope and authority ambiguity when conversational context or multiple active repositories could otherwise supply an implicit target.

## Impact

Repository work will continue to produce repository-native artifacts automatically after successful startup. Canonical artifact formats remain free to evolve, and humans can still explicitly request a different style or leave repository mode.

## Validation

- `make check`
  - Markdown lint: 0 issues
  - Unit tests: 42 passed