### PR TITLE
Add evidence classification and operator observability rules

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -34,16 +34,49 @@ ordinary chat, brainstorming, or conceptual discussion procedural.
   authority sensitivity, and irreversibility. Small, obvious, reversible work
   should not inherit unnecessary ceremony. Repository proposal-first delivery
   remains owned by [`feature-lifecycle.md`](feature-lifecycle.md).
-- **Make the phase and next permitted action legible when they matter.** Report
-  observable decisions, artifacts, unmet criteria, and transition boundaries
-  instead of narrating internal activity. Do not impose a universal phase
-  machine on simple work.
 - **Validate or verify before relying on consequential conclusions.** Choose
   checks that match the claim and risk. Passing validation is evidence about
   what was checked; it is not acceptance, approval, or broader authority.
 - **Re-observe resulting reality after consequential change.** Retrieve the
   actual outcome instead of assuming the planned effect occurred, then
   reconcile separately owned systems only when their workflows require it.
+
+## Evidence Classification Invariant
+
+Before drawing a material conclusion, identify the source authoritative for
+that conclusion and classify each relied-on input by its relationship to that
+source. Use the evidence classes that fit the question rather than imposing a
+fixed taxonomy.
+
+Distinguish authoritative state from artifacts derived from it. Reports,
+dashboards, receipts, summaries, caches, and other derived artifacts may be
+evidence of their own production or preserved history, but they must be
+validated against the authoritative source before supporting a conclusion
+about the state they represent. A derived artifact must never become evidence
+for the authoritative state it summarizes.
+
+This is a semantic execution invariant, not a prompt-writing convention.
+Repository retrieval triggers, source ordering, verification gates, and
+recovery mechanics remain owned by
+[`source-first-retrieval.md`](source-first-retrieval.md).
+
+## Operator Observability
+
+During consequential work, surface meaningful operational state transitions
+when they materially change subsequent execution. The update should let the
+operator understand the state entered and why that state changes what may
+happen next.
+
+Relevant transitions can include establishing an operating mode, selecting a
+work classification, identifying governing contracts, setting an evidence
+boundary or authoritative source, selecting a validation strategy, completing
+validation, becoming ready to mutate repository state, or encountering a
+blocker. These are examples, not a required phase list or reporting taxonomy.
+
+Do not require every transition to be reported, prescribe exact wording or a
+logging style, narrate hidden deliberation, or expose or request private
+chain-of-thought. Operator observability reports execution state and its
+behavioral consequence; it does not report internal reasoning.
 
 ## Authority Follows The Question
 

--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -22,12 +22,16 @@ safeguards. It does not assume or describe platform internals.
 ## Authority Selection
 
 Apply the question-typed authority rule in
-[`core-model.md`](core-model.md#authority-follows-the-question) before using the
-evidence hierarchy below. The hierarchy orders evidence for a claim only after
-the source that owns that kind of fact has been identified; it is not a global
-system-of-record ranking. When a question spans planning, repository, runtime,
-or historical evidence boundaries, retrieve each applicable owner and preserve
-their separate claims during reconciliation.
+[`core-model.md`](core-model.md#authority-follows-the-question) and its
+[`Evidence Classification Invariant`](core-model.md#evidence-classification-invariant)
+before using the evidence hierarchy below. The core model owns those semantic
+requirements; this document owns repository retrieval triggers, source
+ordering, verification gates, and recovery mechanics. The hierarchy orders
+evidence for a claim only after the source that owns that kind of fact has been
+identified; it is not a global system-of-record ranking. When a question spans
+planning, repository, runtime, or historical evidence boundaries, retrieve
+each applicable owner and preserve their separate claims during
+reconciliation.
 
 ## Evidence Hierarchy
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -32,9 +32,10 @@ boundaries materially affect the outcome:
 8. After consequential change, retrieve the resulting state and reconcile any
    separately owned system only when its workflow requires it.
 
-Keep the current phase and next permitted action legible when they affect human
-review or workflow authority. This is observable workflow state, not a request
-for private reasoning or a universal phase machine.
+Apply the core model's
+[`Operator Observability`](core-model.md#operator-observability) guidance when
+an execution-state transition materially affects human review, workflow
+authority, or subsequent behavior.
 
 ### Connector availability is runtime evidence
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -342,11 +342,12 @@ as though the reviewer performed that verification.
 
 ## Workflow-State Progress Rendering
 
-This is the Codex rendering of the general principle to make material phases
-and next permitted actions legible; it does not redefine that principle. For
-material proposal-first or multi-stage work, report observable workflow state
-instead of narrating model activity. Keep updates concise and include only what
-helps the human understand or verify the current boundary:
+This is the Codex rendering of the core model's
+[`Operator Observability`](../core-model.md#operator-observability) guidance; it
+does not redefine that guidance. For material proposal-first or multi-stage
+work, report observable workflow state instead of narrating model activity.
+Keep updates concise and include only what helps the human understand or verify
+the current boundary:
 
 - current phase and exact artifact identities;
 - satisfied prerequisites and the evidence that satisfied them;


### PR DESCRIPTION
## Summary

- define evidence classification as a semantic execution invariant in the core model
- define material execution-state transitions as operator observability guidance, separate from evidence classification
- route startup and source-first guidance to the core owners and keep the Codex section explicitly adapter-only

## Rationale

This prevents derived reports, dashboards, receipts, summaries, and caches from substituting for the authoritative state they represent. It also lets operators see consequential execution-mode changes and their behavioral effects without requesting private reasoning or imposing a logging format.

## Validation

- make check
- Markdown lint: 0 issues
- unit tests: 42 passed
- focused documentation overlap and ownership review