### PR TITLE
Define recurring automation execution locality

### DIFF
--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -161,6 +161,65 @@ repository change is proposed. Report-only or cross-repository runs should use
 the workspace's designated durable operational-record location. Runtime output
 paths and notification routing remain local configuration.
 
+## Execution Locality
+
+Execution locality answers where a recurring capability can execute correctly.
+Classify it by asking:
+
+> Which environment owns the facts, resources, and mutation surfaces required
+> for correct execution?
+
+Use one of three locality classes:
+
+- **Local**: use local execution when correctness depends on workstation-owned
+  state or resources, such as local branches or worktrees, scheduler
+  configuration or runtime history, automation memory, machine-specific files,
+  paths, credentials, or caches, or state that cannot be reconstructed safely
+  in a clean hosted runtime.
+- **Hosted**: prefer hosted execution when authoritative inputs are repository
+  or provider state; execution can begin from a clean checkout or clean hosted
+  environment; identity and secrets can be provisioned explicitly; outputs can
+  use normal hosted evidence and review surfaces; and correct conclusions do
+  not depend on unobserved workstation state. GitHub Actions is one example of
+  a hosted executor, not the abstraction itself.
+- **Hybrid**: use hybrid as a decomposition signal when a capability spans
+  local and hosted authority domains. Split it into separately authoritative
+  local and hosted components rather than creating one job that ambiguously
+  mixes domains. Each component makes claims only about state its environment
+  owns, does not infer the other environment's live state, and produces
+  independently attributable evidence. Reconciliation must preserve unknowns,
+  unequal freshness, and disagreements.
+
+Locality and authority class are independent axes. Locality answers where the
+capability can execute correctly; the authority class above answers what the
+capability may do. For example:
+
+| Capability | Locality | Authority class |
+| --- | --- | --- |
+| Memory review | Local | Observe and report |
+| Local branch cleanup | Local | Perform bounded hygiene |
+| Repository validation | Hosted | Observe and report |
+| Documentation correction | Hosted | Propose review-ready changes |
+| Governance review spanning hosted and workstation state | Hybrid | Observe and report |
+
+Evidence must support the selected locality as well as the capability result:
+
+- **Local evidence** identifies the local configuration identity and scope, the
+  actual scheduler evidence available, workstation resources relied upon, and
+  skipped or unknown state. It also records mutation and recovery evidence
+  where applicable.
+- **Hosted evidence** identifies the repository and tested revision, run and
+  trigger, executing identity, permissions used, result, logs or artifacts and
+  their retention, and skipped or inaccessible hosted scope.
+- **Hybrid evidence** keeps separate local and hosted evidence packages. It may
+  use a correlation identity, but it must not infer across domains and must
+  reconcile disagreements or unequal freshness explicitly.
+
+Reports, receipts, dashboards, and other derived artifacts do not become
+authority for the mutable state they summarize; apply the evidence
+classification invariant in
+[`core-model.md`](core-model.md#evidence-classification-invariant).
+
 ## Repository Autonomy
 
 The layer preserves repository autonomy by applying shared expectations through
@@ -215,6 +274,7 @@ Canonical playbook doctrine owns:
 - the existence and purpose of the autonomous maintenance layer
 - its responsibility and non-responsibility boundaries
 - its authority classes, stop conditions, and evidence contract
+- its execution-locality classes and classification invariants
 - its relationship to doctrine, executors, repositories, contracts, and human
   approval
 - its self-review and drift expectations

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -240,10 +240,10 @@ recommendations, and "what changed?" or "what next?" requests:
 ### Conditional Repository Guidance
 
 Read `docs/maintenance-automations.md` only when repository work touches
-recurring automation design or review, automation prompt authoring, fleet-wide
-maintenance, governance or drift automation, scheduled inspection or
-correction, autonomous-maintenance architecture, or automation authority,
-evidence, scope, and safety contracts.
+recurring automation design or review, execution-locality classification,
+automation prompt authoring, fleet-wide maintenance, governance or drift
+automation, scheduled inspection or correction, autonomous-maintenance
+architecture, or automation authority, evidence, scope, and safety contracts.
 
 Read `docs/ai-workflow-ecosystem.md`,
 `docs/repo-to-repo-interface-contracts.md`, and


### PR DESCRIPTION
## Summary

- define Local, Hosted, and Hybrid execution-locality classes in the canonical maintenance-automation guidance
- classify locality by the environment owning the facts, resources, and mutation surfaces required for correct execution
- add locality-specific evidence expectations and a compact capability matrix
- route execution-locality questions from `docs/start-here.md`

## Rationale

Execution locality is a separate axis from automation authority: locality answers where a capability can execute correctly, while the existing authority classes answer what it may do. Hybrid is a decomposition signal, so local and hosted components remain separately authoritative, produce attributable evidence, and never infer each other's live state.

## Validation

- `make check`
  - markdownlint-cli2: 0 issues
  - unit tests: 42 passed
- `git diff --check`

## Deliberate non-changes

- no local Codex automation configuration changes
- no GitHub Actions workflow changes
- no automation migration, disablement, or retirement
- no changes to the CAK-72 review artifact
- GitHub Actions remains an example of a hosted executor, not the abstraction