### PR TITLE
Ignore CodexBar during Codex log cleanup

### DIFF
--- a/scripts/workstation/cleanup-codex-logs.sh
+++ b/scripts/workstation/cleanup-codex-logs.sh
@@ -94,6 +94,9 @@ list_codex_processes() {
       if (lower !~ /codex/) {
         next
       }
+      if (lower ~ /\/codexbar[.]app\//) {
+        next
+      }
       if (lower ~ /cleanup-codex-logs[.]sh/) {
         next
       }


### PR DESCRIPTION
## Summary

- ignore processes launched from `/Applications/CodexBar.app/` when checking whether Codex is active
- preserve the existing fail-closed behavior for actual Codex processes and unknown process names containing `codex`
- keep dry-run and apply-mode process detection aligned

## Root cause

`cleanup-codex-logs.sh` scanned the full `ps` line for the substring `codex`, so CodexBar and its widget were treated as active Codex processes and blocked `--apply`.

## Impact

CodexBar can remain running while the cleanup script executes, while real Codex processes still prevent mutation of the log database.

## Validation

- verified the branch is exactly one commit ahead of `main`
- verified the diff changes only `scripts/workstation/cleanup-codex-logs.sh`
- verified the diff contains three additions and no deletions
- `make check` was not run in this environment because the runtime has neither `gh` nor outbound DNS access for a fresh checkout; CI should provide the authoritative repository validation
