### PR TITLE
Harden automated Claude reviewer context

### DIFF
--- a/docs/external-ai-reviewer.md
+++ b/docs/external-ai-reviewer.md
@@ -60,6 +60,22 @@ can complete the review or the human authority explicitly approves a revised
 review plan. Do not silently substitute another provider, relabel substitute
 output as the selected review, or omit the failure from provenance.
 
+Before an expensive Claude review, run its bounded effective-user auth
+preflight. A successful preflight only establishes authentication for that
+process context; it is not evidence about candidate quality or a guarantee for
+the later review. On a preflight or review failure, preserve candidate and
+review state unchanged, record only non-secret diagnostics, stop automated
+retries, and do not infer `REJECT`, alter auth/session files, or try another
+identity-context guess after the validated context is in effect.
+
+When provider output reliably identifies `AUTH_OAUTH_TOKEN_EXPIRED_401` or
+`AUTH_SAVED_LOGIN_REFRESH_REJECTED`, stop at `REVIEWER INFRASTRUCTURE FAILURE
+— OPERATOR REAUTHENTICATION REQUIRED` and require interactive reauthentication
+before rerunning the unchanged preflight and review. Preserve documented
+revoked/invalid-credential classes separately; unknown auth-shaped output must
+fail closed without a conjectured provider cause. Neither kind of failure is
+candidate evidence or grounds to substitute another reviewer.
+
 Use [`review-packet.md#independent-review-findings-and-re-review`](review-packet.md#independent-review-findings-and-re-review)
 for finding disposition and the decision between no re-review, focused
 re-review, and a fresh proposal with full review. Do not duplicate those

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -628,6 +628,50 @@ contents do not matter after the command finishes.
 Direct Claude Code execution from Codex under `workspace-write` has a narrower
 qualified runtime contract in addition to the general child-process guidance:
 
+For an automated, non-interactive Claude review, use the repository's
+[`claude-review`](../../scripts/claude-review) launcher rather than a hand-built
+environment assignment. It derives the effective operating-system account,
+normalizes `USER`, `LOGNAME`, and `HOME` for the Claude child, reads the review
+prompt from standard input rather than argv, and emits a bounded, redacted
+diagnostic record. Pass the existing review flags unchanged after `--`; the
+launcher does not select a model, tools, permissions, or reviewer role.
+
+Before an expensive independent review, run the same launcher with
+`--auth-preflight`. It reuses the effective-user environment and executable
+resolution, sends only the fixed `CLAUDE_AUTH_OK` prompt on standard input,
+disables all Claude tools, passes `--no-session-persistence`, and runs from a
+fresh temporary directory. It may retain the selected model and effort, but it
+is not substantive review and does not read repository, candidate, or held-out
+content.
+For example:
+
+```text
+scripts/claude-review --auth-preflight -- --model opus --effort high
+```
+
+`AUTH_PREFLIGHT_OK` means authentication worked for that process context only;
+it does not guarantee that a later review cannot expire. Do not start the
+review after a preflight failure.
+
+The launcher preserves distinct documented failure classes when provider output
+supports them: `AUTH_OAUTH_TOKEN_EXPIRED_401`,
+`AUTH_SAVED_LOGIN_REFRESH_REJECTED`, `AUTH_OAUTH_TOKEN_REVOKED`, and
+`AUTH_INVALID_CREDENTIALS`. An auth-shaped but unsupported variant is
+`AUTH_UNKNOWN_FAIL_CLOSED`; do not invent a provider cause. All auth failures
+preserve candidate bytes and review state, retain only non-secret diagnostics,
+stop automated retries, do not mutate auth/session files, and never emit
+`REJECT`. `AUTH_OAUTH_TOKEN_EXPIRED_401` and
+`AUTH_SAVED_LOGIN_REFRESH_REJECTED` require interactive operator
+reauthentication before rerunning the unchanged preflight and review. The
+remaining documented classes require the matching supported operator diagnosis
+in the same environment; do not substitute another reviewer.
+
+Anthropic's [authentication documentation](https://code.claude.com/docs/en/authentication)
+describes `claude setup-token` as a separate long-lived automation credential
+option. This reviewer path neither provisions nor adopts it. Any
+future use requires separate credential-management authority, a supported
+secret store, rotation/revocation ownership, and redacted receipts.
+
 - Keep `USER` and `LOGNAME` consistent with the effective user for the Claude
   child. On the qualification host, normalizing those variables restored
   Claude authentication; the precise authentication mechanism was not

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Launch a non-interactive Claude review with safe, diagnostic context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import pwd
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+AUTH_FAILURE_EXIT = 78
+REVIEWER_FAILURE_EXIT = 70
+MAX_ERROR_CHARS = 1_000
+AUTH_PREFLIGHT_PROMPT = b"Reply exactly: CLAUDE_AUTH_OK\n"
+AUTH_PREFLIGHT_RESPONSE = "CLAUDE_AUTH_OK"
+OAUTH_REAUTHENTICATION_DISPOSITION = (
+    "REVIEWER INFRASTRUCTURE FAILURE — OPERATOR REAUTHENTICATION REQUIRED"
+)
+OAUTH_REAUTHENTICATION_MESSAGE = (
+    "Claude reviewer authentication has expired. The validated user-context invocation "
+    "is already in effect, so this is not an environment-context mismatch. Please "
+    "reauthenticate Claude interactively, then rerun this task. Candidate bytes and "
+    "review state remain unchanged."
+)
+
+
+def bounded_redacted(value: str) -> str:
+    """Keep failure evidence useful without retaining credential values."""
+    import re
+
+    redacted = re.sub(
+        r"(?i)\bauthorization\b\s*[:=]\s*(?:bearer\s+)?\S+",
+        "authorization=[REDACTED]",
+        value,
+    )
+    redacted = re.sub(
+        r"(?i)\b(bearer|token|api[_ -]?key|cookie)\b\s*[:=]\s*\S+",
+        r"\1=[REDACTED]",
+        redacted,
+    )
+    redacted = re.sub(
+        r'''(?i)[A-Za-z_]*(?:auth|cookie|credential|key|secret|token)[A-Za-z_]*["']?\s*[:=]\s*["']?[^\s,"'}]+''',
+        "[REDACTED]",
+        redacted,
+    )
+    redacted = re.sub(r"\b(?:sk|gho|ghp)[_-][A-Za-z0-9_=-]+", "[REDACTED]", redacted)
+    return redacted[:MAX_ERROR_CHARS]
+
+
+def documented_auth_failure_classification(output: str) -> str | None:
+    normalized = output.lower()
+    if "failed to authenticate: oauth session expired and could not be refreshed" in normalized:
+        return "AUTH_SAVED_LOGIN_REFRESH_REJECTED"
+    if "oauth token revoked" in normalized:
+        return "AUTH_OAUTH_TOKEN_REVOKED"
+    if "api error: 401 invalid authentication credentials" in normalized:
+        return "AUTH_INVALID_CREDENTIALS"
+    if "api error: 401 oauth access token has expired" in normalized:
+        return "AUTH_OAUTH_TOKEN_EXPIRED_401"
+    return None
+
+
+def json_error_auth_failure_classification(output: str) -> str | None:
+    records = [output]
+    if "\n" in output:
+        records = [line for line in output.splitlines() if line.lstrip().startswith("{")]
+    for encoded_record in records:
+        try:
+            record = json.loads(encoded_record)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        is_error = record.get("is_error") is True or record.get("subtype") == "error_during_execution"
+        if is_error:
+            classification = documented_auth_failure_classification(json.dumps(record))
+            if classification is not None:
+                return classification
+    return None
+
+
+def terminal_auth_failure_classification(output: str, exit_code: int) -> str | None:
+    if exit_code == 0:
+        return None
+    structured = json_error_auth_failure_classification(output)
+    if structured is not None:
+        return structured
+    lines = output.strip().splitlines()
+    if not lines:
+        return None
+    for line in lines:
+        terminal_line = line.strip()
+        if terminal_line.startswith("Failed to authenticate.") or terminal_line.startswith(
+            "Failed to authenticate: OAuth session expired and could not be refreshed"
+        ):
+            return documented_auth_failure_classification(terminal_line)
+    return None
+
+
+def stderr_auth_failure_classification(stderr: str) -> str | None:
+    for line in stderr.splitlines():
+        classification = documented_auth_failure_classification(line)
+        if classification is not None:
+            return classification
+    return None
+
+
+def is_auth_shaped_failure(output: str) -> bool:
+    normalized = output.lower()
+    return "oauth" in normalized or "authentication" in normalized or "failed to authenticate" in normalized
+
+
+def classify_failure(stderr: str, stdout: str, exit_code: int, *, preflight: bool = False) -> str | None:
+    classification = json_error_auth_failure_classification(stdout)
+    if classification is not None:
+        return classification
+    if preflight and exit_code != 0:
+        for stream in (stdout, stderr):
+            classification = documented_auth_failure_classification(stream)
+            if classification is not None:
+                return classification
+    classification = terminal_auth_failure_classification(stdout, exit_code)
+    if classification is None and exit_code != 0 and not stdout.strip():
+        classification = stderr_auth_failure_classification(stderr)
+    if classification is not None:
+        return classification
+    if exit_code != 0 and any(
+        marker in stderr.lower()
+        for marker in ("session environment", ".claude/session-env", "home directory")
+    ):
+        return "RUNTIME_LOGIN_CONTEXT_MISMATCH"
+    if preflight:
+        if is_auth_shaped_failure(stdout) or is_auth_shaped_failure(stderr):
+            return "AUTH_UNKNOWN_FAIL_CLOSED"
+        if exit_code != 0 or stdout.strip() != AUTH_PREFLIGHT_RESPONSE:
+            return "PREFLIGHT_OUTPUT_MISMATCH"
+    if exit_code != 0 and (is_auth_shaped_failure(stdout) or is_auth_shaped_failure(stderr)):
+        return "AUTH_UNKNOWN_FAIL_CLOSED"
+    if exit_code != 0:
+        return "reviewer_execution_failure"
+    return None
+
+
+def effective_identity() -> tuple[int, str, str]:
+    uid = os.geteuid()
+    try:
+        account = pwd.getpwuid(uid)
+    except KeyError as error:
+        raise RuntimeError(f"effective uid {uid} has no local account entry") from error
+    return uid, account.pw_name, account.pw_dir
+
+
+def version_of(executable: str, environment: dict[str, str], *, cwd: str) -> str | None:
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            check=False,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return bounded_redacted((result.stdout or result.stderr).strip()) or None
+
+
+def emit_diagnostics(record: dict[str, Any], destination: Path | None) -> None:
+    encoded = json.dumps(record, sort_keys=True)
+    print(f"claude-review diagnostics: {encoded}", file=sys.stderr)
+    if destination is not None:
+        try:
+            destination.write_text(f"{encoded}\n", encoding="utf-8")
+        except OSError as error:
+            print(
+                f"claude-review diagnostics file was not written: {bounded_redacted(str(error))}",
+                file=sys.stderr,
+            )
+
+
+def failure_fields(classification: str | None) -> dict[str, Any]:
+    if classification == "AUTH_OAUTH_TOKEN_EXPIRED_401":
+        return {
+            "disposition": OAUTH_REAUTHENTICATION_DISPOSITION,
+            "operator_action": OAUTH_REAUTHENTICATION_MESSAGE,
+            "candidate_review_state": "unchanged_by_launcher",
+            "automated_retry_attempted": False,
+        }
+    if classification == "AUTH_SAVED_LOGIN_REFRESH_REJECTED":
+        return {
+            "disposition": "REVIEWER INFRASTRUCTURE FAILURE — OPERATOR REAUTHENTICATION REQUIRED",
+            "operator_action": "Claude saved-login refresh was rejected. Reauthenticate Claude interactively in the same environment, then rerun the unchanged preflight and review.",
+            "candidate_review_state": "unchanged_by_launcher",
+            "automated_retry_attempted": False,
+        }
+    if classification in {"AUTH_OAUTH_TOKEN_REVOKED", "AUTH_INVALID_CREDENTIALS", "AUTH_UNKNOWN_FAIL_CLOSED"}:
+        return {
+            "disposition": "REVIEWER INFRASTRUCTURE FAILURE",
+            "operator_action": "Stop without retrying or changing authentication state. Check Claude's active authentication source in the same environment, then take the supported operator action before rerunning the unchanged preflight and review.",
+            "candidate_review_state": "unchanged_by_launcher",
+            "automated_retry_attempted": False,
+        }
+    if classification is not None:
+        return {
+            "disposition": "REVIEWER INFRASTRUCTURE FAILURE",
+            "candidate_review_state": "unchanged_by_launcher",
+            "automated_retry_attempted": False,
+        }
+    return {}
+
+
+def preflight_arguments(arguments: list[str]) -> list[str]:
+    """Keep the preflight harmless while retaining selected model/effort context."""
+    selected: list[str] = []
+    permitted = {"--model", "--effort"}
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument in permitted and index + 1 < len(arguments):
+            selected.extend((argument, arguments[index + 1]))
+            index += 2
+        elif any(argument.startswith(f"{option}=") for option in permitted):
+            selected.append(argument)
+            index += 1
+        else:
+            index += 1
+    return [*selected, "--tools", "", "--no-session-persistence"]
+
+
+def redacted_argv(argv: list[str]) -> list[str]:
+    secret_markers = ("auth", "cookie", "credential", "key", "secret", "token")
+    redacted: list[str] = []
+    redact_next = False
+    for value in argv:
+        if redact_next:
+            redacted.append("[REDACTED]")
+            redact_next = False
+        else:
+            redacted.append(bounded_redacted(value))
+            redact_next = (
+                value.startswith("-")
+                and "=" not in value
+                and (
+                    any(marker in value.lower() for marker in secret_markers)
+                    or ("settings" in value.lower() and "{" in "".join(argv))
+                )
+            )
+    return redacted
+
+
+def parse_arguments(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Claude -p with effective-user USER, LOGNAME, and HOME; read the "
+            "review prompt from standard input."
+        )
+    )
+    parser.add_argument("--claude-bin", default="claude")
+    parser.add_argument("--diagnostics-file", type=Path)
+    parser.add_argument("--auth-preflight", action="store_true")
+    parser.add_argument("claude_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.claude_args[:1] == ["--"]:
+        args.claude_args = args.claude_args[1:]
+    if args.claude_args and not args.claude_args[0].startswith("-"):
+        parser.error("do not pass a positional prompt; provide the prompt on standard input")
+    if any(value in {"-p", "--print", "--prompt"} for value in args.claude_args):
+        parser.error("do not pass Claude prompt flags; provide the prompt on standard input")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_arguments(argv or sys.argv[1:])
+    try:
+        uid, user, effective_home = effective_identity()
+    except RuntimeError as error:
+        emit_diagnostics(
+            {
+                "kind": "claude_reviewer_attempt",
+                "runtime": {"effective_uid": os.geteuid(), "cwd": os.getcwd()},
+                "failure_classification": "RUNTIME_LOGIN_CONTEXT_MISMATCH",
+                "candidate_verdict": "not_produced",
+                "substantive_review_output": False,
+                "claude_exit_code": None,
+                "launcher_exit_code": REVIEWER_FAILURE_EXIT,
+                "stderr": bounded_redacted(str(error)),
+                **failure_fields("RUNTIME_LOGIN_CONTEXT_MISMATCH"),
+            },
+            args.diagnostics_file,
+        )
+        return REVIEWER_FAILURE_EXIT
+    inherited_home = os.environ.get("HOME")
+    child_environment = os.environ.copy()
+    child_environment.update({"HOME": effective_home, "USER": user, "LOGNAME": user})
+    executable = shutil.which(args.claude_bin, path=child_environment.get("PATH"))
+
+    selected_arguments = preflight_arguments(args.claude_args) if args.auth_preflight else args.claude_args
+    preflight_directory = tempfile.TemporaryDirectory(prefix="claude-review-preflight-") if args.auth_preflight else None
+    execution_cwd = preflight_directory.name if preflight_directory else os.getcwd()
+    command = [executable, "-p", *selected_arguments] if executable else None
+    runtime = {
+        "claude_executable": executable,
+        "claude_version": version_of(executable, child_environment, cwd=execution_cwd) if executable else None,
+        "argv": redacted_argv(command) if command else None,
+        "requested_argv": redacted_argv([executable, "-p", *args.claude_args]) if executable else None,
+        "effective_uid": uid,
+        "effective_user": user,
+        "HOME": effective_home,
+        "inherited_HOME": inherited_home,
+        "USER": user,
+        "LOGNAME": user,
+        "cwd": execution_cwd,
+        "cwd_class": "temporary" if args.auth_preflight else "review",
+    }
+    if not executable:
+        emit_diagnostics(
+            {
+                "kind": "claude_reviewer_attempt",
+                "runtime": runtime,
+                "failure_classification": "reviewer_execution_failure",
+                "candidate_verdict": "not_produced",
+                "substantive_review_output": False,
+                "claude_exit_code": None,
+                "launcher_exit_code": REVIEWER_FAILURE_EXIT,
+                "stderr": "Claude executable was not found on PATH.",
+                **failure_fields("reviewer_execution_failure"),
+            },
+            args.diagnostics_file,
+        )
+        if preflight_directory:
+            preflight_directory.cleanup()
+        return REVIEWER_FAILURE_EXIT
+
+    prompt = AUTH_PREFLIGHT_PROMPT if args.auth_preflight else sys.stdin.buffer.read()
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            env=child_environment,
+            input=prompt,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=execution_cwd,
+        )
+    except OSError as error:
+        emit_diagnostics(
+            {
+                "kind": "claude_reviewer_attempt",
+                "runtime": runtime,
+                "failure_classification": "reviewer_execution_failure",
+                "candidate_verdict": "not_produced",
+                "substantive_review_output": False,
+                "claude_exit_code": None,
+                "launcher_exit_code": REVIEWER_FAILURE_EXIT,
+                "stderr": bounded_redacted(str(error)),
+                **failure_fields("reviewer_execution_failure"),
+            },
+            args.diagnostics_file,
+        )
+        if preflight_directory:
+            preflight_directory.cleanup()
+        return REVIEWER_FAILURE_EXIT
+
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    failure = classify_failure(stderr, stdout, result.returncode, preflight=args.auth_preflight)
+    launcher_exit_code = (
+        AUTH_FAILURE_EXIT
+        if failure and failure.startswith("AUTH_")
+        else REVIEWER_FAILURE_EXIT
+        if failure
+        else result.returncode
+    )
+    record = {
+        "kind": "claude_reviewer_attempt",
+        "attempt_kind": "auth_preflight" if args.auth_preflight else "substantive_review",
+        "runtime": runtime,
+        "failure_classification": failure,
+        "candidate_verdict": "not_applicable" if args.auth_preflight else "not_produced" if failure else "uninterpreted",
+        "substantive_review_output": bool(stdout.strip()) and failure is None and not args.auth_preflight,
+        "claude_output_received": bool(stdout.strip()),
+        "claude_output_withheld": bool(stdout.strip()) and failure is not None,
+        "claude_exit_code": result.returncode,
+        "launcher_exit_code": launcher_exit_code,
+        "stderr": bounded_redacted(stderr),
+        "auth_preflight_status": "AUTH_PREFLIGHT_OK" if args.auth_preflight and failure is None else None,
+        **failure_fields(failure),
+    }
+    if args.auth_preflight and failure == "PREFLIGHT_OUTPUT_MISMATCH":
+        record["preflight_output"] = bounded_redacted(stdout)
+    if stdout and failure is None:
+        sys.stdout.write(stdout)
+    emit_diagnostics(record, args.diagnostics_file)
+    if failure == "AUTH_OAUTH_TOKEN_EXPIRED_401":
+        print(OAUTH_REAUTHENTICATION_MESSAGE, file=sys.stderr)
+    if preflight_directory:
+        preflight_directory.cleanup()
+    return launcher_exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -1,0 +1,392 @@
+import json
+import os
+from pathlib import Path
+import pwd
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LAUNCHER = ROOT / "scripts" / "claude-review"
+
+
+class ClaudeReviewLauncherTests(unittest.TestCase):
+    def run_launcher(
+        self,
+        fake_body: str,
+        *,
+        auth_preflight: bool = False,
+        environment: dict[str, str] | None = None,
+    ):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            fake_claude = temporary / "fake-claude"
+            fake_claude.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os\n"
+                "import sys\n"
+                "if '--version' in sys.argv:\n"
+                "    print('fake-claude 1.0')\n"
+                "    raise SystemExit(0)\n"
+                "count_path = os.environ.get('CLAUDE_REVIEW_TEST_COUNT')\n"
+                "if count_path:\n"
+                "    with open(count_path, 'a', encoding='utf-8') as count_file:\n"
+                "        count_file.write('review\\n')\n"
+                "print(os.environ['USER'], os.environ['LOGNAME'], os.environ['HOME'], file=sys.stderr)\n"
+                + textwrap.dedent(fake_body),
+                encoding="utf-8",
+            )
+            fake_claude.chmod(0o755)
+            diagnostics = temporary / "diagnostics.json"
+            command = [
+                str(LAUNCHER),
+                "--claude-bin",
+                str(fake_claude),
+                "--diagnostics-file",
+                str(diagnostics),
+            ]
+            if auth_preflight:
+                command.append("--auth-preflight")
+            command.extend(("--", "--model", "opus", "--effort", "high", "--tools", "Read"))
+            completed = subprocess.run(
+                command,
+                check=False,
+                input="review prompt that must not enter argv\n",
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=environment or os.environ.copy(),
+            )
+            return completed, json.loads(diagnostics.read_text(encoding="utf-8"))
+
+    def test_normalizes_missing_user_and_mismatched_logname_to_effective_user(self):
+        effective = pwd.getpwuid(os.geteuid())
+        environment = os.environ.copy()
+        environment.update({"LOGNAME": "stale-login", "HOME": effective.pw_dir})
+        environment.pop("USER", None)
+        completed, diagnostic = self.run_launcher("print('ACCEPT')\n", environment=environment)
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "ACCEPT\n")
+        self.assertEqual(diagnostic["runtime"]["effective_user"], effective.pw_name)
+        self.assertEqual(diagnostic["runtime"]["USER"], effective.pw_name)
+        self.assertEqual(diagnostic["runtime"]["LOGNAME"], effective.pw_name)
+        self.assertEqual(diagnostic["runtime"]["HOME"], effective.pw_dir)
+        self.assertEqual(diagnostic["runtime"]["inherited_HOME"], effective.pw_dir)
+        self.assertEqual(
+            diagnostic["runtime"]["argv"][-6:],
+            ["--model", "opus", "--effort", "high", "--tools", "Read"],
+        )
+        self.assertNotIn("review prompt that must not enter argv", json.dumps(diagnostic))
+
+    def test_already_correct_user_and_logname_remain_bound_to_effective_user(self):
+        effective = pwd.getpwuid(os.geteuid())
+        environment = os.environ.copy()
+        environment.update({"USER": effective.pw_name, "LOGNAME": effective.pw_name, "HOME": effective.pw_dir})
+        completed, diagnostic = self.run_launcher("print('ACCEPT')\n", environment=environment)
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(diagnostic["runtime"]["USER"], effective.pw_name)
+        self.assertEqual(diagnostic["runtime"]["LOGNAME"], effective.pw_name)
+        self.assertEqual(diagnostic["runtime"]["HOME"], effective.pw_dir)
+
+    def test_oauth_expiry_is_an_infrastructure_failure_not_a_reject_verdict(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            count_path = temporary / "review-count"
+            candidate_state = temporary / "candidate-state"
+            auth_state = temporary / "claude-auth-state"
+            candidate_state.write_text("frozen candidate bytes", encoding="utf-8")
+            auth_state.write_text("operator-owned auth state", encoding="utf-8")
+            environment = os.environ.copy()
+            environment["CLAUDE_REVIEW_TEST_COUNT"] = str(count_path)
+            completed, diagnostic = self.run_launcher(
+                "print('Failed to authenticate. API Error: 401 OAuth access token has expired')\n"
+                "raise SystemExit(1)\n",
+                environment=environment,
+            )
+
+            self.assertEqual(completed.returncode, 78)
+            self.assertEqual(completed.stdout, "")
+            self.assertEqual(diagnostic["failure_classification"], "AUTH_OAUTH_TOKEN_EXPIRED_401")
+            self.assertEqual(
+                diagnostic["disposition"],
+                "REVIEWER INFRASTRUCTURE FAILURE — OPERATOR REAUTHENTICATION REQUIRED",
+            )
+            self.assertIn("reauthenticate Claude interactively", diagnostic["operator_action"])
+            self.assertEqual(diagnostic["candidate_verdict"], "not_produced")
+            self.assertEqual(diagnostic["candidate_review_state"], "unchanged_by_launcher")
+            self.assertFalse(diagnostic["automated_retry_attempted"])
+            self.assertFalse(diagnostic["substantive_review_output"])
+            self.assertTrue(diagnostic["claude_output_received"])
+            self.assertTrue(diagnostic["claude_output_withheld"])
+            self.assertEqual(diagnostic["claude_exit_code"], 1)
+            self.assertEqual(count_path.read_text(encoding="utf-8"), "review\n")
+            self.assertEqual(candidate_state.read_text(encoding="utf-8"), "frozen candidate bytes")
+            self.assertEqual(auth_state.read_text(encoding="utf-8"), "operator-owned auth state")
+
+    def test_invalid_oauth_authentication_is_also_an_operator_reauthentication_failure(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Failed to authenticate: 401 OAuth token invalid', file=sys.stderr)\n"
+            "raise SystemExit(1)\n"
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_UNKNOWN_FAIL_CLOSED")
+        self.assertEqual(diagnostic["candidate_verdict"], "not_produced")
+
+    def test_diagnostics_include_required_runtime_metadata_and_redact_credentials(self):
+        completed, diagnostic = self.run_launcher(
+            "print('authorization: Bearer secret-token-value cookie=session-secret sk-ant-secret-value', file=sys.stderr)\n"
+            "raise SystemExit(1)\n"
+        )
+
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "reviewer_execution_failure")
+        for key in ("claude_executable", "claude_version", "argv", "effective_uid", "effective_user", "HOME", "USER", "LOGNAME", "cwd"):
+            self.assertIn(key, diagnostic["runtime"])
+        serialized = json.dumps(diagnostic)
+        self.assertNotIn("secret-token-value", serialized)
+        self.assertNotIn("session-secret", serialized)
+        self.assertNotIn("sk-ant-secret-value", serialized)
+        self.assertNotIn("secret-token-value", completed.stderr)
+        self.assertNotIn("session-secret", completed.stderr)
+        self.assertNotIn("sk-ant-secret-value", completed.stderr)
+        self.assertIn("[REDACTED]", diagnostic["stderr"])
+
+    def test_review_prose_about_oauth_is_not_mistaken_for_an_authentication_failure(self):
+        completed, diagnostic = self.run_launcher(
+            "print('The docs mention 401 OAuth access token has expired, but this is review prose.')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertIsNone(diagnostic["failure_classification"])
+        self.assertTrue(diagnostic["substantive_review_output"])
+
+    def test_json_oauth_error_is_an_infrastructure_failure_even_with_exit_zero(self):
+        completed, diagnostic = self.run_launcher(
+            "print('{\"type\": \"result\", \"subtype\": \"error_during_execution\", \"is_error\": true, \"result\": \"API Error: 401 OAuth access token has expired\"}')\n"
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_OAUTH_TOKEN_EXPIRED_401")
+
+    def test_stream_json_oauth_error_is_an_infrastructure_failure_even_with_exit_zero(self):
+        completed, diagnostic = self.run_launcher(
+            "print('{\"type\": \"system\", \"subtype\": \"init\"}')\n"
+            "print('{\"type\": \"result\", \"subtype\": \"error_during_execution\", \"is_error\": true, \"result\": \"API Error: 401 OAuth access token has expired\"}')\n"
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(completed.stdout, "")
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_OAUTH_TOKEN_EXPIRED_401")
+
+    def test_review_prose_on_stderr_is_not_mistaken_for_an_authentication_failure(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Review note: 401 OAuth access token has expired is documented behavior.', file=sys.stderr)\n"
+            "print('ACCEPT')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "ACCEPT\n")
+        self.assertIsNone(diagnostic["failure_classification"])
+
+    def test_authentication_error_on_stderr_does_not_discard_a_completed_review(self):
+        completed, diagnostic = self.run_launcher(
+            "print('API Error: 401 OAuth access token has expired', file=sys.stderr)\n"
+            "print('ACCEPT')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "ACCEPT\n")
+        self.assertIsNone(diagnostic["failure_classification"])
+
+    def test_review_prose_beginning_with_an_api_error_quote_is_not_an_authentication_failure(self):
+        completed, diagnostic = self.run_launcher(
+            "print('API Error: 401 OAuth access token has expired is a quote from the docs.')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertTrue(diagnostic["substantive_review_output"])
+        self.assertIsNone(diagnostic["failure_classification"])
+
+    def test_review_prose_beginning_with_a_failed_to_authenticate_quote_is_not_an_authentication_failure(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Failed to authenticate is the literal under review, not a runtime failure.')\n"
+            "print('ACCEPT WITH CHANGES')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertTrue(diagnostic["substantive_review_output"])
+        self.assertIsNone(diagnostic["failure_classification"])
+
+    def test_auth_preflight_uses_fixed_prompt_and_omits_review_tools(self):
+        completed, diagnostic = self.run_launcher(
+            "prompt = sys.stdin.read()\n"
+            "assert prompt == 'Reply exactly: CLAUDE_AUTH_OK\\n'\n"
+            "assert sys.argv[sys.argv.index('--tools') + 1] == ''\n"
+            "assert '--model' in sys.argv\n"
+            "assert '--effort' in sys.argv\n"
+            "assert not os.path.exists('.git')\n"
+            "print('CLAUDE_AUTH_OK')\n",
+            auth_preflight=True,
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "CLAUDE_AUTH_OK\n")
+        self.assertEqual(diagnostic["attempt_kind"], "auth_preflight")
+        self.assertEqual(diagnostic["auth_preflight_status"], "AUTH_PREFLIGHT_OK")
+        self.assertEqual(diagnostic["candidate_verdict"], "not_applicable")
+        self.assertFalse(diagnostic["substantive_review_output"])
+        self.assertIn("--tools", diagnostic["runtime"]["requested_argv"])
+        self.assertEqual(diagnostic["runtime"]["argv"][-3:], ["--tools", "", "--no-session-persistence"])
+        self.assertEqual(diagnostic["runtime"]["cwd_class"], "temporary")
+
+    def test_auth_preflight_distinguishes_saved_login_refresh_rejection(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Failed to authenticate: OAuth session expired and could not be refreshed')\n"
+            "raise SystemExit(1)\n",
+            auth_preflight=True,
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_SAVED_LOGIN_REFRESH_REJECTED")
+        self.assertIn("Reauthenticate Claude interactively", diagnostic["operator_action"])
+        self.assertFalse(diagnostic["automated_retry_attempted"])
+        self.assertEqual(diagnostic["candidate_verdict"], "not_applicable")
+
+    def test_auth_preflight_classifies_documented_oauth_expired_401(self):
+        completed, diagnostic = self.run_launcher(
+            "print('API Error: 401 OAuth access token has expired')\n"
+            "raise SystemExit(1)\n",
+            auth_preflight=True,
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_OAUTH_TOKEN_EXPIRED_401")
+
+    def test_auth_preflight_unknown_auth_failure_fails_closed_without_provider_cause(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Authentication could not continue')\n"
+            "raise SystemExit(1)\n",
+            auth_preflight=True,
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_UNKNOWN_FAIL_CLOSED")
+        self.assertEqual(diagnostic["candidate_verdict"], "not_applicable")
+
+    def test_auth_preflight_non_auth_output_mismatch_is_not_labeled_as_authentication(self):
+        completed, diagnostic = self.run_launcher("print('unexpected preflight output')\n", auth_preflight=True)
+
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "PREFLIGHT_OUTPUT_MISMATCH")
+        self.assertEqual(diagnostic["preflight_output"], "unexpected preflight output\n")
+
+    def test_successful_review_quoting_terminal_auth_text_is_not_discarded(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Failed to authenticate. API Error: 401 OAuth access token has expired')\n"
+            "print('ACCEPT')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertIsNone(diagnostic["failure_classification"])
+        self.assertTrue(diagnostic["substantive_review_output"])
+
+    def test_split_terminal_auth_text_fails_closed_without_an_expiry_cause(self):
+        completed, diagnostic = self.run_launcher(
+            "print('Failed to authenticate.')\n"
+            "print('unrelated output')\n"
+            "print('API Error: 401 OAuth access token has expired')\n"
+            "raise SystemExit(1)\n"
+        )
+
+        self.assertEqual(completed.returncode, 78)
+        self.assertEqual(diagnostic["failure_classification"], "AUTH_UNKNOWN_FAIL_CLOSED")
+
+    def test_successful_review_survives_incidental_context_stderr(self):
+        completed, diagnostic = self.run_launcher(
+            "print('note: home directory scanned', file=sys.stderr)\n"
+            "print('ACCEPT')\n"
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(completed.stdout, "ACCEPT\n")
+        self.assertIsNone(diagnostic["failure_classification"])
+
+    def test_auth_preflight_accepts_fixed_response_without_a_trailing_newline(self):
+        completed, diagnostic = self.run_launcher(
+            "sys.stdout.write('CLAUDE_AUTH_OK')\n", auth_preflight=True
+        )
+
+        self.assertEqual(completed.returncode, 0)
+        self.assertEqual(diagnostic["auth_preflight_status"], "AUTH_PREFLIGHT_OK")
+
+    def test_auth_preflight_retains_equals_form_model_and_effort(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary = Path(temporary_directory)
+            fake_claude = temporary / "fake-claude"
+            fake_claude.write_text(
+                "#!/usr/bin/env python3\n"
+                "import sys\n"
+                "if '--version' in sys.argv: raise SystemExit(0)\n"
+                "assert '--model=opus' in sys.argv\n"
+                "assert '--effort=high' in sys.argv\n"
+                "print('CLAUDE_AUTH_OK')\n",
+                encoding="utf-8",
+            )
+            fake_claude.chmod(0o755)
+            completed = subprocess.run(
+                [str(LAUNCHER), "--claude-bin", str(fake_claude), "--auth-preflight", "--", "--model=opus", "--effort=high"],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        self.assertEqual(completed.returncode, 0)
+
+    def test_argv_diagnostics_redact_credential_values(self):
+        import importlib.machinery
+        import importlib.util
+
+        loader = importlib.machinery.SourceFileLoader("claude_review", str(LAUNCHER))
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
+
+        self.assertEqual(
+            module.redacted_argv(
+                [
+                    "claude",
+                    "--token",
+                    "secret",
+                    "--api-key=another-secret",
+                    "--anthropic-api-key",
+                    "another-secret",
+                    "--session-token",
+                    "session-secret",
+                    "--settings",
+                    '{"apiKey":"settings-secret"}',
+                ]
+            ),
+            [
+                "claude",
+                "--token",
+                "[REDACTED]",
+                "--api-[REDACTED]",
+                "--anthropic-api-key",
+                "[REDACTED]",
+                "--session-token",
+                "[REDACTED]",
+                "--settings",
+                "[REDACTED]",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Reconciles the automated Claude reviewer launcher with completed CAK-114 evidence.

- uses one fixed, no-content `CLAUDE_AUTH_OK` preflight before an expensive Claude review;
- reuses the existing effective-user `USER`, `LOGNAME`, `HOME`, executable, and redacted-diagnostics seam;
- runs the preflight in a fresh temporary directory with all Claude tools disabled;
- preserves documented failure distinctions where output reliably supports them: `AUTH_OAUTH_TOKEN_EXPIRED_401`, `AUTH_SAVED_LOGIN_REFRESH_REJECTED`, revoked/invalid-credential classes, and fail-closed unknowns;
- preserves no retry, no auth mutation, no candidate verdict, and no reviewer substitution on failure.

## CAK-114 reconciliation

The completed durable investigation is `history/investigations/claude-oauth-user-context-investigation-20260812.md`.

It establishes that user-context normalization and genuine OAuth interruption are independent. A successful preflight proves only authentication in that process context; it is not a promise that a later review cannot expire. The supported `claude setup-token` alternative is noted only as a separate future credential-management design: this PR does not provision, adopt, inspect, or store it.

Remaining unknowns are preserved: the failure-time credential source/precedence, the provider-side cause of the historical 401, and saved-login/refresh lifetimes.

## Validation

Head: `ac0e847a83aa2d2986bb52883ccc07eaf9a053d1`.

- Focused launcher tests: 23 passed.
- `make check`: markdownlint 0 issues; 85 tests passed.
- `make authoritative-source-check`: passed.
- `git diff --check`: passed.
- Harmless real-path preflight: exact `CLAUDE_AUTH_OK`, exit 0, Claude `2.1.221 (Claude Code)`, normalized effective user context, temporary cwd, and no available Claude tools.

## Independent review

The independent Claude rereview returned `ACCEPT` on the final head after operator reauthentication. It verified that successful review prose is not mistaken for auth failure, specific plain-text classes require one-line documented evidence and a nonzero exit, structured error records remain recognized, preflight response formatting is tolerant, and failure handling has no retry, auth mutation, candidate verdict, state change, or reviewer substitution.

No model/thread routing doctrine, downstream executable review prompt, CAK-106 work, credential provisioning, or automated login changed.