### PR TITLE
Avoid authoritative scanner symlink reads

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -214,6 +214,9 @@ def changed_markdown_files(base_ref: str | None, head_ref: str | None) -> list[P
 def markdown_sources(paths: list[Path]) -> list[tuple[str, str]]:
     sources: list[tuple[str, str]] = []
     for path in paths:
+        if path.is_symlink():
+            print(f"authoritative-source-check: skipped symbolic link {path}")
+            continue
         if not path.is_file():
             continue
         try:
@@ -228,7 +231,11 @@ def is_scannable_markdown_path(path: Path) -> bool:
 
 
 def all_markdown_files(root: Path = Path(".")) -> list[Path]:
-    return sorted(path for path in root.glob("**/*.md") if is_scannable_markdown_path(path))
+    return sorted(
+        path
+        for path in root.glob("**/*.md")
+        if not path.is_symlink() and is_scannable_markdown_path(path)
+    )
 
 
 def dedupe(findings: list[dict[str, object]]) -> list[dict[str, object]]:

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -281,6 +281,35 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
         self.assertIn("https://medium.com/source-doc", result.stdout)
         self.assertNotIn("https://medium.com/worktree-doc", result.stdout)
 
+    def test_markdown_sources_skip_symbolic_links_without_reading_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "machine-local-source"
+            target.write_text(
+                "REST retry behavior source: https://medium.com/private-source",
+                encoding="utf-8",
+            )
+            link = root / "linked.md"
+            link.symlink_to(target)
+
+            sources = scanner.markdown_sources([link])
+
+        self.assertEqual(sources, [])
+
+    def test_all_markdown_files_excludes_symbolic_links(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "machine-local-source"
+            target.write_text("private local content", encoding="utf-8")
+            link = root / "linked.md"
+            link.symlink_to(target)
+            regular = root / "regular.md"
+            regular.write_text("# Regular\n", encoding="utf-8")
+
+            paths = scanner.all_markdown_files(root)
+
+        self.assertEqual(paths, [regular])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- skip Markdown symlinks before authoritative-source content reads
- exclude Markdown symlinks from full repository discovery
- cover changed-file and recursive discovery paths with regression tests

## Validation
- make check

## Scope
Focused repository-boundary hardening; no scanner policy or allowlist changes.