### PR TITLE
Add cross-vendor task routing guidance

### DIFF
--- a/docs/external-ai-reviewer.md
+++ b/docs/external-ai-reviewer.md
@@ -12,6 +12,14 @@ A reviewer verdict is evidence, not execution authority. It does not grant
 implementation, approval, merge, release, or another transition. Human and
 repo-local authority boundaries continue to control.
 
+External-review independence is a role boundary, not a model, vendor, effort,
+or thread property. A child task spawned by the reviewed party does not satisfy
+the external-review role, even when it uses a different provider or isolated
+context. A qualifying external reviewer is separately invoked under the review
+contract and does not inherit the reviewed party's execution context or
+authority. This rule does not make child work generally invalid; it only limits
+what can satisfy the external-review prerequisite.
+
 ## Review Modes
 
 ### Lightweight targeted review

--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -124,7 +124,7 @@ includes, as applicable:
 - requested executor model and reasoning/thinking configuration, plus the
   effective values when the runtime exposes them;
 - any observed runtime fallback or substitution event, including any available
-  reason and the qualification consequence; and
+  reason and the qualification consequence;
 - deterministic transport selection and delivery evidence;
 - acting identity and live-authority re-verification result;
 - current runtime safety-policy observation;

--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -121,6 +121,10 @@ includes, as applicable:
 - rendered-prompt digest and byte length;
 - selected hydrator, representation adapter, renderer, validation profile,
   and validator;
+- requested executor model and reasoning/thinking configuration, plus the
+  effective values when the runtime exposes them;
+- any observed runtime fallback or substitution event, including any available
+  reason and the qualification consequence; and
 - deterministic transport selection and delivery evidence;
 - acting identity and live-authority re-verification result;
 - current runtime safety-policy observation;

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -81,8 +81,8 @@ its meaning or execution.
 
 Use this template only when the intended interaction mode is direct
 implementation. For review or orchestration, use the matching template instead.
-Apply the reasoning-selection guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
+Apply the model-and-reasoning routing guidance in
+[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
 to the bounded task. The first block below is operator metadata for the human
 or operator. It is not part of the executable prompt and should not be copied
 into the downstream agent. Copy or deliver only the second block. Emit the two
@@ -90,6 +90,7 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
+Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:
@@ -215,8 +216,8 @@ Required inputs:
 - `validation_path`
 - `delivery_expectation`
 
-Apply the reasoning-selection guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
+Apply the model-and-reasoning routing guidance in
+[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
 to the bounded task. The first block below is operator metadata for the human
 or operator. It is not part of the executable prompt and should not be copied
 into the downstream agent. Copy or deliver only the second block. Emit the two
@@ -224,6 +225,7 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
+Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:
@@ -326,8 +328,8 @@ Required inputs:
 - `task_or_issue_context` (`none` when unavailable)
 - `summary_only` (`yes` or `no`)
 
-Apply the reasoning-selection guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#reasoning-level-recommendations)
+Apply the model-and-reasoning routing guidance in
+[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
 to the bounded task. The first block below is operator metadata for the human
 or operator. It is not part of the executable prompt and should not be copied
 into the downstream agent. Copy or deliver only the second block. Emit the two
@@ -335,6 +337,7 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
+Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
 Recommended reasoning level: [Light | Medium | High]
 
 Reason:

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -31,8 +31,10 @@ separate decisions. Declare one of these routing values in operator metadata:
 - `FRESH THREAD`: select the task-appropriate model and separately select a
   supported reasoning or thinking configuration through the executor adapter.
 - `SAME THREAD`: preserve the current thread's model and configuration by
-  default. A lower-cost setting being sufficient for the next sub-phase does
-  not itself authorize or justify changing an already-running task.
+  default. Preserve the requested parent configuration; observe and account for
+  any effective runtime substitution. A lower-cost setting being sufficient for
+  the next sub-phase does not itself authorize or justify changing an
+  already-running task.
 - `CHILD TASK`: select the lowest-cost sufficient configuration for the bounded
   child, and preserve its model/configuration, inputs, execution identity,
   durable result, and authority boundary where the workflow requires it.
@@ -44,6 +46,15 @@ existing stronger task's deterministic follow-up, prefer a bounded cheaper
 child where worthwhile rather than downgrading the parent in place. Continuity
 preserves context, decision provenance, reproducibility, and qualification
 boundaries; it does not prevent justified escalation.
+
+Requested configuration is the operator's selected model and supported
+reasoning/thinking setting. Effective configuration is what the runtime reports
+as serving the work. Record requested and effective values separately where the
+runtime exposes them, along with a fallback or substitution event. If the
+effective value is not observable, say so; requested configuration alone does
+not prove execution identity. A runtime change is not automatically fatal, but
+requalify, escalate, or stop when it fails a minimum-capability or exact-model
+requirement.
 
 ## Prompt Contract Identity
 
@@ -113,8 +124,8 @@ blocks consecutively with no intervening heading or explanation.
 ```text
 Operator metadata (do not include in prompt)
 Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
-Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
+Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
+Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
 
 Reason:
 [one concise task-specific explanation]
@@ -249,8 +260,8 @@ blocks consecutively with no intervening heading or explanation.
 ```text
 Operator metadata (do not include in prompt)
 Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
-Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
+Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
+Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
 
 Reason:
 [one concise task-specific explanation]
@@ -362,8 +373,8 @@ blocks consecutively with no intervening heading or explanation.
 ```text
 Operator metadata (do not include in prompt)
 Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
-Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
+Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
+Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
 
 Reason:
 [one concise task-specific explanation]

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -23,6 +23,28 @@ identity, authority, safety, validation, or unambiguous retrieval. Reducing
 redundant context is execution engineering, not methodology or architecture
 evidence.
 
+## Thread Routing And Configuration Continuity
+
+Model selection, reasoning or thinking configuration, and thread routing are
+separate decisions. Declare one of these routing values in operator metadata:
+
+- `FRESH THREAD`: select the task-appropriate model and separately select a
+  supported reasoning or thinking configuration through the executor adapter.
+- `SAME THREAD`: preserve the current thread's model and configuration by
+  default. A lower-cost setting being sufficient for the next sub-phase does
+  not itself authorize or justify changing an already-running task.
+- `CHILD TASK`: select the lowest-cost sufficient configuration for the bounded
+  child, and preserve its model/configuration, inputs, execution identity,
+  durable result, and authority boundary where the workflow requires it.
+
+Use the executor adapter for vendor-specific routing. For an existing task that
+exceeds its assigned capability, prefer a bounded stronger child or an explicit
+fresh-thread transition over an untracked parent configuration change. For an
+existing stronger task's deterministic follow-up, prefer a bounded cheaper
+child where worthwhile rather than downgrading the parent in place. Continuity
+preserves context, decision provenance, reproducibility, and qualification
+boundaries; it does not prevent justified escalation.
+
 ## Prompt Contract Identity
 
 For material execution that may be reviewed, recovered, or replayed, apply the
@@ -90,8 +112,9 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
-Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
-Recommended reasoning level: [Light | Medium | High]
+Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
+Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
+Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
 
 Reason:
 [one concise task-specific explanation]
@@ -225,8 +248,9 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
-Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
-Recommended reasoning level: [Light | Medium | High]
+Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
+Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
+Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
 
 Reason:
 [one concise task-specific explanation]
@@ -337,8 +361,9 @@ blocks consecutively with no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)
-Recommended model: [GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol]
-Recommended reasoning level: [Light | Medium | High]
+Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
+Recommended model: [FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve current thread model]
+Recommended reasoning level: [FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve current thread setting]
 
 Reason:
 [one concise task-specific explanation]

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -118,12 +118,103 @@ available. For GitHub PR and issue work, prefer connector-first inspection per
 `gh` supplement it and remain appropriate for verified connector gaps or
 repo-local workflows.
 
+## Claude Model, Thinking, And Thread Routing
+
+Choose the lowest-cost Claude Code model/configuration expected to preserve the
+confidence required by the bounded task. Do not infer a mapping from OpenAI
+model names or tiers. Current Claude Code documentation, checked 2026-08-10,
+establishes the executor-native `haiku`, `sonnet`, and `opus` aliases: Haiku for
+simple fast tasks, Sonnet for daily coding, and Opus for complex reasoning.
+Anthropic's current platform model guidance independently positions Haiku 4.5
+for fast, high-volume, cost-sensitive work; Sonnet 5 for coding, agents, and
+enterprise workflows; and Opus 5 for complex agentic coding and enterprise
+work. Exact model IDs, aliases, model availability, context variants, and
+administrator allowlists are runtime evidence, not this adapter's assumption.
+The broader platform catalog also lists Claude Fable 5; it is outside this
+Claude Code routing matrix because the current Claude Code model configuration
+documents `haiku`, `sonnet`, and `opus` as its selectable task-routing aliases.
+
+| Claude task class | Default Claude Code model | Thinking/effort guidance | Escalate when | Downgrade/follow up when |
+| --- | --- | --- | --- | --- |
+| Deterministic external verification; hashes, inventories, evidence citations; simple source inspection; mechanical fallback verification | `haiku` | Use executor default; Claude Code does not document effort control for Haiku | a result is ambiguous, changes a decision, or source access is insufficient | substantive review has converged and a qualified deterministic check remains |
+| Implementation review; evidence-package review; reviewer follow-up after substantive convergence; bounded long-context evidence synthesis | `sonnet` | Use `high` for intelligence-sensitive review where the active runtime supports effort; otherwise preserve the executor default | residual findings repeat, evidence conflicts, or semantics remain unresolved | split inventories, hashes, and other externally checkable claims to Haiku or another qualified mechanism |
+| Substantive adversarial code review; protocol/design review; architecture review; authority or security-boundary review | `opus` | Use `xhigh` where the active runtime supports it; otherwise use the highest supported setting justified by the bounded review | a new trust boundary, unresolved architecture/security implication, conflicting authority, or a finding that changes qualification disposition appears | after substantive convergence, delegate only the remaining mechanical claim; do not relabel it as substantive review |
+
+The table is a conservative routing hypothesis, not a quality-parity claim. A
+large evidence package does not automatically require Opus, and a small
+authority-boundary change may. Do not downgrade when error consequences are
+high, ambiguity is material, independent verification is weak, work is hard to
+reverse, or failure could silently corrupt authority or evidence.
+
+### Thinking And Effort
+
+Claude's thinking and effort controls are distinct from model choice where the
+active Claude surface supports them. Anthropic documents adaptive thinking and
+an `effort` parameter on current supported models; its Claude Code documentation
+lists the actual model/effort combinations and says the effort scale is
+calibrated per model. Use the executor's canonical terminology and supported
+values rather than treating `light`, `medium`, and `high` as portable numeric
+equivalents. For current Claude Code, `low`, `medium`, `high`, `xhigh`, and
+`max` availability depends on the selected model; verify the effective choice
+at runtime. Do not invent a Haiku effort setting where the executor does not
+offer one.
+
+### Thread Routing And Review Boundaries
+
+Apply the shared `FRESH THREAD`, `SAME THREAD`, and `CHILD TASK` vocabulary in
+[`prompts.md`](../prompts.md#thread-routing-and-configuration-continuity). For
+a FRESH THREAD, choose this matrix's task-appropriate model and supported
+thinking/effort setting. For a SAME THREAD, preserve the existing parent model
+and thinking/effort configuration by default: a cheaper setting being sufficient
+for the current sub-phase does not itself justify changing the running task.
+For a CHILD TASK, select the lowest-cost sufficient Claude configuration for the
+bounded child and preserve its inputs, configuration, execution identity,
+durable result, and authority boundary where the workflow requires it.
+
+If a lower-capability SAME THREAD reaches unresolved ambiguity, an architecture
+or authority decision, conflicting authoritative evidence, repeated residual
+correctness findings, an unexplained invariant, a new trust boundary, or a
+decision-relevant uncertainty, prefer a bounded stronger child or explicit
+fresh-thread transition over mutating the parent silently. If a stronger parent
+reaches deterministic follow-up, delegate the bounded check to Haiku or another
+qualified mechanism where worthwhile instead of downgrading the parent solely
+for cost.
+
+Reviewer independence is separate from model, thinking/effort, and thread
+routing. A qualified separate Claude invocation can supply the selected external
+review only when it meets the reviewer contract; an internally spawned Codex
+review remains Codex review. Mechanical external verification and Codex
+mechanical fallback must be labeled as their actual mechanism and never
+retroactively stand in for substantive external review. CAK-106 is observational
+workflow evidence only: substantive authority/process findings justified deeper
+review, while later evidence-precision, environment-limited verification, and
+mechanical follow-up were candidates for a bounded qualified mechanism. It does
+not establish savings, quality parity, or cross-vendor equivalence.
+
+### Prompt Operator Metadata
+
+When an operator prepares a Claude prompt, use one complete metadata block:
+
+```text
+Operator metadata (do not include in prompt)
+Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>
+Recommended model: <FRESH THREAD/CHILD TASK: haiku | sonnet | opus; SAME THREAD: Preserve current thread model>
+Recommended thinking/effort: <FRESH THREAD/CHILD TASK: supported executor setting; SAME THREAD: Preserve current thread setting>
+
+Reason:
+<one concise task-specific selection or continuity justification>
+```
+
+This metadata is operator guidance, not task authority. Do not recommend a
+model, effort, or child configuration that the current Claude surface cannot
+support.
+
 ## Reasoning And Model Configuration
 
 When a material prompt uses the product-neutral reasoning class in
 [`prompt-contracts.md`](../prompt-contracts.md) (`light`, `medium`, `high`), the
-Claude representation is an extended-thinking budget plus model selection chosen
-for the bounded task. Concrete model names and thinking budgets are adapter
+Claude representation is a supported thinking/effort setting plus model
+selection chosen for the bounded task. Concrete model names and thinking budgets are adapter
 configuration and attempt-receipt metadata, not the meaning of the class.
 Preserve whether the class and each capability are mandatory or advisory; if the
 available Claude surface cannot meet a mandatory requirement without weakening a
@@ -163,4 +254,10 @@ including [memory](https://docs.claude.com/en/docs/claude-code/memory),
 [permissions](https://code.claude.com/docs/en/permissions),
 [the tools reference](https://code.claude.com/docs/en/tools-reference),
 [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
-[worktrees](https://code.claude.com/docs/en/worktrees).
+[worktrees](https://code.claude.com/docs/en/worktrees). Model-routing claims
+above are additionally derived from Anthropic's official [Claude Code model
+configuration](https://code.claude.com/docs/en/model-config), [model-selection
+guide](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model),
+[models overview](https://platform.claude.com/docs/en/about-claude/models/overview),
+and [thinking guide](https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models),
+checked 2026-08-10.

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -123,22 +123,27 @@ repo-local workflows.
 Choose the lowest-cost Claude Code model/configuration expected to preserve the
 confidence required by the bounded task. Do not infer a mapping from OpenAI
 model names or tiers. Current Claude Code documentation, checked 2026-08-10,
-establishes the executor-native `haiku`, `sonnet`, and `opus` aliases: Haiku for
-simple fast tasks, Sonnet for daily coding, and Opus for complex reasoning.
+establishes the executor-native `haiku`, `sonnet`, `opus`, and `fable` aliases:
+Haiku for simple fast tasks, Sonnet for daily coding, Opus for complex reasoning,
+and Fable for the hardest and longest-running tasks.
 Anthropic's current platform model guidance independently positions Haiku 4.5
 for fast, high-volume, cost-sensitive work; Sonnet 5 for coding, agents, and
 enterprise workflows; and Opus 5 for complex agentic coding and enterprise
 work. Exact model IDs, aliases, model availability, context variants, and
 administrator allowlists are runtime evidence, not this adapter's assumption.
-The broader platform catalog also lists Claude Fable 5; it is outside this
-Claude Code routing matrix because the current Claude Code model configuration
-documents `haiku`, `sonnet`, and `opus` as its selectable task-routing aliases.
+Claude Code documents `best` as Fable where available and otherwise the latest
+Opus; it is not a durable qualification guarantee. Fable requires a current
+Claude Code version and is unavailable under zero-data-retention. Its safety
+classifiers can trigger documented fallback, so use an explicit Fable request
+only when its effective runtime identity can be observed and meets the task's
+qualification requirements.
 
 | Claude task class | Default Claude Code model | Thinking/effort guidance | Escalate when | Downgrade/follow up when |
 | --- | --- | --- | --- | --- |
 | Deterministic external verification; hashes, inventories, evidence citations; simple source inspection; mechanical fallback verification | `haiku` | Use executor default; Claude Code does not document effort control for Haiku | a result is ambiguous, changes a decision, or source access is insufficient | substantive review has converged and a qualified deterministic check remains |
-| Implementation review; evidence-package review; reviewer follow-up after substantive convergence; bounded long-context evidence synthesis | `sonnet` | Use `high` for intelligence-sensitive review where the active runtime supports effort; otherwise preserve the executor default | residual findings repeat, evidence conflicts, or semantics remain unresolved | split inventories, hashes, and other externally checkable claims to Haiku or another qualified mechanism |
-| Substantive adversarial code review; protocol/design review; architecture review; authority or security-boundary review | `opus` | Use `xhigh` where the active runtime supports it; otherwise use the highest supported setting justified by the bounded review | a new trust boundary, unresolved architecture/security implication, conflicting authority, or a finding that changes qualification disposition appears | after substantive convergence, delegate only the remaining mechanical claim; do not relabel it as substantive review |
+| Implementation review; evidence-package review; reviewer follow-up after substantive convergence; bounded long-context evidence synthesis | `sonnet` | Use the documented default `high`; use `medium` or `low` only as an explicit cost/latency trade-off where bounded evidence supports it | residual findings repeat, evidence conflicts, or semantics remain unresolved | split inventories, hashes, and other externally checkable claims to Haiku or another qualified mechanism |
+| Substantive adversarial code review; protocol/design review; architecture review; authority or security-boundary review | `opus` | Use the model's documented default; do not assume `xhigh` applies to every Opus runtime | a new trust boundary, unresolved architecture/security implication, conflicting authority, or a finding that changes qualification disposition appears | after substantive convergence, delegate only the remaining mechanical claim; do not relabel it as substantive review |
+| Especially hard long-running investigation, outage/root-cause work, or architecture decision that exceeds a normal Opus review | `fable`, where available | Adaptive thinking is always on; use the documented default `high`, and reserve `xhigh`/`max` for a bounded demonstrated need | a safety fallback, unavailable Fable runtime, or remaining decision risk defeats the qualification requirement | keep Fable out of routine review and delegate only bounded deterministic follow-up |
 
 The table is a conservative routing hypothesis, not a quality-parity claim. A
 large evidence package does not automatically require Opus, and a small
@@ -156,8 +161,10 @@ calibrated per model. Use the executor's canonical terminology and supported
 values rather than treating `light`, `medium`, and `high` as portable numeric
 equivalents. For current Claude Code, `low`, `medium`, `high`, `xhigh`, and
 `max` availability depends on the selected model; verify the effective choice
-at runtime. Do not invent a Haiku effort setting where the executor does not
-offer one.
+at runtime. Claude Code documents `high` as the default for every
+effort-capable model except Opus 4.7, which defaults to `xhigh`; lowering effort
+is the primary cost/latency lever for a bounded task. Do not invent a Haiku
+effort setting where the executor does not offer one.
 
 ### Thread Routing And Review Boundaries
 
@@ -171,6 +178,19 @@ For a CHILD TASK, select the lowest-cost sufficient Claude configuration for the
 bounded child and preserve its inputs, configuration, execution identity,
 durable result, and authority boundary where the workflow requires it.
 
+Requested configuration and effective runtime configuration are distinct.
+Claude Code can intentionally switch `opusplan` from Opus in plan mode to Sonnet
+in execution, and can use configured fallback chains for unavailable or
+overloaded models; Fable/Opus safety-classifier fallback is also documented.
+For governed work, record the requested model/effort and the effective values
+when the runtime exposes them, plus any substitution event. `/status` exposes
+the current Claude Code model; API fallback responses expose the serving model,
+fallback blocks, and attempt iterations. If effective identity is unavailable,
+record that limitation rather than treating the request as proof. Requalify,
+escalate, or stop only when the effective result violates a required capability
+or exact-model reviewer qualification; a runtime event is not automatically
+fatal.
+
 If a lower-capability SAME THREAD reaches unresolved ambiguity, an architecture
 or authority decision, conflicting authoritative evidence, repeated residual
 correctness findings, an unexplained invariant, a new trust boundary, or a
@@ -182,8 +202,10 @@ for cost.
 
 Reviewer independence is separate from model, thinking/effort, and thread
 routing. A qualified separate Claude invocation can supply the selected external
-review only when it meets the reviewer contract; an internally spawned Codex
-review remains Codex review. Mechanical external verification and Codex
+review only when it meets the reviewer contract. A child spawned by the party
+under review is not externally independent, regardless of its model, vendor,
+effort, or isolated context; an internally spawned Codex review remains Codex
+review. Mechanical external verification and Codex
 mechanical fallback must be labeled as their actual mechanism and never
 retroactively stand in for substantive external review. CAK-106 is observational
 workflow evidence only: substantive authority/process findings justified deeper
@@ -198,8 +220,8 @@ When an operator prepares a Claude prompt, use one complete metadata block:
 ```text
 Operator metadata (do not include in prompt)
 Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>
-Recommended model: <FRESH THREAD/CHILD TASK: haiku | sonnet | opus; SAME THREAD: Preserve current thread model>
-Recommended thinking/effort: <FRESH THREAD/CHILD TASK: supported executor setting; SAME THREAD: Preserve current thread setting>
+Recommended model: <FRESH THREAD/CHILD TASK: haiku | sonnet | opus | fable; SAME THREAD: Preserve requested thread model and observe effective runtime model>
+Recommended thinking/effort: <FRESH THREAD/CHILD TASK: supported executor setting; SAME THREAD: Preserve requested thread setting and observe effective runtime setting>
 
 Reason:
 <one concise task-specific selection or continuity justification>
@@ -259,5 +281,6 @@ above are additionally derived from Anthropic's official [Claude Code model
 configuration](https://code.claude.com/docs/en/model-config), [model-selection
 guide](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model),
 [models overview](https://platform.claude.com/docs/en/about-claude/models/overview),
-and [thinking guide](https://platform.claude.com/docs/en/about-claude/models/extended-thinking-models),
+[thinking guide](https://platform.claude.com/docs/en/build-with-claude/thinking),
+and [fallback guide](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback),
 checked 2026-08-10.

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -143,7 +143,7 @@ qualification requirements.
 | Deterministic external verification; hashes, inventories, evidence citations; simple source inspection; mechanical fallback verification | `haiku` | Use executor default; Claude Code does not document effort control for Haiku | a result is ambiguous, changes a decision, or source access is insufficient | substantive review has converged and a qualified deterministic check remains |
 | Implementation review; evidence-package review; reviewer follow-up after substantive convergence; bounded long-context evidence synthesis | `sonnet` | Use the documented default `high`; use `medium` or `low` only as an explicit cost/latency trade-off where bounded evidence supports it | residual findings repeat, evidence conflicts, or semantics remain unresolved | split inventories, hashes, and other externally checkable claims to Haiku or another qualified mechanism |
 | Substantive adversarial code review; protocol/design review; architecture review; authority or security-boundary review | `opus` | Use the model's documented default; do not assume `xhigh` applies to every Opus runtime | a new trust boundary, unresolved architecture/security implication, conflicting authority, or a finding that changes qualification disposition appears | after substantive convergence, delegate only the remaining mechanical claim; do not relabel it as substantive review |
-| Especially hard long-running investigation, outage/root-cause work, or architecture decision that exceeds a normal Opus review | `fable`, where available | Adaptive thinking is always on; use the documented default `high`, and reserve `xhigh`/`max` for a bounded demonstrated need | a safety fallback, unavailable Fable runtime, or remaining decision risk defeats the qualification requirement | keep Fable out of routine review and delegate only bounded deterministic follow-up |
+| Especially hard long-running investigation, outage/root-cause work, or architecture decision that exceeds a normal Opus review | `fable`, where available | Adaptive thinking is always on; use the documented default `high`, and reserve `xhigh`/`max` for a bounded demonstrated need | a safety fallback, unavailable Fable runtime, or remaining decision risk defeats the qualification requirement; stop, seek an explicit human decision, or use another independently qualified mechanism | keep Fable out of routine review and delegate only bounded deterministic follow-up |
 
 The table is a conservative routing hypothesis, not a quality-parity claim. A
 large evidence package does not automatically require Opus, and a small
@@ -184,12 +184,14 @@ in execution, and can use configured fallback chains for unavailable or
 overloaded models; Fable/Opus safety-classifier fallback is also documented.
 For governed work, record the requested model/effort and the effective values
 when the runtime exposes them, plus any substitution event. `/status` exposes
-the current Claude Code model; API fallback responses expose the serving model,
-fallback blocks, and attempt iterations. If effective identity is unavailable,
-record that limitation rather than treating the request as proof. Requalify,
-escalate, or stop only when the effective result violates a required capability
-or exact-model reviewer qualification; a runtime event is not automatically
-fatal.
+the current Claude Code model, and Claude Code shows a transcript notice when a
+documented switch occurs. On the Claude API, server-side fallback responses
+identify the serving model and expose fallback blocks and attempt iterations.
+Other providers and error paths need not expose the same evidence or perform a
+server-side fallback. If effective identity is unavailable, record that
+limitation rather than treating the request as proof. Requalify, escalate, or
+stop only when the effective result violates a required capability or exact-model
+reviewer qualification; a runtime event is not automatically fatal.
 
 If a lower-capability SAME THREAD reaches unresolved ambiguity, an architecture
 or authority decision, conflicting authoritative evidence, repeated residual
@@ -236,8 +238,9 @@ support.
 When a material prompt uses the product-neutral reasoning class in
 [`prompt-contracts.md`](../prompt-contracts.md) (`light`, `medium`, `high`), the
 Claude representation is a supported thinking/effort setting plus model
-selection chosen for the bounded task. Concrete model names and thinking budgets are adapter
-configuration and attempt-receipt metadata, not the meaning of the class.
+selection chosen for the bounded task. Concrete model names and thinking/effort
+settings are adapter configuration and attempt-receipt metadata, not the meaning
+of the class.
 Preserve whether the class and each capability are mandatory or advisory; if the
 available Claude surface cannot meet a mandatory requirement without weakening a
 guarantee, fail closed rather than silently downgrade. A model change alone does

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -75,8 +75,9 @@ downward when supported: Sol architecture to Terra implementation; Sol or Terra
 to Luna for lint, hashes, inventories, fixture execution, and evidence
 packaging. Preserve each child's selected model, reasoning effort, bounded
 inputs, execution identity, durable result, and authority boundary in the
-attempt evidence when the workflow requires it. A lower-cost child is not an
-independent external reviewer.
+attempt evidence when the workflow requires it. A child spawned by the reviewed
+party is not an independent external reviewer; this does not invalidate child
+work for other purposes.
 
 ### Thread Routing And Configuration Continuity
 
@@ -216,7 +217,7 @@ setting.
 
 This posture is derived from OpenAI's current
 [GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
-and [model selection reference](https://developers.openai.com/api/docs/models),
+and [OpenAI models reference](https://developers.openai.com/api/docs/models),
 checked 2026-08-10.
 
 ## Prompt-Contract Mapping

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -43,7 +43,7 @@ remain on Luna.
 | Deterministic file edits or docs cleanup with explicit acceptance criteria; routine PR publication | Luna | Medium | semantics, scope, or validation expectations are unclear | Terra/Sol parent delegates the bounded edit or delivery plumbing |
 | Localized bug fix; routine implementation; normal PR work; CI debugging with a legible failure; frozen-controller test changes; evidence interpretation | Terra | Medium | repeated attempts fail, an invariant cannot be explained, or cross-system scope appears | delegate lint, hashes, fixture runs, and evidence packaging to Luna |
 | Substantial but bounded analysis; moderate synthesis; difficult localized debugging | Terra | High | architecture or authority decisions, conflicting evidence, or unresolved ambiguity remain after bounded investigation | move deterministic execution and verification to Luna |
-| Protocol/design work; architecture synthesis; ambiguous root-cause debugging; high-consequence authority or controller semantics; difficult adversarial review | Sol | High | use `xhigh` or `max` only when representative evidence shows a material reliability gain | delegate established-contract implementation to Terra and mechanical verification to Luna |
+| Protocol/design work; architecture synthesis; ambiguous root-cause debugging; high-consequence authority or controller semantics; difficult adversarial review | Sol | High; consider `xhigh` or `max` only with a measured need | use a bounded supported Pro-mode execution, independent review, or explicit human decision when the unresolved risk remains material | delegate established-contract implementation to Terra and mechanical verification to Luna |
 
 Defaults are routing hypotheses, not a guarantee that the lower-cost choice is
 sufficient. Do not downgrade when consequences are high, ambiguity is
@@ -51,6 +51,14 @@ material, validation is weak, work is hard to reverse, or a failure could
 silently corrupt authority or evidence. `xhigh` and `max` are exceptional:
 use them only for a bounded demanding task with an observed quality need; do
 not promote them to a routine default.
+
+OpenAI documents Pro mode as a distinct Responses API execution mode: it keeps
+the selected GPT-5.6 model, chooses effort independently, and applies more
+model work for difficult quality-first tasks. Use it only where the runtime
+exposes it and a bounded quality/reliability need justifies the added cost and
+latency; it is not a routine Sol default. The `gpt-5.6` alias resolves to Sol,
+so use an explicit Terra or Luna identifier whenever that lower-cost routing is
+intended.
 
 ### Escalation And Delegation
 
@@ -75,8 +83,10 @@ independent external reviewer.
 Apply the shared `FRESH THREAD`, `SAME THREAD`, and `CHILD TASK` vocabulary in
 [`prompts.md`](../prompts.md#thread-routing-and-configuration-continuity). For
 a FRESH THREAD, select the matrix's task-appropriate GPT-5.6 model and effort.
-For a SAME THREAD, preserve the parent model and effort by default: task-class
-sufficiency alone does not justify mutating an already-running configuration.
+For a SAME THREAD, preserve the requested parent model and effort by default:
+task-class sufficiency alone does not justify intentionally mutating an
+already-running configuration. Record the effective model and effort separately
+when the runtime exposes them, along with any fallback or substitution event.
 For a CHILD TASK, independently select the lowest-cost sufficient model and
 effort for that bounded child and retain the child evidence required by the
 governing workflow.
@@ -144,8 +154,9 @@ When the playbook produces or recommends a complete Codex prompt, precede the
 executable prompt with this plain-text operator metadata:
 
 ```text
-Recommended model: <GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol>
-Recommended reasoning level: <Light | Medium | High>
+Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>
+Recommended model: <FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve requested thread model and observe effective runtime model>
+Recommended reasoning level: <FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve requested thread setting and observe effective runtime setting>
 
 Reason:
 <one concise task-specific explanation>

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -70,6 +70,27 @@ inputs, execution identity, durable result, and authority boundary in the
 attempt evidence when the workflow requires it. A lower-cost child is not an
 independent external reviewer.
 
+### Thread Routing And Configuration Continuity
+
+Apply the shared `FRESH THREAD`, `SAME THREAD`, and `CHILD TASK` vocabulary in
+[`prompts.md`](../prompts.md#thread-routing-and-configuration-continuity). For
+a FRESH THREAD, select the matrix's task-appropriate GPT-5.6 model and effort.
+For a SAME THREAD, preserve the parent model and effort by default: task-class
+sufficiency alone does not justify mutating an already-running configuration.
+For a CHILD TASK, independently select the lowest-cost sufficient model and
+effort for that bounded child and retain the child evidence required by the
+governing workflow.
+
+If a lower-capability SAME THREAD encounters an escalation trigger, delegate
+the unresolved question to a bounded stronger child or make an explicit
+fresh-thread transition where supported; do not silently mutate the parent. If
+a stronger SAME THREAD reaches mechanical follow-up, it may delegate lint,
+hashes, inventories, fixture execution, or evidence packaging to a cheaper
+child without changing the parent. This default preserves context and decision
+continuity, reproducibility, execution provenance, and qualification
+boundaries; it does not claim that an in-thread configuration change necessarily
+harms quality.
+
 For reviews, preserve reviewer independence separately from model capability.
 Keep the selected substantive external reviewer (for example, qualified Claude)
 when the review contract requires it. Internal or mechanical review follows

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -16,11 +16,74 @@ a second copy of those rules.
 - Small tasks stay small when they extend an existing documented seam and avoid
   new abstractions unless clearly required.
 
-## GPT-5.6 Sol Posture
+## GPT-5.6 Model And Reasoning Routing
 
-GPT-5.6 Sol is the flagship GPT-5.6 role for complex reasoning and coding, not
-a universal replacement for lower-cost or latency-sensitive model roles. For
-Codex work using Sol, prefer a compact, outcome-oriented task envelope that:
+Choose the lowest-cost GPT-5.6 model and reasoning effort that preserves the
+confidence required by the bounded task. Model selection and reasoning effort
+are separate configuration decisions: select both deliberately, and do not
+default substantial work to Sol merely because it is long-running.
+
+The current official positioning, checked 2026-08-10, is: Sol for frontier
+capability, Terra for an intelligence/cost balance, and Luna for efficient,
+high-volume, cost-sensitive workloads. GPT-5.6 supports `none`, `low`,
+`medium`, `high`, `xhigh`, and `max` reasoning effort; availability of a
+specific combination remains executor/runtime evidence. This adapter uses
+Light, Medium, and High as portable recommendation classes, mapped to the
+available runtime setting by the operator.
+
+Use task characteristics, not duration, to route: ambiguity, consequence of
+error, repository-context breadth, novelty, architectural judgment,
+reversibility, reviewer role, repetition/volume, and strength of independent
+validation. A short task can still require Sol; a long deterministic task can
+remain on Luna.
+
+| Task class | Default model | Default reasoning | Escalate when | Downgrade/delegate when |
+| --- | --- | --- | --- | --- |
+| Status hydration; Git/Linear checks; inventories/hashes; test or lint invocation; formatting; bounded mechanical verification; evidence-only packaging | Luna | Light | the result is ambiguous, fails unexpectedly, or changes a decision | split data collection and repeatable checks from interpretation |
+| Deterministic file edits or docs cleanup with explicit acceptance criteria; routine PR publication | Luna | Medium | semantics, scope, or validation expectations are unclear | Terra/Sol parent delegates the bounded edit or delivery plumbing |
+| Localized bug fix; routine implementation; normal PR work; CI debugging with a legible failure; frozen-controller test changes; evidence interpretation | Terra | Medium | repeated attempts fail, an invariant cannot be explained, or cross-system scope appears | delegate lint, hashes, fixture runs, and evidence packaging to Luna |
+| Substantial but bounded analysis; moderate synthesis; difficult localized debugging | Terra | High | architecture or authority decisions, conflicting evidence, or unresolved ambiguity remain after bounded investigation | move deterministic execution and verification to Luna |
+| Protocol/design work; architecture synthesis; ambiguous root-cause debugging; high-consequence authority or controller semantics; difficult adversarial review | Sol | High | use `xhigh` or `max` only when representative evidence shows a material reliability gain | delegate established-contract implementation to Terra and mechanical verification to Luna |
+
+Defaults are routing hypotheses, not a guarantee that the lower-cost choice is
+sufficient. Do not downgrade when consequences are high, ambiguity is
+material, validation is weak, work is hard to reverse, or a failure could
+silently corrupt authority or evidence. `xhigh` and `max` are exceptional:
+use them only for a bounded demanding task with an observed quality need; do
+not promote them to a routine default.
+
+### Escalation And Delegation
+
+Escalate a lower-cost task only on evidence: unresolved ambiguity after a
+bounded investigation, an architecture decision, conflicting authorities,
+a high-consequence security/authority decision, repeated failed attempts, an
+unexplained invariant, or a reviewer finding that changes the methodology
+rather than the implementation. Prefer a bounded Sol subtask for that question
+over restarting the entire workflow on Sol when the execution topology allows
+it.
+
+A stronger parent should delegate deterministic, independently checkable work
+downward when supported: Sol architecture to Terra implementation; Sol or Terra
+to Luna for lint, hashes, inventories, fixture execution, and evidence
+packaging. Preserve each child's selected model, reasoning effort, bounded
+inputs, execution identity, durable result, and authority boundary in the
+attempt evidence when the workflow requires it. A lower-cost child is not an
+independent external reviewer.
+
+For reviews, preserve reviewer independence separately from model capability.
+Keep the selected substantive external reviewer (for example, qualified Claude)
+when the review contract requires it. Internal or mechanical review follows
+this matrix; Sol is not automatic for a narrow, deterministic fallback.
+
+The CAK-106 experience supports this split as observed workflow evidence, not
+a benchmark: protocol ambiguity, authority architecture, controller semantics,
+and architecture synthesis justified stronger reasoning, while repeated focused
+validation, hashes/inventories, Git checks, fixture execution, evidence
+packaging, and review-follow-up plumbing were plausible Terra or Luna work. Do
+not infer quantitative savings without measured usage evidence.
+
+For a Codex task using any selected model, prefer a compact, outcome-oriented
+task envelope that:
 
 - names the current work layer for a long task: research, design,
   implementation, review, or coordination
@@ -54,12 +117,13 @@ caching, and multi-agent execution outside the baseline migration. Evaluate
 each optional feature separately only when the workload shape and measured
 results justify it. Preserve behavior and settings before optimizing.
 
-### Reasoning-Level Recommendations
+### Operator Metadata And Reasoning Recommendations
 
 When the playbook produces or recommends a complete Codex prompt, precede the
 executable prompt with this plain-text operator metadata:
 
 ```text
+Recommended model: <GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol>
 Recommended reasoning level: <Light | Medium | High>
 
 Reason:
@@ -71,10 +135,11 @@ immediately afterward. When rendering Markdown, separate the metadata and
 prompt body into consecutive code blocks with no intervening prose so the
 operator can copy only the executable prompt.
 
-Treat Light, Medium, and High as practical recommendation categories when the
-execution surface does not provide more specific established terminology. The
-recommendation is advisory, not a guarantee. Choose it from the bounded task
-being handed off:
+This metadata is operator guidance, not task authority. The recommendation is
+advisory, not a guarantee. Choose the model and effort from the bounded task
+being handed off, using the routing matrix above. Light, Medium, and High are
+practical recommendation categories when the execution surface does not
+provide more specific established terminology:
 
 - High usually fits workflow or system architecture, ambiguous repository-wide
   design, synthesis across conflicting evidence, major refactoring with broad
@@ -119,7 +184,8 @@ setting.
 
 This posture is derived from OpenAI's current
 [GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
-and [GPT-5.6 Sol model reference](https://developers.openai.com/api/docs/models/gpt-5.6-sol).
+and [model selection reference](https://developers.openai.com/api/docs/models),
+checked 2026-08-10.
 
 ## Prompt-Contract Mapping
 

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -201,6 +201,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             "review-packet.md": "prompt-contracts.md",
             "feature-lifecycle.md": "prompt-contracts.md",
             "tool-adapters/codex.md": "prompt-contracts.md",
+            "tool-adapters/claude.md": "prompt-contracts.md",
             "tool-adapters/copilot.md": "prompt-contracts.md",
         }
         for relative_path, link in required_references.items():
@@ -222,6 +223,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             "review-packet.md",
             "feature-lifecycle.md",
             "tool-adapters/codex.md",
+            "tool-adapters/claude.md",
             "tool-adapters/copilot.md",
         )
         link_pattern = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
@@ -235,6 +237,22 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
                     continue
                 resolved = (document.parent / path_text).resolve()
                 self.assertTrue(resolved.exists(), f"{relative_path}: {target}")
+
+    def test_model_routing_metadata_and_vendor_boundaries(self):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")
+        claude = (DOCS / "tool-adapters/claude.md").read_text(encoding="utf-8")
+
+        self.assertIn("Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]", prompts)
+        self.assertIn("Preserve current thread model", prompts)
+        self.assertIn("Preserve current thread setting", prompts)
+        self.assertIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", prompts)
+        self.assertIn("For a SAME THREAD, preserve the parent model and effort", codex)
+        self.assertIn("`haiku`, `sonnet`, and `opus` aliases", claude)
+        self.assertIn("Thinking And Effort", claude)
+        self.assertIn("Reviewer independence is separate", claude)
+        for forbidden_equivalence in ("Haiku = Luna", "Sonnet = Terra", "Opus = Sol"):
+            self.assertNotIn(forbidden_equivalence, claude)
 
 
 class PromptContractCanonicalizationVectorTests(unittest.TestCase):

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -244,15 +244,19 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         claude = (DOCS / "tool-adapters/claude.md").read_text(encoding="utf-8")
 
         self.assertIn("Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]", prompts)
-        self.assertIn("Preserve current thread model", prompts)
-        self.assertIn("Preserve current thread setting", prompts)
-        self.assertIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", prompts)
-        self.assertIn("For a SAME THREAD, preserve the parent model and effort", codex)
-        self.assertIn("`haiku`, `sonnet`, and `opus` aliases", claude)
+        self.assertIn("Preserve requested thread model", prompts)
+        self.assertIn("observe effective runtime model", prompts)
+        self.assertNotIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", prompts)
+        self.assertIn("Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>", codex)
+        self.assertIn("effective model and effort separately", codex)
+        self.assertIn("`haiku`, `sonnet`, `opus`, and `fable` aliases", claude)
         self.assertIn("Thinking And Effort", claude)
+        self.assertIn("Requested configuration and effective runtime configuration", claude)
         self.assertIn("Reviewer independence is separate", claude)
-        for forbidden_equivalence in ("Haiku = Luna", "Sonnet = Terra", "Opus = Sol"):
-            self.assertNotIn(forbidden_equivalence, claude)
+        self.assertIn("Do not infer a mapping from OpenAI", claude)
+        reviewer = (DOCS / "external-ai-reviewer.md").read_text(encoding="utf-8")
+        self.assertIn("A child task spawned by the reviewed party", reviewer)
+        self.assertIn("the external-review role", reviewer)
 
 
 class PromptContractCanonicalizationVectorTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add independently sourced OpenAI/Codex routing: Luna for deterministic externally checkable work, Terra for normal engineering, and Sol for material ambiguity, architecture, authority, and difficult adversarial review
- add independently sourced Claude Code routing: haiku for mechanical work, sonnet for routine substantive review, opus for high-consequence review, and constrained fable escalation for the hardest long-running work where available
- separate model selection from OpenAI reasoning effort and Anthropic thinking/effort; retain no cross-vendor tier-equivalence claim
- establish FRESH THREAD, SAME THREAD, and CHILD TASK routing; SAME THREAD preserves requested configuration while observing effective runtime configuration and substitutions
- record requested/effective configuration and runtime fallback or substitution events when exposed; a child spawned by the reviewed party does not manufacture external-review independence
- make generic prompt metadata vendor-neutral; concrete model choices remain in executor adapters
- retain CAK-106 only as observational workflow evidence

## Official-source basis
- verified current OpenAI GPT-5.6 model, reasoning-effort, Pro-mode, and models documentation on 2026-08-10
- verified current Anthropic Claude Code model configuration, model selection, model overview, thinking, and fallback documentation on 2026-08-10

## Review disposition
- initial substantive Claude review: ACCEPT WITH CHANGES
- HIGH and MEDIUM decision-relevant findings were corrected
- focused Claude delta re-review: ACCEPT
- focused reviewer result: NO DECISION-RELEVANT BLOCKERS
- remaining LOW findings were corrected locally; no additional external re-review was required by the convergence rule

## Prompt-size check
- recurring direct implementation template: 3151 to 3494 bytes, +343 bytes, +10.9 percent
- recurring orchestration handoff template: 3983 to 4326 bytes, +343 bytes, +8.6 percent
- recurring PR review template: 2368 to 2711 bytes, +343 bytes, +14.5 percent
- the repeated impact is SMALL: routing matrices and vendor documentation remain separately retrieved adapter doctrine, not executable downstream prompt text

## Validation
- env TMPDIR=/Users/keith/src/ctrl-alt-keith/ai-workflow-playbook make check — passed (49 tests; temporary path is outside .worktrees because one scanner test intentionally ignores worktree paths)
- python3 -m unittest tests.test_prompt_contract_semantics -v — passed (14 tests)
- make authoritative-source-check — passed
- git diff --check — passed