### PR TITLE
Clarify proportional cross-thread handoffs

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -8,29 +8,20 @@ Prompts should remain routing and execution envelopes, not duplicated workflow
 doctrine. For the rationale, see
 [`sparse-rehydration-and-source-grounding.md`](sparse-rehydration-and-source-grounding.md).
 
-For a fresh repository-scoped thread, explicitly route through the current
-[`start-here.md`](start-here.md) startup contract and point to the authoritative
-Repository or History artifacts that preserve established state. Do not
-reconstruct frozen identities, methodology, lineage, completed history, or
-other durable packages in the prompt when the downstream agent can retrieve
-and verify the authoritative artifact. The prompt should carry the current
-delta: goal, governing issue, authoritative artifact locations, exact
-authorization, constraints, completion boundary, and stop rules.
+For a fresh repository-scoped thread, explicitly route through current
+[`start-here.md`](start-here.md) and hydrate established state from
+authoritative Repository or History artifacts instead of replaying it in the
+prompt. The prompt carries the current delta: goal, governing authority or
+issue, authoritative artifact references, authorization, constraints,
+completion boundary, and stop rules.
 Self-contained means complete routing and authorization, not embedding every
 referenced artifact.
 
-In the same thread, after repository startup and the relevant source state have
-already been established, a short incremental authorization is sufficient. It
-does not need to repeat the startup route or durable state package. Reapply the
-startup contract when the work moves to another repository, and re-retrieve
-mutable sources when freshness matters.
-
-Keep this compression proportional. Repeat an exact value in the prompt when
-the value itself must be frozen at the prompt boundary, an artifact reference
-cannot bind it unambiguously, the downstream executor cannot retrieve the
-artifact, or omission would weaken a required identity, authority, safety, or
-validation constraint. Reducing redundant prompt context is execution
-engineering; it is not evidence about methodology, architecture, or validity.
+A same-thread continuation may carry only the changed delta while established
+source state remains current. Keep exact values prompt-local when required for
+identity, authority, safety, validation, or unambiguous retrieval. Reducing
+redundant context is execution engineering, not methodology or architecture
+evidence.
 
 ## Prompt Contract Identity
 
@@ -195,35 +186,24 @@ Parallel execution:
 Use this prompt when the deliverable is a complete downstream task envelope, not
 direct mutation by the current agent.
 
-A compact fresh-thread handoff can use this proportional shape when the named
-artifacts already carry the established state:
+A compact fresh-thread handoff can use this shape when the named artifacts
+already carry the established state:
 
 ```text
 Startup:
 - Retrieve current `docs/start-here.md` through GitHub source access when
   available and follow its repository startup route.
-
 Governing issue:
 - [issue identifier or durable authority source]
-
 Authoritative state:
 - [Repository or History artifact locations and exact identities when needed]
-
 Authorized action:
 - [the new bounded action]
-
 Constraints:
 - [only task-specific constraints not already owned by the referenced sources]
-
 Completion and stop boundary:
 - [required result, validation, delivery, and conditions that require stopping]
 ```
-
-For a same-thread continuation whose startup and authoritative state are still
-current, send only the changed authorization, constraints, completion boundary,
-or stop condition. Do not replay the durable package merely to make the prompt
-self-contained; source retrieval, not conversational repetition, provides that
-continuity.
 
 Required inputs:
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -8,6 +8,30 @@ Prompts should remain routing and execution envelopes, not duplicated workflow
 doctrine. For the rationale, see
 [`sparse-rehydration-and-source-grounding.md`](sparse-rehydration-and-source-grounding.md).
 
+For a fresh repository-scoped thread, explicitly route through the current
+[`start-here.md`](start-here.md) startup contract and point to the authoritative
+Repository or History artifacts that preserve established state. Do not
+reconstruct frozen identities, methodology, lineage, completed history, or
+other durable packages in the prompt when the downstream agent can retrieve
+and verify the authoritative artifact. The prompt should carry the current
+delta: goal, governing issue, authoritative artifact locations, exact
+authorization, constraints, completion boundary, and stop rules.
+Self-contained means complete routing and authorization, not embedding every
+referenced artifact.
+
+In the same thread, after repository startup and the relevant source state have
+already been established, a short incremental authorization is sufficient. It
+does not need to repeat the startup route or durable state package. Reapply the
+startup contract when the work moves to another repository, and re-retrieve
+mutable sources when freshness matters.
+
+Keep this compression proportional. Repeat an exact value in the prompt when
+the value itself must be frozen at the prompt boundary, an artifact reference
+cannot bind it unambiguously, the downstream executor cannot retrieve the
+artifact, or omission would weaken a required identity, authority, safety, or
+validation constraint. Reducing redundant prompt context is execution
+engineering; it is not evidence about methodology, architecture, or validity.
+
 ## Prompt Contract Identity
 
 For material execution that may be reviewed, recovered, or replayed, apply the
@@ -170,6 +194,36 @@ Parallel execution:
 
 Use this prompt when the deliverable is a complete downstream task envelope, not
 direct mutation by the current agent.
+
+A compact fresh-thread handoff can use this proportional shape when the named
+artifacts already carry the established state:
+
+```text
+Startup:
+- Retrieve current `docs/start-here.md` through GitHub source access when
+  available and follow its repository startup route.
+
+Governing issue:
+- [issue identifier or durable authority source]
+
+Authoritative state:
+- [Repository or History artifact locations and exact identities when needed]
+
+Authorized action:
+- [the new bounded action]
+
+Constraints:
+- [only task-specific constraints not already owned by the referenced sources]
+
+Completion and stop boundary:
+- [required result, validation, delivery, and conditions that require stopping]
+```
+
+For a same-thread continuation whose startup and authoritative state are still
+current, send only the changed authorization, constraints, completion boundary,
+or stop condition. Do not replay the durable package merely to make the prompt
+self-contained; source retrieval, not conversational repetition, provides that
+continuity.
 
 Required inputs:
 


### PR DESCRIPTION
## Summary

- clarify that fresh repository-scoped handoffs bootstrap through current `docs/start-here.md` and hydrate established state from authoritative Repository or History artifacts
- state that prompts carry the current authorization and constraint delta instead of replaying durable packages
- distinguish fresh-thread startup from same-thread incremental authorization
- add a compact `Startup → Governing issue → Authoritative state → Authorized action → Constraints → Completion` example
- preserve explicit prompt-boundary values when identity, authority, safety, validation, or retrieval constraints require them

## Rationale

CAK-96 successor experiment packages already preserve exact controller, methodology, lineage, capture/scoring, model, reasoning, and qualification identities. Replaying those durable fields in orchestration prompts increases execution overhead without creating authority. Existing Playbook guidance covered source-first retrieval, bounded hydration, routing envelopes, and sparse rehydration, but did not state the fresh-thread/same-thread delta rule directly in the canonical prompt owner.

This is a non-material doctrine clarification under `docs/feature-lifecycle.md`: it changes no authority boundary, mandatory lifecycle gate, canonical owner, or cross-boundary obligation. Token reduction is framed as execution engineering, not methodology or architecture evidence.

Planning context: Linear CAK-93, CAK-70, and CAK-96.

## Validation

- `make check` — passed (53 Markdown files, 0 lint issues; 48 tests passed)
- `git diff --check` — passed