### PR TITLE
docs: record constitutional terminology ratification decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/constitutional-vocabulary-guide.md`](docs/constitutional-vocabulary-guide.md):
   implementation guidance for distinguishing Product authority, human
   governance authority, repository implementation, and runtime execution
+- [`docs/constitutional-terminology-ratification-decision.md`](docs/constitutional-terminology-ratification-decision.md):
+  accepted human governance decision recording ratified and deferred
+  constitutional terminology
 - [`docs/repo-to-repo-interface-contracts.md`](docs/repo-to-repo-interface-contracts.md): lightweight pattern for documenting producer/consumer boundaries
 - [`docs/cross-repo-glossary.md`](docs/cross-repo-glossary.md): qualified cross-repository architecture vocabulary
 - [`docs/ai-workflow-ecosystem.md`](docs/ai-workflow-ecosystem.md): conceptual overview of the repository ecosystem, retained-knowledge boundaries, and architectural direction

--- a/docs/constitutional-terminology-ratification-decision.md
+++ b/docs/constitutional-terminology-ratification-decision.md
@@ -1,0 +1,184 @@
+# Human Constitutional Terminology Ratification Decision
+
+> Status: accepted human governance decision
+>
+> Decision date: 2026-07-24
+>
+> Authority: explicit human constitutional terminology-ratification decision
+>
+> Effect: ratifies the terminology named below as Playbook implementation
+> guidance. This decision is not doctrine promotion, Product promotion, a new
+> Product Model, or an authority-boundary change.
+
+## Purpose
+
+This document is the durable record of the human governance act that completed
+the terminology-ratification boundary in the
+[`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md).
+
+This decision owns ratification status. The Vocabulary Guide remains the
+implementation guide for applying the accepted terminology. Related doctrine
+and candidate architecture retain their existing authority and status.
+
+## Background
+
+The Constitutional Vocabulary Guide separated Product authority, human
+governance authority, Repository implementation and accepted source state, and
+runtime execution. It deliberately deferred four terminology decisions until
+explicit human governance could evaluate demonstrated operational usefulness
+rather than conceptual completeness alone.
+
+The resulting Constitutional Terminology Ratification Review evaluated those
+four terms without reopening the architecture, modifying doctrine, or making a
+Product Promotion Decision. The human terminology-ratification authority
+accepted that review and its recommendations on 2026-07-24.
+
+## Decision
+
+- **Product Candidate vs Enduring Product — Ratified**
+- **Semantic Contract Producer vs Runtime Producer — Ratified (using the
+  refined naming)**
+- **Repository Authority — Ratified as question-typed authority**
+- **Governance Function — Deferred**
+
+## Evidence Considered
+
+The accepted decision considered:
+
+- current Playbook doctrine, especially the human-rooted and question-typed
+  authority rules in [`core-model.md`](core-model.md);
+- the [`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md),
+  [`Cross-Repo Architecture Glossary`](cross-repo-glossary.md),
+  [`Repo-To-Repo Interface Contracts`](repo-to-repo-interface-contracts.md),
+  and [`ai-workflow Ecosystem Overview`](ai-workflow-ecosystem.md);
+- the non-authoritative
+  [`Candidate Architecture Foundation`](architecture-foundation-candidate.md)
+  as the historical source of the deferred terminology boundary;
+- archived product-model validation, independent review, and evidence
+  reconciliation;
+- the Source Acquisition and Knowledge Record Product Identity Promotion
+  Packets;
+- the Product Promotion Workflow observations; and
+- the accepted Constitutional Vocabulary Review and the implementation change
+  that produced the Vocabulary Guide.
+
+Historical governance artifacts supplied evidence only. Current Playbook
+doctrine remained authoritative, and the human decision supplied ratification.
+
+## Ratified Terminology
+
+### Product Candidate vs Enduring Product — Ratified
+
+First reference to a specific Product identity must preserve its applicable
+status: Product Candidate, Enduring Product, proposed Product identity,
+rejected identity, or superseded identity.
+
+The distinction is ratified because the promotion exercises demonstrated that
+current status, operational evidence, a promotion recommendation, and an
+explicit human Product Promotion Decision must remain separate. A Product
+Candidate does not become an Enduring Product through implementation, use,
+validation, a merged change, or a recommendation.
+
+### Semantic Contract Producer vs Runtime Producer — Ratified (Using The Refined Naming)
+
+The refined formal term is **Semantic Contract Producer**. It identifies the
+Product or other typed identity responsible for shared contract meaning,
+emission semantics, and compatible evolution. **Runtime Producer** identifies
+the component, command, adapter, service, or process that emits a contract
+instance.
+
+The distinction is ratified because contract work demonstrated that semantic
+ownership, normative contract hosting, runtime emission, consumer-local policy,
+and consequential human authority are materially different roles. Repository
+placement and runtime emission do not independently establish semantic
+ownership.
+
+### Repository Authority — Ratified as question-typed authority
+
+Repository Authority is limited to a named Repository question, such as
+accepted source, current implementation, validation, review, or merge state. It
+is not general Product authority, domain authority, or human decision
+authority.
+
+The terminology is ratified because question-typing prevents a Repository name
+from becoming shorthand for Product meaning, human judgment, and implementation
+behavior simultaneously.
+
+## Deferred Terminology
+
+### Governance Function — Deferred
+
+Governance Function remains a proposed term. The reviewed evidence did not show
+that the abstraction solves a demonstrated governance problem today.
+
+Until a later explicit human ratification decision, use the specific applicable
+authority name, such as authorized human reviewer, planning authority,
+Repository merge authority, or Product-promotion authority. Do not adopt
+Governance Function merely as a conceptually complete non-Product category.
+
+## Implementation Consequences
+
+- The Constitutional Vocabulary Guide remains the canonical implementation
+  guide for the ratified terminology.
+- Documentation may proceed with first-reference Product-status qualification.
+- Contract documentation may distinguish the Semantic Contract Producer,
+  Runtime Producer, normative contract host, consumer, consumer
+  implementation, transport, and consequential human authority when material.
+- Repository-authority statements must name the Repository-controlled
+  question.
+- Documentation should continue to avoid Governance Function and use a
+  specific authority name instead.
+- Repository-wide documentation alignment is a separate implementation phase;
+  this decision does not perform or authorize that alignment by itself.
+
+## Explicit Non-Goals
+
+This decision does not:
+
+- promote or modify Playbook doctrine;
+- promote the Candidate Architecture Foundation;
+- define, classify, or promote a Product identity;
+- make a Product Promotion Decision;
+- settle the operational-evidence threshold for Product promotion;
+- alter a Product, Repository, contract, consumer, runtime, or human authority
+  boundary;
+- redesign Repository or runtime topology;
+- require implementation or schema changes; or
+- ratify Governance Function.
+
+## Reversal Criteria
+
+Ratified terminology may be revised, demoted, or withdrawn only through a later
+explicit human governance decision that preserves this record and identifies
+the evidence supporting the change.
+
+- Revisit first-reference Product-status qualification if repeated Product
+  Promotion Decisions show that it causes systematic misclassification or
+  obscures rather than clarifies accepted status.
+- Revisit the Semantic Contract Producer and Runtime Producer distinction if
+  real contract alignment fails to produce distinct, actionable ownership
+  statements, or multi-producer contracts show that the distinction makes
+  material claims inaccurate.
+- Revisit question-typed Repository Authority if it repeatedly causes readers
+  to confuse Repository facts with human authorization or Product authority
+  despite the required question qualification.
+- Consider ratifying Governance Function only after multiple concrete
+  governance cases require a stable non-Product category and specific authority
+  names prove insufficient or repeatedly inconsistent.
+
+## Relationship To Other Guidance
+
+- This document is the canonical record of the human terminology-ratification
+  decision.
+- The
+  [`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md)
+  controls implementation usage.
+- [`core-model.md`](core-model.md) remains authoritative for human-rooted,
+  question-typed authority.
+- [`repo-to-repo-interface-contracts.md`](repo-to-repo-interface-contracts.md)
+  applies the ratified producer terminology to cross-Repository contracts.
+- [`cross-repo-glossary.md`](cross-repo-glossary.md) provides qualified
+  navigation vocabulary.
+- The
+  [`Candidate Architecture Foundation`](architecture-foundation-candidate.md)
+  remains non-authoritative candidate guidance.

--- a/docs/constitutional-vocabulary-guide.md
+++ b/docs/constitutional-vocabulary-guide.md
@@ -6,6 +6,10 @@
 >
 > Authority: subordinate to current Playbook doctrine
 >
+> Ratification: the accepted
+> [Human Constitutional Terminology Ratification Decision](constitutional-terminology-ratification-decision.md)
+> records which terminology is ratified and which remains deferred
+>
 > Adoption boundary: inclusion in a reviewed Playbook change records adoption
 > as implementation guidance only. It is not doctrine promotion, Product
 > promotion, a new Product Model, an authority-boundary change, or automatic
@@ -397,7 +401,7 @@ Use operational verbs for operational actors:
 
 Execution does not create authority or approval.
 
-### 5. Separate Semantic Producer From Runtime Producer
+### 5. Separate Semantic Contract Producer From Runtime Producer
 
 A Product owns shared contract meaning. A component emits a conforming
 instance. A Repository hosts the contract and implementation.
@@ -614,7 +618,7 @@ This definition still requires human ratification. Until then, prefer a
 specific authority name such as "authorized human reviewer," "Repository merge
 authority," or "Product-promotion authority."
 
-### Semantic Producer Term
+### Semantic Contract Producer Term
 
 The Product identity responsible for shared contract meaning, emission
 semantics, and compatible evolution.
@@ -667,19 +671,24 @@ Link to it from:
 
 Repository-local documents should apply this guide, not fork or redefine it.
 
-## Completion And Ratification Boundary
+## Ratification Status
 
-The guide is complete enough to drive a focused documentation-alignment pass
-using consistent, mechanical language rules.
+The explicit human
+[Constitutional Terminology Ratification Decision](constitutional-terminology-ratification-decision.md)
+ratified:
 
-Before Repository-wide updates begin, explicit human ratification remains
-required for:
-
-1. the formal definition of **Governance Function**;
-2. the required first-reference distinction between **Product Candidate** and
+1. the required first-reference distinction between **Product Candidate** and
    **Enduring Product**;
-3. the formal **Semantic Producer** versus **Runtime Producer** distinction;
-4. the question-typed meaning of **Repository Authority**; and
-5. adoption and any future status of this guide itself.
+2. the formal **Semantic Contract Producer** versus **Runtime Producer**
+   distinction; and
+3. the question-typed meaning of **Repository Authority**.
 
-No Product promotion or architectural redesign follows from this guide.
+The decision deferred **Governance Function**. Until a later explicit human
+ratification decision, prefer a specific authority name such as "authorized
+human reviewer," "Repository merge authority," or "Product-promotion
+authority."
+
+The decision records accepted terminology as implementation guidance. It does
+not promote this guide into doctrine, make a Product Promotion Decision, or
+promote or modify the candidate Architecture Foundation. Repository-wide
+documentation alignment remains a separate implementation phase.

--- a/docs/cross-repo-glossary.md
+++ b/docs/cross-repo-glossary.md
@@ -153,8 +153,8 @@ Architecture Foundation into doctrine.
 
 - **Product Candidate**: a Product identity that has passed the conceptual test
   but has not received explicit human promotion to Enduring Product. The
-  required first-reference status distinction remains subject to the
-  ratification boundary recorded in the Constitutional Vocabulary Guide.
+  required first-reference status distinction is ratified in the
+  [`Human Constitutional Terminology Ratification Decision`](constitutional-terminology-ratification-decision.md).
 - **Enduring Product**: a Product Candidate whose outcome and authority
   boundary have satisfied the accepted operational standard and received
   explicit human Product promotion.
@@ -171,15 +171,15 @@ Architecture Foundation into doctrine.
 Infrastructure used during a workflow is not automatically the product or
 repository-owned state.
 
-### Semantic Producer
+### Semantic Contract Producer
 
-A Semantic Producer is the Product or other typed identity responsible for
-shared contract meaning, emission semantics, and compatible evolution.
+A Semantic Contract Producer is the Product or other typed identity responsible
+for shared contract meaning, emission semantics, and compatible evolution.
 
 The normative contract may currently live in the producer implementation
 repository, but that location does not make the repository the constitutional
-owner of the contract's meaning. This distinction remains subject to the
-ratification boundary recorded in the Constitutional Vocabulary Guide.
+owner of the contract's meaning. This distinction is ratified in the
+[`Human Constitutional Terminology Ratification Decision`](constitutional-terminology-ratification-decision.md).
 
 ### Runtime Producer
 
@@ -197,8 +197,8 @@ Repository Authority is always question-typed. A repository and its hosted
 state control current files, implementation, review, validation, and merge
 facts. That authority does not become general Product or domain authority.
 
-The formal question-typed terminology remains subject to the ratification
-boundary recorded in the Constitutional Vocabulary Guide.
+The formal question-typed terminology is ratified in the
+[`Human Constitutional Terminology Ratification Decision`](constitutional-terminology-ratification-decision.md).
 
 ### Capability
 

--- a/docs/repo-to-repo-interface-contracts.md
+++ b/docs/repo-to-repo-interface-contracts.md
@@ -9,8 +9,10 @@ central schema repository, shared library, or new approval gate.
 
 Apply the subject and authority rules in the
 [`Constitutional Vocabulary Guide`](constitutional-vocabulary-guide.md) when
-naming semantic producers, runtime producers, contract hosts, consumers,
-human authority, and repository implementation.
+naming Semantic Contract Producers, Runtime Producers, contract hosts,
+consumers, human authority, and repository implementation. The
+[`Human Constitutional Terminology Ratification Decision`](constitutional-terminology-ratification-decision.md)
+records the accepted terminology status.
 
 This is a documentation pattern, not a required file format. Use only the
 sections that clarify the real interface. A short section in an existing design
@@ -54,8 +56,8 @@ justify a shared library or centrally managed schema.
 - Put accepted versions, consumer-specific policy, and integration validation
   with each contract consumer, normally in its current implementation
   repository.
-- Link both sides explicitly and name the semantic producer that governs shared
-  semantics.
+- Link both sides explicitly and name the Semantic Contract Producer that
+  governs shared semantics.
 - Keep transport or orchestration responsibility separate when an operator or
   a third repository moves the artifact between producer and consumer.
 - Name the human authority when consequential approval, acceptance, retention,
@@ -174,8 +176,8 @@ library.
 
 - Does the contract describe the interface that exists, with links to current
   evidence, rather than a hoped-for abstraction?
-- Are the semantic producer, runtime producer, normative contract host,
-  consumer, transport, and any consequential human authority distinct?
+- Are the Semantic Contract Producer, Runtime Producer, normative contract
+  host, consumer, transport, and any consequential human authority distinct?
 - Can the consumer detect unsupported or stale input before unsafe use?
 - Are security, durability, and failure claims no stronger than implementation
   and validation evidence?


### PR DESCRIPTION
## Summary

- add a durable Human Constitutional Terminology Ratification Decision beside the existing implementation guide
- record the three ratified terminology outcomes and the intentionally deferred Governance Function term
- connect the decision from the Vocabulary Guide, cross-repo glossary, interface-contract guidance, and documentation index
- apply the accepted refined name `Semantic Contract Producer` within those canonical guidance surfaces

## Why

The Constitutional Vocabulary Guide intentionally deferred four terminology decisions until explicit human governance could evaluate operational usefulness. That review is complete and its recommendations were accepted. This pull request preserves the human governance act so later implementation does not have to reconstruct ratification status from a review narrative or conversation.

## Decision recorded

- Product Candidate vs Enduring Product — Ratified
- Semantic Contract Producer vs Runtime Producer — Ratified (using the refined naming)
- Repository Authority — Ratified as question-typed authority
- Governance Function — Deferred

## Governance boundary

This is a terminology-governance decision, not new doctrine. It does not promote or modify the Candidate Architecture Foundation, promote any Product Candidate, make a Product Promotion Decision, alter an authority boundary, or perform repository-wide documentation alignment. The Constitutional Vocabulary Guide remains the implementation guide; the new document is the canonical record of ratification status.

Repository documentation alignment is the next implementation phase and remains outside this pull request.

## Validation

- `make check`
  - Markdown lint: 0 issues
  - unit tests: 42 passed
  - tracked local Markdown links and heading fragments resolve
- `git diff --cached --check`
- verified `docs/architecture-foundation-candidate.md` is unchanged