### PR TITLE
docs: add ChatGPT/Work executor adapter

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -125,8 +125,9 @@ scoped analysis, review, planning, advice, prompting, or mutation.
 - `docs/core-model.md` -> general operating principles and roles
 - the target repository's `AGENTS.md` -> repo-local execution authority
 - `docs/tool-adapters/<executor>.md` -> executor-specific deltas when a matching
-  adapter exists; Codex runs must read `docs/tool-adapters/codex.md` and Claude
-  runs must read `docs/tool-adapters/claude.md`
+  adapter exists; Codex runs must read `docs/tool-adapters/codex.md`, Claude
+  runs must read `docs/tool-adapters/claude.md`, and repository-scoped
+  ChatGPT/Work runs must read `docs/tool-adapters/chatgpt.md`
 - `docs/engineering-baseline.md` -> foundational engineering expectations
 - `docs/source-first-retrieval.md` -> repository triggers, retrieval ordering,
   verification gates, and recovery
@@ -170,7 +171,8 @@ Apply overlapping repository instructions in this order:
 2. The target repository's repo-local `AGENTS.md` and other repo-local policy
    for repository-specific execution details.
 3. The matching executor adapter, such as `docs/tool-adapters/codex.md` for
-   Codex-specific behavior.
+   Codex-specific behavior or `docs/tool-adapters/chatgpt.md` for
+   ChatGPT/Work-specific behavior.
 4. Shared Playbook docs as reusable workflow defaults.
 
 Repo-local instructions are authoritative for allowed tools, Git usage,
@@ -206,7 +208,8 @@ recommendations, and "what changed?" or "what next?" requests:
 2. Read the target repository's repo-local `AGENTS.md`.
 3. Apply the matching executor adapter. Codex runs must apply
    `docs/tool-adapters/codex.md`; Claude runs must apply
-   `docs/tool-adapters/claude.md`.
+   `docs/tool-adapters/claude.md`; repository-scoped ChatGPT/Work runs must
+   apply `docs/tool-adapters/chatgpt.md`.
 4. Identify the repository or workspace's primary purpose.
 5. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.
@@ -243,6 +246,13 @@ establish sufficiency.
   leaves repository work or the human explicitly requests a different artifact
   style. Moving to another repository requires applying that repository's
   startup contract before assuming its native conventions.
+- Repository operating-mode persistence does not freeze the required source
+  set. When a task materially changes interaction mode, artifact type,
+  workflow, authoritative-source requirements, execution locality, or
+  authority boundary, re-evaluate activation routing for the current task and
+  retrieve newly required sources before answering, planning, drafting, or
+  acting. Reuse still-current verified sources; do not replay unchanged
+  doctrine or hydrate unrelated documents.
 - `docs/prompt-contracts.md` and its versioned machine-readable companions own
   shared prompt-contract meaning; implementing repositories own operational
   schemas, hydration, rendering, receipts, and validation code.

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -1,0 +1,104 @@
+# ChatGPT/Work Adapter
+
+This adapter projects the Playbook onto repository-scoped ChatGPT and Work
+use. It begins after repository work has been activated; ordinary conceptual
+Chat remains outside repository startup. Shared operating rules remain owned
+by [`start-here.md`](../start-here.md) and
+[`core-model.md`](../core-model.md).
+
+## Repository-bootstrap boundary
+
+Project instructions are bootstrap and routing input, not a second copy of the
+Playbook. After the CAK-108 project bootstrap has routed repository work to the
+current [`start-here.md`](../start-here.md), apply this adapter with the
+repository floor and the task-activated guidance.
+
+## Project and conversation context
+
+Project instructions, project or uploaded files, conversation history, memory,
+and prior hydration can help route or continue work, but do not establish the
+current source boundary. Generated artifacts and Work state are derived
+outputs; connected-app availability is runtime capability evidence; a
+connector result is evidence only for its observed operation. Classify and use
+each surface through [`core-model.md`](../core-model.md#authority-follows-the-question),
+[`source-first-retrieval.md`](../source-first-retrieval.md), and, for material
+prompts, [`prompt-contracts.md`](../prompt-contracts.md).
+
+## Persistent-context activation
+
+Repository mode may continue across Chat and Work turns. For an ordinary
+repository follow-up whose task shape remains sufficient, reuse still-current
+verified sources. If the task materially changes interaction mode, artifact,
+workflow, source need, execution locality, or authority boundary, re-run the
+current activation route before responding, planning, drafting, or acting.
+Retrieve newly activated owners without replaying unchanged doctrine or
+hydrating unrelated documents. This is the persistent-context projection of
+the [activation-sufficiency invariant](../start-here.md#required-repository-invariants);
+[`repo-readiness.md`](../repo-readiness.md) owns interaction-mode selection.
+
+## Chat, Work, and execution locality
+
+Chat and Work are task-shape and capability surfaces under this one adapter,
+not separate authority contracts. A transition between them preserves
+repository mode unless the task's source or boundary needs change. When Work
+moves between local and cloud execution, revalidate the required sources,
+working location, tools, credentials, acting identity, and mutation surface
+that materially changed. Use [`repo-readiness.md`](../repo-readiness.md) for
+repository execution posture and
+[`maintenance-automations.md`](../maintenance-automations.md) when locality or
+unattended-work guidance is activated.
+
+## Connected apps, approvals, and consequential actions
+
+An installed or authenticated app, available action, or product approval
+setting describes capability or permission behavior; it does not expand the
+human-authorized task. Keep consequential writes within the authorized scope
+and re-observe their result before reporting the intended effect. The shared
+authority, decision-boundary, and re-observation rules remain in
+[`core-model.md`](../core-model.md), while connector availability is governed
+by [`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence).
+
+## Prompt and downstream-context projection
+
+When the task becomes prompt authoring, activate the current prompt and
+orchestration owners rather than reproducing their doctrine here. Project or
+controller context does not prove a downstream prompt has the same sources or
+evidence. Use [`prompts.md`](../prompts.md),
+[`prompt-contracts.md`](../prompt-contracts.md), and
+[`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md) for
+the applicable prompt and downstream-context contract.
+
+## Generated artifacts
+
+Creating a ChatGPT or Work artifact does not make it current authoritative
+state or grant publication, sharing, overwrite, or adoption authority. Apply
+the derived-artifact and consequential-action boundaries in
+[`core-model.md`](../core-model.md) and the material-artifact contract in
+[`prompt-contracts.md`](../prompt-contracts.md) when activated.
+
+## Scheduled and unattended execution
+
+Scheduled or unattended ChatGPT/Work must project the current automation,
+source, and locality rules for each run. A standalone run cannot assume an
+originating conversation; an in-chat run may use conversation as context but
+not as proof of current canonical or provider state. Do not depend on an
+interactive approval or unavailable local state. The governing owner is
+[`maintenance-automations.md`](../maintenance-automations.md), with current
+retrieval in [`source-first-retrieval.md`](../source-first-retrieval.md).
+
+## Recovery after activation drift
+
+If persistent context proves under-hydrated, stop continuity-based drafting or
+action and re-enter current canonical routing. Retrieve the missing activated
+owners, revalidate mutable sources, and replace or correct the affected
+artifact as a whole before resuming. This is a ChatGPT/Work projection of
+[`source-first-retrieval.md`](../source-first-retrieval.md) and, for prompts,
+[`prompts.md`](../prompts.md); it is not symptom-by-symptom repair from
+conversation memory.
+
+## Evidence and provider-reference boundary
+
+This adapter defines Playbook behavior, not a provider guarantee about how
+ChatGPT context, memory, permissions, or Work execution operates. Re-check
+provider behavior through authoritative current evidence when a task depends
+on it; keep observed runtime behavior separate from that evidence.

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+
+class ChatGPTAdapterTests(unittest.TestCase):
+    def test_start_here_activates_chatgpt_work_and_rechecks_sources(self):
+        contents = (DOCS / "start-here.md").read_text(encoding="utf-8")
+
+        self.assertIn("ChatGPT/Work runs must read", contents)
+        self.assertIn("docs/tool-adapters/chatgpt.md", contents)
+        self.assertIn("Repository operating-mode persistence does not freeze", contents)
+        self.assertIn("re-evaluate activation routing", contents)
+        self.assertIn("Reuse still-current verified sources", contents)
+
+    def test_adapter_projects_boundaries_to_canonical_owners(self):
+        contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
+
+        for heading in (
+            "Repository-bootstrap boundary",
+            "Project and conversation context",
+            "Persistent-context activation",
+            "Chat, Work, and execution locality",
+            "Connected apps, approvals, and consequential actions",
+            "Prompt and downstream-context projection",
+            "Generated artifacts",
+            "Scheduled and unattended execution",
+            "Recovery after activation drift",
+            "Evidence and provider-reference boundary",
+        ):
+            self.assertIn(heading, contents)
+
+        for owner in (
+            "start-here.md",
+            "core-model.md",
+            "source-first-retrieval.md",
+            "repo-readiness.md",
+            "prompts.md",
+            "prompt-contracts.md",
+            "orchestration-and-parallelism.md",
+            "maintenance-automations.md",
+        ):
+            self.assertIn(owner, contents)
+
+        self.assertIn("not separate authority contracts", contents)
+        self.assertIn(
+            "does not expand the human-authorized task", " ".join(contents.split())
+        )
+        self.assertIn("not symptom-by-symptom repair", contents)

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -203,6 +203,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             "tool-adapters/codex.md": "prompt-contracts.md",
             "tool-adapters/claude.md": "prompt-contracts.md",
             "tool-adapters/copilot.md": "prompt-contracts.md",
+            "tool-adapters/chatgpt.md": "prompt-contracts.md",
         }
         for relative_path, link in required_references.items():
             contents = (DOCS / relative_path).read_text(encoding="utf-8")
@@ -225,6 +226,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             "tool-adapters/codex.md",
             "tool-adapters/claude.md",
             "tool-adapters/copilot.md",
+            "tool-adapters/chatgpt.md",
         )
         link_pattern = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
         for relative_path in affected_documents:


### PR DESCRIPTION
## Summary

- add one shared ChatGPT/Work executor adapter for repository-scoped work
- activate the adapter wherever matching executors are required and add the shared activation-sufficiency invariant
- add focused regression coverage for adapter activation, owner routing, prompt-contract links, and local links

## Rationale

Implements CAK-109's approved recommendation: persistent repository mode may continue across Chat and Work, but a material task transition must re-evaluate activation routing and retrieve newly required sources without replaying unrelated doctrine.

## Validation

- `make check` — passed (Markdown lint; 55 unit tests)

## Residual limitations

The adapter deliberately does not claim ChatGPT automatically re-evaluates repository routing, or that product approval syntax can encode every narrow task boundary. Provider/runtime behavior remains subject to current authoritative evidence.

References CAK-109.