### PR TITLE
Clarify feature lifecycle activation boundary

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -13,6 +13,27 @@ Each phase should have a clear goal, a clear review surface, and a natural stopp
 
 Use [`alignment-checkpoints.md`](alignment-checkpoints.md) to decide when to pause or split work, and use [`review-packet.md`](review-packet.md) to prepare the review surface before merge or release.
 
+## Activation
+
+Feature-lifecycle guidance becomes required when the current authorized action
+first enters feature-delivery planning or execution. Establish the current
+delegated action and interaction mode, then the governing workflow and current
+authorized action, before deciding whether lifecycle planning or execution is
+current.
+
+Related nouns, recorded future intent, explicit implementation intent, and
+implementation eligibility do not activate this guidance by themselves. When a
+prerequisite workflow owns the current completion boundary, it remains the
+governing workflow until the current authorized action transitions into
+feature-delivery planning or execution.
+
+Lifecycle planning includes defining intended behavior, constraints, risks, or
+acceptance shape; preparing a proposal-first change; and defining contract
+tests. Proposal-first planning therefore activates this guidance before
+mutation. Activation does not grant implementation authority, and an
+implementation blocker does not deactivate lifecycle planning that is already
+the current authorized action.
+
 ## Phase Guidance
 
 ### Design

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -265,6 +265,11 @@ automation prompt authoring, fleet-wide maintenance, governance or drift
 automation, scheduled inspection or correction, autonomous-maintenance
 architecture, or automation authority, evidence, scope, and safety contracts.
 
+Read `docs/feature-lifecycle.md` when the current authorized action first enters
+feature-delivery planning or execution; use its activation boundary to
+distinguish intent, prerequisite workflow ownership, and implementation
+eligibility.
+
 Read `docs/ai-workflow-ecosystem.md`,
 `docs/repo-to-repo-interface-contracts.md`, and
 `docs/cross-repo-glossary.md` only when the work involves multiple


### PR DESCRIPTION
# Summary

## What changed

- Define the observable activation boundary for `feature_lifecycle` from the current authorized action.
- Preserve separate concepts for implementation intent, prerequisite workflow ownership, lifecycle planning, lifecycle execution, implementation eligibility, and implementation authority.
- Add one short `start-here` routing cross-reference to the owning activation rule.

## Why

The completed `feature-lifecycle-activation-v1` doctrine analysis determined that canonical guidance was ambiguous about the transition between explicit implementation intent, the current authorized action, and prerequisite workflow ownership. This PR promotes one bounded doctrinal clarification of that activation boundary.

The clarification is motivated by doctrine analysis. Experiments identified the ambiguity but did not determine the rule, and no experimental result is promoted.

## Scope check

- [x] This PR contains one logical change.

## Interaction mode

Implementation.

## Validation

- [x] `make check`
- [x] Manual review of activation language, proposal-first behavior, prerequisite workflow ownership, implementation authority, and changed-file scope

`make check` passed Markdown lint and all 48 unit tests, including local Markdown link and heading-fragment resolution.

## Source evidence

- Completed doctrine determination: `feature-lifecycle-activation-v1` — `CANONICALLY AMBIGUOUS`
- Canonical source baseline: `e4948751e510324ce3f3ebb028c5e4c182d5044c`

## Experiment reconciliation

This clarification explains why Experiment 3 could not classify `feature_lifecycle` deterministically. It does not change the frozen disposition. It provides a deterministic routing rule for future experiments.

## Residual risks / follow-ups

This is a material doctrine activation clarification. The exact PR artifact remains subject to the applicable doctrine-promotion review and human decision boundaries before merge.

## Issue closure

No issue closure.