### PR TITLE
Clarify operator metadata prompt boundary

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -56,6 +56,54 @@ not prove execution identity. A runtime change is not automatically fatal, but
 requalify, escalate, or stop when it fails a minimum-capability or exact-model
 requirement.
 
+## Operator Metadata And Executable Prompts
+
+Generated task prompts serve two audiences:
+
+- **Operator metadata** is for the human/operator or an orchestration layer
+  that instantiates the task. It may state thread routing, a recommended model
+  and reasoning/thinking setting, a selection reason, and other runtime
+  guidance the downstream agent cannot control.
+- **Executable prompt** is for the downstream execution agent. It contains
+  only task authority, repository and workflow instructions, scope,
+  constraints, decision rules, validation, stop boundaries, and information
+  the agent can observe, control, or must use to make a task decision.
+
+Copy or deliver only the executable prompt to the downstream agent unless its
+execution surface separately consumes metadata. Operator metadata must never
+be semantically required by the task body: removing it must leave one complete,
+actionable prompt.
+
+Use this drafting test for every executable instruction: include it only when
+the downstream agent can observe it, control it, or must use it to make a task
+decision. Thread creation, parent-model selection, reasoning configuration,
+subscription or usage-budget considerations, and instructions to preserve an
+already-created parent's configuration normally belong only in operator
+metadata. They are immutable runtime facts, not task authority.
+
+Apply the rule to routing as follows:
+
+- For a `FRESH THREAD`, the operator selects the thread, model, and
+  reasoning/thinking setting before prompt delivery. The executable body does
+  not repeat those selections.
+- For a `SAME THREAD`, operator metadata may preserve current configuration;
+  the executable body states only task-relevant continuity, such as preserving
+  repository authority, durable state, or the current branch/PR.
+- For a `CHILD TASK`, the executable body may authorize bounded delegation
+  only where the active executor can perform it. Keep vendor model matrices,
+  effort mapping, and selection rationale in the adapter or orchestration
+  configuration rather than copying them into every child prompt.
+
+This boundary does not remove runtime evidence that the task itself requires.
+An executable prompt may require recording or verifying requested/effective
+runtime model evidence, detecting a disallowed substitution, or writing an
+execution receipt when that information is part of the task's validation or
+qualification boundary.
+
+When a complete prompt materially changes, emit a complete replacement
+operator-metadata block and executable prompt. Do not emit a partial prompt
+patch that requires the operator to splice text into an older prompt.
+
 ## Prompt Contract Identity
 
 For material execution that may be reviewed, recovered, or replayed, apply the
@@ -118,8 +166,9 @@ Apply the model-and-reasoning routing guidance in
 [`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
 to the bounded task. The first block below is operator metadata for the human
 or operator. It is not part of the executable prompt and should not be copied
-into the downstream agent. Copy or deliver only the second block. Emit the two
-blocks consecutively with no intervening heading or explanation.
+into the downstream agent. Copy or deliver only the second block. The second
+block is complete without the metadata. Emit the two blocks consecutively with
+no intervening heading or explanation.
 
 ```text
 Operator metadata (do not include in prompt)

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -231,7 +231,12 @@ Reason:
 
 This metadata is operator guidance, not task authority. Do not recommend a
 model, effort, or child configuration that the current Claude surface cannot
-support.
+support. Interpret FRESH/SAME routing before prompt delivery: do not tell the
+downstream Claude task to change or preserve parent configuration when that
+surface does not expose the control. The executable task body must be complete
+without metadata and may authorize child dispatch only where that Claude
+surface supports it. Keep task-required requested/effective runtime evidence in
+the executable body when it is a validation or qualification requirement.
 
 ## Reasoning And Model Configuration
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -169,10 +169,16 @@ prompt body into consecutive code blocks with no intervening prose so the
 operator can copy only the executable prompt.
 
 This metadata is operator guidance, not task authority. The recommendation is
-advisory, not a guarantee. Choose the model and effort from the bounded task
-being handed off, using the routing matrix above. Light, Medium, and High are
-practical recommendation categories when the execution surface does not
-provide more specific established terminology:
+advisory, not a guarantee. Interpret FRESH/SAME routing before prompt delivery:
+do not tell downstream Codex to change or preserve its parent model or
+reasoning level when it lacks that control. The executable task body remains
+complete without metadata and includes child-dispatch instructions only when
+the active Codex surface can perform that bounded delegation. Runtime-model
+facts may remain in the task body when the task must record or validate them.
+Choose the model and effort from the bounded task being handed off, using the
+routing matrix above. Light, Medium, and High are practical recommendation
+categories when the execution surface does not provide more specific
+established terminology:
 
 - High usually fits workflow or system architecture, ambiguous repository-wide
   design, synthesis across conflicting evidence, major refactoring with broad

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -258,6 +258,25 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         self.assertIn("A child task spawned by the reviewed party", reviewer)
         self.assertIn("the external-review role", reviewer)
 
+    def test_operator_metadata_stays_outside_complete_executable_prompts(self):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")
+        claude = (DOCS / "tool-adapters/claude.md").read_text(encoding="utf-8")
+        normalized_prompts = " ".join(prompts.split())
+        normalized_codex = " ".join(codex.split())
+        normalized_claude = " ".join(claude.split())
+
+        self.assertIn("Generated task prompts serve two audiences", prompts)
+        self.assertIn("Copy or deliver only the executable prompt", prompts)
+        self.assertIn("can observe it, control it, or must use it", normalized_prompts)
+        self.assertIn("must never be semantically required", normalized_prompts)
+        self.assertIn("complete replacement", prompts)
+        self.assertIn("runtime evidence that the task itself requires", prompts)
+        self.assertIn("do not tell downstream Codex", normalized_codex)
+        self.assertIn("child-dispatch instructions only when", normalized_codex)
+        self.assertIn("does not expose the control", normalized_claude)
+        self.assertIn("requested/effective runtime evidence", normalized_claude)
+
 
 class PromptContractCanonicalizationVectorTests(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- separates operator metadata from the executable prompt with an explicit two-audience model
- adds the actionable-content drafting test and FRESH/SAME/CHILD copy boundaries
- clarifies Codex and Claude handling while preserving vendor routing matrices and task-required runtime evidence
- adds prompt-contract regression coverage

## Prompt-size impact
The three representative executable template bodies are unchanged: 2,373, 2,399, and 1,510 bytes (each ±0). The prior templates already kept recurring operator configuration outside those bodies; this PR makes that boundary explicit rather than deleting task authority.

## Validation
- `make check` (50 tests; Markdown lint: 0 issues)
- `make authoritative-source-check`
- `git diff --check`
- focused prompt-contract tests (15 tests)

## Independent review
A bounded Claude review could not start because its OAuth session had expired. A separate read-only Codex review was attempted twice, but its runtime cache/result channel failed before a verdict; no review verdict is claimed.