### PR TITLE
docs: clarify Codex shell-only execution

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -431,6 +431,22 @@ Codex-specific application:
   Keep the wrapped operation narrow enough for review and approval surfaces to
   see the intended action.
 
+### Shell-Only Execution Surfaces
+
+Some Codex execution surfaces expose a shell command string even when Codex
+selected a simple direct operation. A fixed non-login runner such as `zsh -c`
+may therefore appear in executor logs. This transport detail does not authorize
+agent-authored shell wrappers, weaken command-form preflight, or grant an
+approval exemption.
+
+Continue to select the narrowest direct operation and disable login-shell
+semantics where the surface exposes that setting. If a static, contained
+filesystem operation still prompts because the surface exposes no native or
+argv-style primitive, treat that as a runtime approval limitation. Do not
+compensate by adding a broad `mkdir` or `mkdir -p` prefix allow rule: prefix
+matching cannot establish containment for every operand or resolved path.
+Preserve approval or fail closed, and report the runtime limitation.
+
 ### Child-Process Login Identity
 
 When Codex launches a child CLI whose authentication or runtime behavior

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -295,6 +295,16 @@ Before repo-scoped work:
   provides the required capability. Direct APIs and CLIs remain appropriate
   for verified connector gaps, repository-local workflows, or explicit
   repository policy.
+- For GitHub hydration and ordinary source-first retrieval, treat `gh api` as
+  a direct-service-API fallback rather than the default retrieval primitive.
+  Do not select it only because the REST endpoint is flexible or familiar. Use
+  an available GitHub connector when it provides the required source, or the
+  narrowest high-level `gh` command when that is the appropriate direct
+  repository CLI. If neither provides the required capability, keep `gh api`
+  read-only and scoped to the required state unless the current task separately
+  authorizes mutation. This avoids unnecessary approval friction; it does not
+  create a human approval gate or prohibit `gh api` when it is the narrowest
+  available way to retrieve authoritative state.
 - For policy-sensitive changes, apply the repo-family alignment check in
   [`repo-readiness.md`](../repo-readiness.md#repo-family-policy-alignment)
   before implementation.

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -54,3 +54,14 @@ class CodexAdapterTests(unittest.TestCase):
         self.assertIn("Reconciliation remains controller-owned", self.contents)
         self.assertIn("orchestration-and-parallelism.md", self.contents)
         self.assertNotIn("Reconciliation And Merge Sequence", self.contents)
+
+    def test_shell_only_transport_preserves_runtime_approval_boundary(self):
+        for phrase in (
+            "Shell-Only Execution Surfaces",
+            "fixed non-login runner such as `zsh -c`",
+            "does not authorize agent-authored shell wrappers",
+            "runtime approval limitation",
+            "broad `mkdir` or `mkdir -p` prefix allow rule",
+            "containment for every operand or resolved path",
+        ):
+            self.assertIn(phrase, self.contents)

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -65,3 +65,16 @@ class CodexAdapterTests(unittest.TestCase):
             "containment for every operand or resolved path",
         ):
             self.assertIn(phrase, self.contents)
+
+    def test_github_hydration_uses_gh_api_only_for_capability_gaps(self):
+        for phrase in (
+            "GitHub hydration and ordinary source-first retrieval",
+            "`gh api` as a direct-service-API fallback",
+            "REST endpoint is flexible or familiar",
+            "available GitHub connector",
+            "narrowest high-level `gh` command",
+            "`gh api` read-only and scoped to the required state",
+            "does not create a human approval gate",
+            "narrowest available way to retrieve authoritative state",
+        ):
+            self.assertIn(phrase, self.contents)


### PR DESCRIPTION
## Summary

- clarify that some Codex surfaces transport direct intent through a fixed
  non-login shell runner
- preserve the distinction between agent-authored wrappers and runtime transport
- prohibit unsafe broad `mkdir` prefix allow rules because they cannot prove
  operand or resolved-path containment
- classify `gh api` as a read-only, capability-gap fallback during GitHub
  hydration and ordinary source-first retrieval
- prefer an available connector or a narrow high-level `gh` operation when it
  satisfies the required retrieval

## Validation

- `make check`
