### PR TITLE
Match official GitHub repositories exactly

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -37,11 +37,10 @@ DEFAULT_OFFICIAL_SUFFIXES = (
     "support.atlassian.com",
 )
 OFFICIAL_GITHUB_DOMAINS = {"api.github.com", "docs.github.com"}
-OFFICIAL_GITHUB_PATH_MARKERS = (
-    "/github/docs",
-    "/github/rest-api-description",
-    "openapi",
-)
+OFFICIAL_GITHUB_REPOSITORIES = {
+    ("github", "docs"),
+    ("github", "rest-api-description"),
+}
 SAME_ORG_GITHUB_OWNERS = {"ctrl-alt-keith"}
 KNOWN_THIRD_PARTY_SUFFIXES = ("stackoverflow.com", "medium.com", "dev.to")
 IGNORED_MARKDOWN_PATH_PARTS = (
@@ -85,6 +84,13 @@ def is_same_org_github_repo(path: str) -> bool:
     return len(parts) >= 2 and parts[0] in SAME_ORG_GITHUB_OWNERS
 
 
+def github_repository(path: str) -> tuple[str, str] | None:
+    parts = [part for part in path.lower().split("/") if part]
+    if len(parts) < 2:
+        return None
+    return parts[0], parts[1]
+
+
 def configured_domains(raw_values: list[str]) -> tuple[str, ...]:
     domains: list[str] = []
     for raw_value in raw_values:
@@ -111,9 +117,7 @@ def is_official(
     if domain in OFFICIAL_GITHUB_DOMAINS:
         return True
     if domain == "github.com":
-        return is_same_org_github_repo(path) or any(
-            marker in path for marker in OFFICIAL_GITHUB_PATH_MARKERS
-        )
+        return is_same_org_github_repo(path) or github_repository(path) in OFFICIAL_GITHUB_REPOSITORIES
     return False
 
 

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -163,6 +163,38 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["domain"], "github.com")
 
+    def test_official_github_source_repositories_are_allowed(self) -> None:
+        urls = [
+            "https://github.com/github/docs/blob/main/content/rest/about-the-rest-api.md",
+            "https://github.com/github/rest-api-description/tree/main/descriptions",
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                findings = scanner.scan_text(
+                    "docs/example.md",
+                    f"GitHub API source: {url}",
+                )
+
+                self.assertEqual(findings, [])
+
+    def test_github_path_keywords_do_not_allow_unrelated_repositories(self) -> None:
+        urls = [
+            "https://github.com/example/openapi-guide",
+            "https://github.com/example/github/docs",
+            "https://github.com/example/github-rest-api-description",
+        ]
+
+        for url in urls:
+            with self.subTest(url=url):
+                findings = scanner.scan_text(
+                    "docs/example.md",
+                    f"GitHub API source: {url}",
+                )
+
+                self.assertEqual(len(findings), 1)
+                self.assertEqual(findings[0]["domain"], "github.com")
+
     def test_configured_domains_accept_comma_and_space_separated_values(self) -> None:
         domains = scanner.configured_domains(
             ["https://docs.aws.amazon.com, cloud.google.com learn.microsoft.com"]


### PR DESCRIPTION
## Summary

- replace substring-based GitHub path allowlisting with exact owner/repository matching
- preserve allowances for GitHub's documentation and REST description repositories
- verify unrelated repositories containing trusted-looking path keywords still warn

## Why

The advisory source scanner could classify an unrelated GitHub repository as authoritative when its path merely contained the OpenAPI keyword or a nested trusted-looking path. Exact repository identity closes that trust-boundary gap.

## Validation

- make check (Markdown lint and 50 tests passed)