### PR TITLE
docs: adopt constitutional vocabulary guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/architecture-foundation-candidate.md`](docs/architecture-foundation-candidate.md):
   non-authoritative candidate under adversarial review; not current Playbook
   doctrine
+- [`docs/constitutional-vocabulary-guide.md`](docs/constitutional-vocabulary-guide.md):
+  implementation guidance for distinguishing Product authority, human
+  governance authority, repository implementation, and runtime execution
 - [`docs/repo-to-repo-interface-contracts.md`](docs/repo-to-repo-interface-contracts.md): lightweight pattern for documenting producer/consumer boundaries
 - [`docs/cross-repo-glossary.md`](docs/cross-repo-glossary.md): qualified cross-repository architecture vocabulary
 - [`docs/ai-workflow-ecosystem.md`](docs/ai-workflow-ecosystem.md): conceptual overview of the repository ecosystem, retained-knowledge boundaries, and architectural direction

--- a/docs/ai-workflow-ecosystem.md
+++ b/docs/ai-workflow-ecosystem.md
@@ -9,6 +9,12 @@ policy, a vendor commitment, or a finalized architecture specification. It
 describes the intended shape of the system so repository work can stay aligned
 while the details continue to evolve.
 
+Use the
+[`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md) when
+distinguishing Product authority, human governance authority, repository
+implementation, and runtime execution in this overview or repository-local
+documentation.
+
 ## Purpose
 
 The ecosystem exists to make model-assisted operations inspectable,
@@ -30,45 +36,50 @@ The system should make it possible to ask where knowledge came from, how it was
 processed, who reviewed it, where the retained version lives, and which
 workflow rule governs the next action.
 
-## Repository Roles
+## Current Repository Implementation Roles
 
-The repositories are intentionally small and role-specific. Their boundaries
-may sharpen over time, but the current conceptual split is:
+The repositories are intentionally small and their current implementation
+roles are focused. Repository topology does not establish Product identity or
+authority. A repository may host one Product, multiple Products, part of a
+Product, Capabilities, Subsystems, Surfaces, or governance evidence.
 
-| Repository | Conceptual role |
+| Repository | Current implementation and content role |
 | --- | --- |
 | `ai-workflow-playbook` | Canonical home for reusable workflow patterns, operating philosophy, interaction modes, review expectations, and promotion guidance. It explains how to work. |
 | `ai-workflow-enforcement` | Mechanical verification, advisory and validation tooling, drift reporting, and reusable automation for selected playbook guidance. It implements checkable doctrine without independently establishing workflow policy. |
 | `ai-workflow-incubator` | Exploration and staging for emerging patterns before they are promoted into durable playbook guidance or split into their own repository. |
-| `knowledge-vault` | Reviewed retained knowledge. The vault stores the durable notes, summaries, and retained artifacts that have passed through human review. |
-| `knowledge-adapters` | Acquisition and normalization of external sources. Adapters treat incoming material as untrusted input and prepare it for review without declaring it retained knowledge by default. |
-| `ka-destinations` | Publishing, export, and rendering paths for reviewed knowledge. Destinations adapt retained material for use elsewhere without becoming the source of truth. |
+| `knowledge-vault` | Currently hosts reviewed retained knowledge, its supporting implementation, research workflows, and governance evidence. |
+| `knowledge-adapters` | Currently implements acquisition and normalization of external sources. Adapters treat incoming material as untrusted input and prepare it for review without declaring it retained knowledge by default. |
+| `ka-destinations` | Currently implements publishing, export, and rendering paths for caller-supplied knowledge artifacts. Destinations adapt material for use elsewhere without becoming the source of truth. |
 
-In short: adapters acquire and normalize, the vault retains reviewed knowledge,
-destinations publish or render, the playbook captures reusable patterns,
-enforcement implements selected playbook doctrine mechanically, and the
-incubator gives unsettled ideas a place to mature before promotion. If
-playbook doctrine and enforcement behavior diverge, the playbook is
-authoritative and enforcement should be updated to match. Not every playbook
-rule needs enforcement, and not every enforcement capability should be promoted
-into doctrine.
+In short: adapters perform acquisition and normalization; the current vault
+implementation records reviewed retained knowledge and hosts additional
+workflow evidence; destinations perform publication or rendering; the Playbook
+contains reusable patterns; Enforcement implements selected Playbook doctrine
+mechanically; and the Incubator gives unsettled ideas a place to mature before
+promotion. If Playbook doctrine and Enforcement behavior diverge, the Playbook
+is authoritative for reusable workflow guidance and Enforcement should be
+updated to match. Not every Playbook rule needs enforcement, and not every
+Enforcement Capability should be promoted into doctrine.
 
 ### Enforcement Control Ownership
 
 For reviewed operational controls such as
 [`codex-safe-rm`](https://github.com/ctrl-alt-keith/ai-workflow-enforcement/blob/main/docs/codex-safe-rm.md),
-`ai-workflow-enforcement` owns the helper implementation, threat model,
-installation and verification mechanisms, Codex rule fixtures, and tests.
-`ai-workflow-playbook` owns the behavioral guidance, workflow expectations,
-delegation boundaries, and operator guidance for using that control. Link to
-the enforcement documentation for mechanics instead of copying implementation
-details into the playbook.
+`ai-workflow-enforcement` currently hosts the helper implementation, threat
+model, installation and verification mechanisms, Codex rule fixtures, and
+tests. The Playbook is authoritative for the reusable behavioral guidance,
+workflow expectations, delegation boundaries, and operator guidance for using
+that control. Link to the Enforcement documentation for mechanics instead of
+copying implementation details into the Playbook.
 
 When these or other repositories exchange artifacts, use the lightweight
 [`repo-to-repo interface contract pattern`](repo-to-repo-interface-contracts.md)
 and the qualified terms in the
 [`cross-repo architecture glossary`](cross-repo-glossary.md). Repository-local
-contracts remain authoritative for their domains.
+sources control current repository-specific contract text and execution
+behavior; semantic contract meaning and consequential human authority remain
+separately typed.
 
 ## Autonomous Maintenance Layer
 
@@ -94,11 +105,13 @@ Evidence and review-ready proposals
 Human approval for consequential transitions
 ```
 
-This layer keeps independently owned repositories convergent without requiring
-one shared runtime implementation. It can detect drift, perform narrowly
-bounded hygiene under mechanically verifiable safety predicates, and prepare
-focused changes. Repository-local authority, canonical validation, explicit
-producer/consumer contracts, and human approval boundaries continue to control.
+This layer keeps independently governed repositories convergent without
+requiring one shared runtime implementation. It can detect drift, perform
+narrowly bounded hygiene under mechanically verifiable safety predicates, and
+prepare focused changes. Repository-local authority over current source,
+implementation, validation, review, and merge facts; explicit
+producer/consumer contracts; and human approval boundaries continue to
+control.
 
 Exact schedules, automation identifiers, workstation paths, credentials,
 notification routes, and scheduler implementations are local operational
@@ -116,8 +129,8 @@ Useful states include:
 - `raw`: source material as acquired or referenced
 - `extracted`: selected or normalized material prepared for inspection
 - `reviewed`: human-inspected notes, summaries, or decisions
-- `retained`: durable knowledge accepted into the vault or another owning
-  repository
+- `retained`: durable knowledge accepted into the vault or another
+  repository's governed retained state
 
 The exact file layout and metadata may evolve. The architectural requirement is
 that the workflow keeps those states conceptually separate so later reviewers
@@ -165,18 +178,24 @@ and repository history.
 
 ### Small, Composable Repositories
 
-Each repository should own one major responsibility. Small repositories make it
-easier to reason about authority:
+Small repositories can make implementation, review, validation, release, and
+history boundaries easier to reason about. They do not define Product identity
+or imply that each repository owns one Product authority. A repository may
+host one Product, multiple Products, part of a Product, Capabilities,
+Subsystems, Surfaces, or governance evidence.
 
-- guidance belongs in the playbook
-- mechanical checking belongs in enforcement
-- provisional discovery belongs in incubation
-- reviewed retained knowledge belongs in the vault
-- source acquisition belongs in adapters
-- publication and rendering belong in destinations
+The current implementation placement is:
+
+- reusable guidance is hosted in the Playbook;
+- mechanical checking is implemented in Enforcement;
+- provisional discovery is staged in the Incubator;
+- reviewed retained knowledge is recorded in the vault;
+- source-acquisition behavior is implemented in adapters; and
+- publication and rendering behavior is implemented in destinations.
 
 This separation reduces accidental coupling and makes it easier to change one
 part of the system without silently changing the meaning of retained knowledge.
+Changing that topology does not by itself change Product authority.
 
 ### Reviewable Automation Over Opaque Memory
 
@@ -230,9 +249,10 @@ validation and stop rules.
 
 A preferred scaling model is one top-level orchestration prompt for the run,
 with safe parallel work delegated to self-contained subagents or workers. The
-top-level prompt owns decomposition, lane boundaries, reconciliation, and
-reporting. Workers own only their assigned task envelope and should not depend
-on full conversation history, implicit role inheritance, or shared hidden state.
+orchestrator or authorized human defines decomposition, lane boundaries,
+reconciliation, and reporting. Workers are responsible only for their assigned
+task envelope and should not depend on full conversation history, implicit role
+inheritance, or shared hidden state.
 The canonical operating guidance for deciding when to stay single-threaded,
 when to fan out, and how to reconcile worker outputs lives in
 [`orchestration-and-parallelism.md`](orchestration-and-parallelism.md).

--- a/docs/constitutional-vocabulary-guide.md
+++ b/docs/constitutional-vocabulary-guide.md
@@ -1,0 +1,685 @@
+# Constitutional Vocabulary Guide
+
+> Status: Playbook implementation guidance
+>
+> Source: derived from the accepted Constitutional Vocabulary Review
+>
+> Authority: subordinate to current Playbook doctrine
+>
+> Adoption boundary: inclusion in a reviewed Playbook change records adoption
+> as implementation guidance only. It is not doctrine promotion, Product
+> promotion, a new Product Model, an authority-boundary change, or automatic
+> promotion of the
+> [candidate Architecture Foundation](architecture-foundation-candidate.md)
+> into doctrine.
+
+## Purpose
+
+This guide standardizes constitutional language across the ecosystem. It helps
+documentation consistently distinguish:
+
+- Product authority;
+- human governance authority;
+- repository implementation and accepted source state; and
+- runtime execution.
+
+The central rule is:
+
+> A Product owns the bounded domain question and contract meaning.
+> An authorized human makes consequential decisions.
+> A Repository currently hosts, records, and implements accepted state.
+> A Capability, Subsystem, or runtime component performs work.
+
+Every authority statement should identify the bounded question being answered.
+Avoid using a repository name as shorthand for Product authority, human
+judgment, and implementation behavior simultaneously.
+
+## Constitutional Grammar
+
+### Product Or Product Candidate
+
+A Product is an architectural identity with a bounded outcome and authoritative
+question. A Product Candidate has passed the conceptual test but has not
+received explicit human promotion to enduring status.
+
+Use the precise status on first reference.
+
+**Valid verbs:**
+
+- owns a bounded authoritative question;
+- defines an outcome or stable non-goal;
+- owns shared contract meaning;
+- establishes a lifecycle boundary;
+- produces or preserves Product evidence; and
+- consumes another Product's contract.
+
+**Avoid:**
+
+- implying that a Product Candidate is enduring;
+- saying a Product self-approves or self-promotes;
+- using the Product name for low-level execution when a component performs the
+  action; and
+- inferring Product identity from a repository, package, service, or
+  deployment.
+
+**Example:**
+
+> Publication owns the authorized external-delivery transaction and
+> publication-receipt semantics.
+
+### Enduring Product
+
+An Enduring Product is a Product Candidate that has satisfied the accepted
+operational standard and received explicit human Product promotion.
+
+It uses the same authority grammar as a Product Candidate. "Enduring" describes
+accepted status, not greater execution capability.
+
+**Valid verbs:**
+
+- owns the same bounded authority established by its Product identity;
+- has received explicit Product promotion; and
+- preserves a replacement-resistant outcome and authority boundary.
+
+**Avoid:**
+
+- calling a Product enduring because it has code, users, contracts, tests,
+  successful runs, or merged changes;
+- treating widespread implementation as Product promotion; and
+- omitting the promotion decision when asserting enduring status.
+
+**Example:**
+
+> This identity remains a Product Candidate; no explicit human promotion to
+> Enduring Product has occurred.
+
+### Human Governance Authority
+
+Human governance authority is the root of consequential intent, approval,
+acceptance, promotion, and reversal.
+
+Name the role when the distinction matters: authorized human reviewer, planning
+authority, repository merge authority, Product-promotion authority, or another
+bounded decision role.
+
+**Valid verbs:**
+
+- decides;
+- approves or rejects;
+- authorizes;
+- accepts;
+- promotes;
+- merges;
+- delegates;
+- prioritizes;
+- reverses; and
+- grants permission.
+
+**Avoid:**
+
+- assigning human judgment to a repository, tool, validator, or automation;
+- assuming that an operator automatically has decision authority;
+- treating successful execution or validation as approval; and
+- saying that a Product accepts its own output.
+
+**Example:**
+
+> An authorized human reviewer decides whether candidate material is retained,
+> rejected, restricted, or deferred.
+
+### Repository
+
+A Repository is a source-control, review, history, and implementation
+container. It may implement one Product, multiple Products, part of a Product,
+or supporting Capabilities that are not Products.
+
+**Valid verbs:**
+
+- currently hosts;
+- contains;
+- records;
+- stores;
+- implements;
+- packages;
+- exposes;
+- validates;
+- distributes;
+- provides; and
+- controls accepted repository source, review, validation, and merge facts.
+
+**Avoid:**
+
+- saying a Repository owns a domain merely because its implementation lives
+  there;
+- defining Product identity from repository topology;
+- using "Repository authority" without naming the repository-specific
+  question; and
+- implying that the first or only implementation owns constitutional meaning.
+
+**Example:**
+
+> `ka-destinations` currently implements Publication destination drivers and
+> records publication receipts.
+
+### Semantic Contract Producer
+
+The Semantic Contract Producer is the Product identity responsible for the
+meaning of an emitted artifact or behavior.
+
+**Valid verbs:**
+
+- owns shared contract meaning;
+- defines emission semantics;
+- defines compatibility expectations;
+- maintains compatible evolution; and
+- establishes producer guarantees.
+
+**Avoid:**
+
+- identifying the semantic producer solely by repository location;
+- transferring consumer policy or downstream approval authority to the
+  producer;
+- treating transport as ownership of either side's meaning; and
+- treating an emitting component as the constitutional contract owner.
+
+**Example:**
+
+> Source Acquisition is the semantic producer of the Source Package contract.
+
+### Runtime Producer
+
+A Runtime Producer is the component, command, adapter, service, or process that
+emits a contract instance.
+
+**Valid verbs:**
+
+- emits;
+- serializes;
+- validates before emission;
+- normalizes;
+- packages;
+- records;
+- returns; and
+- performs the producer-side operation.
+
+**Avoid:**
+
+- saying it owns shared semantics unless it is explicitly also the semantic
+  authority;
+- saying its successful output approves a downstream decision;
+- assigning editorial, retention, or publication authority to the component;
+  and
+- confusing provenance identity with authenticated authority.
+
+**Example:**
+
+> The source adapter emits a sealed Source Package conforming to Source
+> Acquisition semantics.
+
+### Contract Consumer
+
+A Contract Consumer accepts or uses an emitted artifact or behavior under
+consumer-local policy.
+
+When necessary, distinguish the consuming Product from the component that
+performs consumer validation.
+
+**Valid verbs:**
+
+- consumes;
+- accepts declared versions;
+- rejects unsupported versions;
+- applies consumer-local policy;
+- validates before use;
+- interprets within the normative contract; and
+- performs real-path integration validation.
+
+**Avoid:**
+
+- redefining producer-owned shared semantics;
+- treating structural validity as approval;
+- assuming that consumption grants authority over the producer; and
+- confusing the consuming Product with the Repository hosting its
+  implementation.
+
+**Example:**
+
+> Knowledge Record consumes the Source Package contract and owns its editorial
+> acceptance policy. The consumer implementation currently hosted in
+> `knowledge-vault` validates packages before review.
+
+### Capability
+
+A Capability is a named ability or behavior. It describes what can be done,
+not who may decide that it should be done.
+
+**Valid verbs:**
+
+- enables;
+- performs;
+- supports;
+- provides;
+- validates;
+- renders;
+- acquires;
+- publishes; and
+- transports.
+
+**Avoid:**
+
+- owns authority;
+- decides;
+- approves;
+- authorizes;
+- governs a Product boundary; and
+- becoming a Product merely because it is technically substantial.
+
+**Example:**
+
+> The publication Capability performs destination-specific rendering under an
+> existing authorization.
+
+### Subsystem
+
+A Subsystem is a cohesive internal component that contributes to a Product
+outcome without owning an independent customer outcome or final authoritative
+question.
+
+**Valid verbs:**
+
+- implements;
+- executes;
+- transforms;
+- validates;
+- coordinates;
+- renders;
+- transports;
+- emits; and
+- records.
+
+**Avoid:**
+
+- assigning final Product authority to the Subsystem;
+- inferring Product identity from independent deployment;
+- saying the Subsystem approves its own output; and
+- using deployment or complexity as evidence of authority.
+
+**Example:**
+
+> The destination driver Subsystem performs the external API operation and
+> returns observed destination identity.
+
+### Surface
+
+A Surface is a human or machine view over state, evidence, or Capabilities.
+
+**Valid verbs:**
+
+- displays;
+- renders;
+- presents;
+- collects;
+- routes;
+- mediates;
+- links; and
+- records evidence of delivery or presentation.
+
+**Avoid:**
+
+- owns the represented state;
+- proves the underlying domain state;
+- decides merely by presenting a control; and
+- becomes authoritative because it is the primary user interface.
+
+**Example:**
+
+> The review Surface presents candidate material and records the reviewer's
+> disposition; it does not make the editorial decision.
+
+## Writing Rules
+
+### 1. Use "Owns" Only For Bounded Authority
+
+Before writing "owns," ask what exact question is controlled.
+
+Valid:
+
+> Knowledge Record owns the editorial-retention authority boundary.
+
+Invalid:
+
+> `knowledge-vault` owns everything related to reviewed knowledge.
+
+Ownership must not be shorthand for implementation location, technical
+Capability, maintenance responsibility, or historical association.
+
+### 2. Repositories Host And Implement
+
+Use Repository names for current topology and accepted Repository state:
+
+- currently hosts;
+- currently implements;
+- contains;
+- records;
+- stores;
+- validates; and
+- distributes.
+
+Prefer "currently" when the implementation location could change without
+changing the Product identity.
+
+### 3. Humans Decide
+
+Consequential decisions must use a human-governance subject unless authority
+has been explicitly delegated.
+
+Use:
+
+- "An authorized human reviewer decides...";
+- "The Product-promotion authority promotes..."; and
+- "Repository merge authority accepts the source change...".
+
+Do not use a tool, Repository, policy document, validator, or Product as a
+substitute for the human decision-maker.
+
+A policy may be authoritative for criteria. A human remains authoritative for
+applying those criteria to a consequential case.
+
+### 4. Capabilities And Subsystems Perform
+
+Use operational verbs for operational actors:
+
+- an adapter acquires;
+- a validator validates;
+- a driver publishes;
+- a renderer renders; and
+- an orchestrator transports.
+
+Execution does not create authority or approval.
+
+### 5. Separate Semantic Producer From Runtime Producer
+
+A Product owns shared contract meaning. A component emits a conforming
+instance. A Repository hosts the contract and implementation.
+
+Use all three subjects when the distinction is material:
+
+> Source Acquisition owns Source Package semantics. `knowledge-adapters`
+> currently hosts the normative contract. A source adapter emits a conforming
+> package.
+
+### 6. Separate Consumer Policy From Producer Semantics
+
+The semantic producer defines the shared interchange. The consumer owns
+accepted versions, consumer-local policy, and validation before use.
+
+A consumer may summarize the producer contract but must not silently redefine
+it.
+
+### 7. Separate Repository Governance From Product Governance
+
+Repository governance controls questions such as:
+
+- which source is accepted;
+- which validation is required;
+- whether review requirements were met;
+- whether a change may merge; and
+- what current implementation exists.
+
+Product governance controls the Product's bounded domain questions.
+
+Repository acceptance is not Product promotion. A merged contract or
+implementation does not make a Product Candidate enduring.
+
+### 8. Preserve Product-Status Qualifiers
+
+On first reference, use:
+
+- Product Candidate;
+- Enduring Product;
+- proposed Product identity; or
+- rejected or superseded identity;
+
+as applicable.
+
+Do not let the unqualified word "Product" obscure whether promotion has
+occurred.
+
+### 9. Do Not Rewrite History Silently
+
+Historical records should remain accurate evidence of the language and
+assumptions used when they were created.
+
+When terminology evolves:
+
+- preserve frozen artifacts and exact historical records;
+- add an interpretation banner, companion note, or current terminology index;
+- distinguish historical implementation allocation from current
+  constitutional authority; and
+- never make old evidence appear to have used vocabulary it did not use.
+
+## Authority Questions
+
+Every governance statement should answer a bounded question.
+
+| Question | Constitutional authority | Implementation or evidence location |
+| --- | --- | --- |
+| What source or implementation is accepted in this Repository? | Repository governance and merge authority | Repository source, review, validation, and history |
+| What candidate material is retained, rejected, restricted, or deferred? | Knowledge Record authority boundary, exercised by an authorized human reviewer | Current Knowledge Record implementation and retained decision records |
+| What exact artifact is authorized for external delivery, and what happened? | Publication authority boundary plus human or delegated publication authorization | Publication implementation, destination driver, and receipt |
+| What was requested, acquired, normalized, and packaged? | Source Acquisition authority boundary | Adapter execution evidence and Source Package |
+| May this Repository change merge? | Repository merge authority | Review state, validation, branch, and pull-request evidence |
+| What does a shared contract mean? | Semantic Contract Producer | Normative contract currently hosted near the producer implementation |
+| Which contract versions and inputs may this consumer accept? | Consuming Product's local policy | Consumer contract, validator, fixtures, and integration tests |
+| What did a command, adapter, validator, or driver do? | No new governance authority; this is an implementation-behavior question | Runtime logs, receipts, tests, and Repository implementation |
+
+Avoid the universal question "Which Repository is the authority?" Ask instead:
+
+> Authority for which fact, decision, transition, or contract meaning?
+
+## Repository-First And Constitutional Examples
+
+### Editorial Retention
+
+Repository-first:
+
+> `knowledge-vault` owns editorial review.
+
+Constitutional:
+
+> Knowledge Record owns the editorial-retention authority boundary. An
+> authorized human reviewer makes consequential retention decisions.
+> `knowledge-vault` currently hosts the implementation and records accepted
+> editorial decisions.
+
+### Acquisition
+
+Repository-first:
+
+> `knowledge-adapters` owns ingestion and normalization.
+
+Constitutional:
+
+> Source Acquisition owns the bounded acquisition transaction and Source
+> Package semantics. `knowledge-adapters` currently implements acquisition
+> adapters and hosts the normative contract.
+
+### Publication
+
+Repository-first:
+
+> `ka-destinations` owns publication.
+
+Constitutional:
+
+> Publication owns the authorized external-delivery transaction and
+> publication-receipt semantics. `ka-destinations` currently implements
+> destination-specific publication behavior.
+
+### Contract Ownership
+
+Repository-first:
+
+> The producer Repository owns the contract.
+
+Constitutional:
+
+> The Semantic Contract Producer owns shared contract meaning and compatible
+> evolution. The producer Repository currently hosts the normative contract
+> and producer implementation.
+
+### Runtime Execution
+
+Repository-first:
+
+> The adapter owns acquisition.
+
+Constitutional:
+
+> Source Acquisition owns acquisition semantics. The adapter performs the
+> acquisition and emits the resulting contract artifact.
+
+### Human Review
+
+Repository-first:
+
+> The vault decides whether content should be retained.
+
+Constitutional:
+
+> An authorized human reviewer decides whether candidate material is retained
+> under Knowledge Record policy. The consumer implementation records and
+> validates that decision.
+
+### Repository Authority
+
+Overbroad:
+
+> This Repository is authoritative.
+
+Constitutional:
+
+> This Repository's accepted source and hosted state are authoritative for its
+> current files, implementation, validation, review, and merge facts.
+
+### Multiple Products In One Repository
+
+Repository-first:
+
+> This Repository's Product is reviewed knowledge.
+
+Constitutional:
+
+> This Repository currently hosts the Knowledge Record implementation and an
+> Evidence Synthesis reference workflow. Their authority boundaries remain
+> distinct even though they share Repository topology.
+
+## Repository Guidance
+
+- A Repository may implement one Product, several Products, part of a Product,
+  or supporting Capabilities that are not Products.
+- Repository boundaries may enforce source control, review, security, release,
+  history, or contamination boundaries without defining Product identity.
+- The first, primary, or only implementation does not automatically own
+  constitutional meaning.
+- Moving an implementation does not move Product authority unless the
+  governing authority boundary is explicitly changed.
+- Shared Repository location does not merge Product authorities.
+- Separate Repositories do not prove separate Product identities.
+- Repository names should appear as implementation or evidence locations, not
+  as substitutes for Products.
+- Historical records should preserve their original vocabulary. Current
+  guidance should explain how historical Repository-first language maps to the
+  constitutional model.
+
+## Terminology Reference
+
+### Product Candidate Term
+
+A Product identity that has passed the conceptual test but has not received
+explicit human promotion to Enduring Product.
+
+### Enduring Product Term
+
+A Product Candidate whose outcome and authority boundary have satisfied the
+accepted operational standard and received explicit human Product promotion.
+
+### Governance Function Term
+
+A proposed term for a human-rooted, non-Product function controlling intent,
+policy, approval, promotion, prioritization, or permission within a bounded
+scope without owning an independent customer outcome.
+
+This definition still requires human ratification. Until then, prefer a
+specific authority name such as "authorized human reviewer," "Repository merge
+authority," or "Product-promotion authority."
+
+### Semantic Producer Term
+
+The Product identity responsible for shared contract meaning, emission
+semantics, and compatible evolution.
+
+### Runtime Producer Term
+
+The component or process that performs producer-side behavior and emits a
+contract instance.
+
+### Repository Authority Term
+
+Authority limited to a named Repository question, such as accepted source,
+current implementation, validation, review, or merge state. It is not general
+Product or domain authority.
+
+### Human Decision Authority Term
+
+The authorized human role whose answer controls a consequential decision or
+transition within a defined scope.
+
+## Relationship To Existing Doctrine
+
+This guide operationalizes the accepted Constitutional Vocabulary Review and
+its application of current doctrine and candidate constitutional guidance.
+Apply it with the human-rooted, question-typed authority rules in
+[`core-model.md`](core-model.md).
+
+It does not:
+
+- promote a Product Candidate;
+- define a new Product;
+- alter an authority boundary;
+- redesign Repository topology;
+- establish a new contract;
+- replace current Playbook doctrine; or
+- convert candidate constitutional guidance into doctrine by itself.
+
+## Recommended Home And Use
+
+This guide lives in the AI Workflow Playbook as reusable implementation
+guidance, adjacent to the cross-repository glossary and interface-contract
+guidance.
+
+Link to it from:
+
+- the cross-repository architecture glossary;
+- the Repository-to-Repository contract guidance;
+- ecosystem documentation; and
+- contributor guidance for Repositories using constitutional terminology.
+
+Repository-local documents should apply this guide, not fork or redefine it.
+
+## Completion And Ratification Boundary
+
+The guide is complete enough to drive a focused documentation-alignment pass
+using consistent, mechanical language rules.
+
+Before Repository-wide updates begin, explicit human ratification remains
+required for:
+
+1. the formal definition of **Governance Function**;
+2. the required first-reference distinction between **Product Candidate** and
+   **Enduring Product**;
+3. the formal **Semantic Producer** versus **Runtime Producer** distinction;
+4. the question-typed meaning of **Repository Authority**; and
+5. adoption and any future status of this guide itself.
+
+No Product promotion or architectural redesign follows from this guide.

--- a/docs/cross-repo-glossary.md
+++ b/docs/cross-repo-glossary.md
@@ -6,8 +6,11 @@ Use these qualifiers when reasoning across repositories. The goal is not one
 universal definition for every domain. It is to prevent humans and AI agents
 from silently treating similar words as identical concepts.
 
-Repository-local contracts remain authoritative. When local usage is narrower
-or intentionally different, name the qualified meaning and link its source.
+Apply the subject, verb, and question-typed authority rules in the
+[`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md).
+Repository-local sources control current repository-specific contract text and
+execution behavior. When local usage is narrower or intentionally different,
+name the qualified meaning and link its source.
 
 ## Terms
 
@@ -125,7 +128,8 @@ automatically the whole contract.
 
 ### Adapter
 
-An adapter translates one interface while preserving an owning boundary.
+An adapter translates one interface while preserving the governing semantic
+boundary.
 
 - **Source adapter**: acquires and normalizes external source material into
   provider-neutral candidate artifacts.
@@ -139,18 +143,62 @@ generic plugin system or ownership of both sides of the interface.
 
 ### Product
 
-A product is the bounded outcome a repository exists to provide, not every
-resource it touches.
+A Product is an architectural identity with a bounded customer outcome and
+authoritative question. Repository topology does not establish Product
+identity.
 
-- **Repository product boundary**: owned responsibilities, primary product
-  object, decision filter, and non-goals.
+The status terms below are implementation vocabulary. They do not classify a
+current identity, promote a Product Candidate, or promote the candidate
+Architecture Foundation into doctrine.
+
+- **Product Candidate**: a Product identity that has passed the conceptual test
+  but has not received explicit human promotion to Enduring Product. The
+  required first-reference status distinction remains subject to the
+  ratification boundary recorded in the Constitutional Vocabulary Guide.
+- **Enduring Product**: a Product Candidate whose outcome and authority
+  boundary have satisfied the accepted operational standard and received
+  explicit human Product promotion.
+- **Repository implementation**: the replaceable code, configuration,
+  operations, process, contracts, or evidence currently hosted by a
+  repository. A repository may host several Products, part of one Product, or
+  non-Product evidence.
 - **Product object**: the durable or reviewable outcome, such as an operational
   receipt or publication event.
 - **External provider product**: a third-party service or API; qualify it as a
-  provider product to avoid assigning its lifecycle to the repository.
+  provider product to avoid assigning its lifecycle to an implementing
+  repository.
 
 Infrastructure used during a workflow is not automatically the product or
 repository-owned state.
+
+### Semantic Producer
+
+A Semantic Producer is the Product or other typed identity responsible for
+shared contract meaning, emission semantics, and compatible evolution.
+
+The normative contract may currently live in the producer implementation
+repository, but that location does not make the repository the constitutional
+owner of the contract's meaning. This distinction remains subject to the
+ratification boundary recorded in the Constitutional Vocabulary Guide.
+
+### Runtime Producer
+
+A Runtime Producer is the component, command, adapter, service, or process that
+emits a contract instance. It performs producer-side behavior under the
+contract; successful emission does not create approval, retention, publication,
+or downstream decision authority.
+
+Do not infer semantic ownership merely because the runtime producer is the
+first or only implementation.
+
+### Repository Authority
+
+Repository Authority is always question-typed. A repository and its hosted
+state control current files, implementation, review, validation, and merge
+facts. That authority does not become general Product or domain authority.
+
+The formal question-typed terminology remains subject to the ratification
+boundary recorded in the Constitutional Vocabulary Guide.
 
 ### Capability
 

--- a/docs/repo-to-repo-interface-contracts.md
+++ b/docs/repo-to-repo-interface-contracts.md
@@ -7,6 +7,11 @@ behavior that another repository consumes. The contract should make ownership,
 compatibility, validation, and failure behavior reviewable without creating a
 central schema repository, shared library, or new approval gate.
 
+Apply the subject and authority rules in the
+[`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md) when
+naming semantic producers, runtime producers, contract hosts, consumers,
+human authority, and repository implementation.
+
 This is a documentation pattern, not a required file format. Use only the
 sections that clarify the real interface. A short section in an existing design
 document is enough for a simple integration; a dedicated contract document is
@@ -19,9 +24,12 @@ The strongest current example is the
 [Trusted Network Registry schema contract](https://github.com/ctrl-alt-keith/trusted-network-registry/blob/main/docs/registry-schema.md)
 and its
 [`linode-image-lab` consumer contract](https://github.com/ctrl-alt-keith/linode-image-lab/blob/main/docs/trusted-registry-firewall-sync.md).
-The producer owns a versioned schema and public-safe fixture. The consumer
-declares the accepted version, carries a compatibility fixture through its real
-validation and planning path, and fails closed on invalid or stale input.
+The registry's semantic contract producer defines the versioned schema. The
+producer repository currently hosts the normative contract, implementation,
+and public-safe fixture. Its runtime producer emits a contract instance. The
+consumer declares the accepted version, carries a compatibility fixture through
+its real validation and planning path, and fails closed on invalid or stale
+input.
 
 The
 [`knowledge-adapters` Source Package Contract](https://github.com/ctrl-alt-keith/knowledge-adapters/blob/main/docs/source-package-contract.md)
@@ -29,28 +37,36 @@ adds proven patterns for semantic compatibility, required capabilities,
 integrity verification, immutable handoffs, and distinct producer and consumer
 responsibilities. Its
 [`knowledge-vault` consumer contract](https://github.com/ctrl-alt-keith/knowledge-vault/blob/main/docs/source-package-consumer-contract.md)
-keeps consumer policy local while linking back to the producer-owned normative
-contract. The bundle-to-destination and image-lab-to-LKE boundaries are lighter:
-they rely primarily on documented file or container/CLI behavior and local
-consumer validation. They do not yet justify a shared library or centrally
-managed schema.
+keeps consumer policy local while linking back to the normative contract
+currently hosted with the producer implementation. The bundle-to-destination
+and image-lab-to-LKE boundaries are lighter: they rely primarily on documented
+file or container/CLI behavior and local consumer validation. They do not yet
+justify a shared library or centrally managed schema.
 
-## Placement And Ownership
+## Semantic Ownership And Placement
 
-- Put the normative artifact shape and producer guarantees in the producer
-  repository, near the implementation, schema, fixture, or command that emits
-  them.
+- Name the semantic contract producer that owns shared meaning, emission
+  semantics, and compatible evolution.
+- Name the runtime producer that emits the artifact or performs the behavior.
+- Put the normative artifact shape and producer guarantees in an explicit
+  normative contract host, normally the producer repository near the
+  implementation, schema, fixture, or command that emits them.
 - Put accepted versions, consumer-specific policy, and integration validation
-  in each consumer repository.
-- Link both sides explicitly and name which side governs shared semantics.
-- Keep transport or orchestration ownership separate when an operator or a
-  third repository moves the artifact between producer and consumer.
+  with each contract consumer, normally in its current implementation
+  repository.
+- Link both sides explicitly and name the semantic producer that governs shared
+  semantics.
+- Keep transport or orchestration responsibility separate when an operator or
+  a third repository moves the artifact between producer and consumer.
+- Name the human authority when consequential approval, acceptance, retention,
+  publication, or another decision boundary is involved.
 - Put reusable guidance here in the playbook; do not move domain contracts into
   the playbook.
 
-Ownership of a contract means responsibility for its documented semantics. It
-does not transfer ownership of the consumer's policy, infrastructure, runtime,
-or downstream lifecycle.
+Semantic ownership of a contract means authority over its documented shared
+meaning. It does not transfer the consumer's policy, infrastructure, runtime,
+or downstream lifecycle. Hosting the normative contract or implementing either
+side does not create Product authority or consequential human approval.
 
 ## Lightweight Contract Template
 
@@ -65,11 +81,18 @@ Status: <draft, experimental, or stable>; version: <identifier if versioned>
 What crosses the boundary, why it exists, and where the interface begins and
 ends.
 
-## Participants And Ownership
-- Producer: <repository/component> owns <emission semantics>.
-- Consumer: <repository/component> owns <acceptance and use>.
-- Operator/orchestrator/transport: <only when applicable>.
-- Normative contract home: <producer-owned link or other explicit authority>.
+## Participants And Authority
+- Semantic contract producer: <Product or other typed identity> owns <shared
+  meaning, emission semantics, and compatible evolution>.
+- Runtime producer: <component or process> emits <artifact or behavior>.
+- Normative contract host: <repository-relative link or other explicit
+  location>.
+- Contract consumer: <Product or other typed identity> accepts <versions and
+  use> under <consumer-local policy>.
+- Consumer implementation: <repository, component, or process>.
+- Operator/orchestrator/transport: <responsibility only when applicable>.
+- Human authority: <consequential decision and authorized role, when
+  applicable>.
 
 ## Inputs And Outputs
 Required and optional inputs; emitted artifacts, API behavior, commands, or
@@ -100,10 +123,11 @@ authenticity guarantees, retention, immutability, and cleanup expectations.
 Responsibilities this interface deliberately does not acquire.
 ```
 
-For a simple file handoff, purpose, owners, input/output shape, validation,
-failure behavior, and non-goals may be the entire contract. Do not add a
-version field merely to complete the template; version only when compatibility
-needs to be negotiated or incompatible evolution must be detectable.
+For a simple file handoff, purpose, typed authority roles, input/output shape,
+validation, failure behavior, and non-goals may be the entire contract. Do not
+add a version field merely to complete the template; version only when
+compatibility needs to be negotiated or incompatible evolution must be
+detectable.
 
 ## Compatibility And Change Guidance
 
@@ -123,9 +147,10 @@ needs to be negotiated or incompatible evolution must be detectable.
 - Treat integrity, provenance, and authenticity as separate claims. A checksum
   can establish byte integrity without authenticating the producer or approving
   the content.
-- Coordinate incompatible changes across repositories, but keep each change in
-  its owning repository and PR. Land producer support before consumer opt-in
-  when ordering matters; preserve an overlap window when practical.
+- Coordinate incompatible changes across repositories, but keep each
+  implementation change in its current repository and PR. Land producer
+  support before consumer opt-in when ordering matters; preserve an overlap
+  window when practical.
 
 ## Recurring Convergence Is Not Compatibility
 
@@ -149,7 +174,8 @@ library.
 
 - Does the contract describe the interface that exists, with links to current
   evidence, rather than a hoped-for abstraction?
-- Are producer, consumer, and transport responsibilities distinct?
+- Are the semantic producer, runtime producer, normative contract host,
+  consumer, transport, and any consequential human authority distinct?
 - Can the consumer detect unsupported or stale input before unsafe use?
 - Are security, durability, and failure claims no stronger than implementation
   and validation evidence?


### PR DESCRIPTION
## Summary

- add `docs/constitutional-vocabulary-guide.md` as durable Playbook implementation guidance
- align Priority 0 terminology in the cross-repo glossary, repo-to-repo contract pattern, and ecosystem overview
- link the guide from those three guidance surfaces and the root documentation index

## Why

Repository-first language had become ambiguous because it could collapse Product authority, human decision authority, repository implementation, and runtime execution into one subject.

This change adopts the reviewed Product/Human/Repository/Capability grammar as implementation guidance so later documentation alignment can apply one consistent vocabulary.

The guide remains subordinate to current Playbook doctrine. It does not promote a Product Candidate, create a new Product Model, alter an authority boundary, or promote the candidate Architecture Foundation into doctrine.

## Priority 0 alignment

- distinguishes semantic contract producer, runtime producer, normative contract host, contract consumer, consumer-local policy, and consequential human authority
- defines Product vocabulary independently of repository topology while preserving Product Candidate and Enduring Product status distinctions
- describes repositories as implementation, source-control, review, validation, history, and governance containers that may host multiple constitutional identities or non-Product evidence
- preserves question-typed repository authority over accepted source, implementation, validation, review, and merge facts

## Ratification boundary

Future human ratification remains required for:

1. the formal definition of Governance Function
2. the required first-reference distinction between Product Candidate and Enduring Product
3. the formal Semantic Producer versus Runtime Producer distinction
4. the question-typed meaning of Repository Authority
5. adoption and any future status of the guide itself

Repository-local documentation alignment remains separate follow-up work.

## Validation

- `make check`
  - Markdown lint: 0 issues
  - unit tests: 42 passed
  - tracked local Markdown links and heading fragments resolve
- `git diff --check`
- verified `docs/architecture-foundation-candidate.md` is unchanged
- verified the branch merges cleanly with current `origin/main`