### PR TITLE
Clarify narrow Codex command execution

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -261,14 +261,24 @@ Follow the command-form guidance in
 
 Codex-specific application:
 
+- Use the narrowest Codex execution primitive that directly represents the
+  intended operation. Prefer a native filesystem or tool operation when one is
+  available; otherwise prefer direct argv-style executable invocation where
+  the execution surface supports it.
 - Prefer direct `git`, `gh`, `make`, `python`, repo-local script, and tool
-  invocations for ordinary repository work.
-- Where the execution surface supports native argv-style execution, use it for
-  `git` and `gh`.
+  invocations for ordinary repository work. Apply the same directness to simple
+  filesystem operations such as directory creation or file inspection.
+- Do not introduce `zsh`, `bash`, `sh`, login-shell wrappers, `-c` wrappers, or
+  equivalent general-purpose shell execution merely for convenience when the
+  operation can be represented directly. This keeps approvals and audit
+  records scoped to the specific operation instead of widening them to a
+  general-purpose shell.
 - If the execution surface defaults to a shell or login shell, disable that
-  wrapper where supported for ordinary `git` and `gh` commands.
-- Use shell wrapping only when the command genuinely needs shell semantics, and
-  keep the wrapped operation narrow enough for review and approval surfaces to
+  wrapper where supported for direct executable commands.
+- Use shell wrapping only when the operation genuinely needs shell semantics,
+  such as pipelines, redirection, command substitution, conditionals, or
+  necessary shell expansion that cannot reasonably be represented directly.
+  Keep the wrapped operation narrow enough for review and approval surfaces to
   see the intended action.
 
 ### Enforcement-Backed Recursive Cleanup


### PR DESCRIPTION
## Summary

- direct Codex to use the narrowest native operation or direct argv-style executable invocation available
- prohibit shell and login-shell wrappers for simple operations performed merely for convenience
- retain shell wrapping for genuine shell semantics while preserving narrow review, approval, and audit surfaces

## Rationale

Simple filesystem and repository operations should not be widened into general-purpose shell execution when Codex can represent the intended action directly. Keeping the execution primitive narrow improves intent visibility and approval and audit granularity while preserving the existing shared command-form ownership model.

## Validation

- `make check`
  - markdownlint-cli2: 0 issues in 53 files
  - unit tests: 48 passed