### PR TITLE
docs: add planning-first thread names

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,8 +1,8 @@
 # Reusable Workflow Prompt Templates
 
-This file holds reusable prompt shapes. Keep workflow rules in the core
-playbook docs, Codex-specific execution guidance in `docs/tool-adapters/codex.md`,
-and repo-local execution rules in `AGENTS.md`.
+This file holds reusable, executor-neutral prompt shapes. Keep workflow rules
+in the core playbook docs, executor-specific execution guidance in the matching
+tool adapter, and repo-local execution rules in `AGENTS.md`.
 
 Prompts should remain routing and execution envelopes, not duplicated workflow
 doctrine. For the rationale, see
@@ -137,9 +137,22 @@ If the execution surface cannot apply the name, continue the substantive task
 and report that limitation. Naming failure is non-blocking because the name is
 navigation only.
 
-When rendering an applicable prompt, replace the thread-name placeholder with
-the exact computed visible name. Do not ask the downstream executor to infer
-or recover it from planning or repository context.
+Use this canonical executable fragment exactly once in an applicable generated
+prompt:
+
+```text
+Thread name:
+- Before substantive work, set this thread's visible name to: `[exact visible name]`.
+- If this surface cannot apply the name, continue and report the limitation;
+  do not ask the operator to set it manually.
+```
+
+During prompt construction, replace `[resolved thread-name section when
+applicable]` with the complete canonical fragment and the exact computed name
+for a `FRESH THREAD` or a separately visible, nameable `CHILD TASK` whose
+surface supports naming. Replace it with nothing for an ordinary `SAME THREAD`.
+Do not leave the placeholder in a final generated prompt or ask the downstream
+executor to infer or recover the name from planning or repository context.
 
 When a complete prompt materially changes, emit a complete replacement
 operator-metadata block and executable prompt. Do not emit a partial prompt
@@ -184,42 +197,39 @@ Use lint-safe placeholders such as `[repository]`, `[validation_path]`, or
 backticked tokens in Markdown templates. Angle-bracket placeholders can be
 interpreted as inline HTML by Markdown tooling.
 
-When rendering a complete Codex prompt inside a Markdown code fence, never
-nest another Markdown code fence inside it. If the prompt needs an embedded
-YAML, JSON, shell, Markdown, or other example, represent the example with
-indentation and prefer plain text over Markdown formatting. Optimize the
-finished prompt for reliable copy/paste across ChatGPT clients without changing
-its meaning or execution.
+## Complete Prompt Shape
+
+For a complete generated prompt, emit one shared operator-metadata block and
+one complete executable block consecutively. The executable block must remain
+complete and actionable without the metadata, so the operator can copy only
+that block. Matching executor adapters own concrete metadata fields and client
+presentation mechanics.
+
+```text
+Operator metadata (do not include in prompt)
+Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
+Recommended model: [matching executor adapter selection]
+Recommended reasoning/thinking: [matching executor adapter selection]
+
+Reason:
+[one concise task-specific explanation]
+```
 
 ## Quick Navigation
 
-- [Codex Implementation Task](#codex-implementation-task)
+- [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Orchestration Handoff](#orchestration-handoff)
 - [Implementation Delivery Add-On](#implementation-delivery-add-on)
 - [PR Review](#pr-review)
 
-## Codex Implementation Task
+## Repository Implementation Task
 
 Use this template only when the intended interaction mode is direct
 implementation. For review or orchestration, use the matching template instead.
-Apply the model-and-reasoning routing guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
-to the bounded task. The first block below is operator metadata for the human
-or operator. It is not part of the executable prompt and should not be copied
-into the downstream agent. Copy or deliver only the second block. The second
-block is complete without the metadata. Emit the two blocks consecutively with
-no intervening heading or explanation.
-
-```text
-Operator metadata (do not include in prompt)
-Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
-Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
-
-Reason:
-[one concise task-specific explanation]
-```
+Use the matching executor adapter to select model and reasoning/thinking
+configuration. For a complete generated prompt, precede this executable body
+with the shared operator-metadata block in [Complete Prompt Shape](#complete-prompt-shape).
 
 ```text
 Role:
@@ -242,16 +252,7 @@ Context:
 - GitHub issues or planning references: [none or identifiers]
 - Dependencies: [none or required predecessors, inputs, or services]
 
-Thread name:
-- Include this section for a FRESH THREAD; before substantive work, set this
-  execution thread's visible name to: `[exact visible name]`.
-- Include it for a CHILD TASK only when the child is separately visible and
-  nameable; set that child's visible name to: `[exact child visible name]`
-  before its substantive work.
-- Omit this section for a SAME THREAD unless this task explicitly authorizes a
-  rename; otherwise preserve the established visible name.
-- If this surface cannot apply the name, continue and report the limitation;
-  do not ask the operator to set it manually.
+[resolved thread-name section when applicable]
 
 Retrieval:
 - Read `ai-workflow-playbook/docs/start-here.md`, the target repo's
@@ -268,7 +269,7 @@ Scope:
 Constraints:
 - Keep the change minimal, scoped, and structurally local.
 - Follow existing repo patterns and canonical validation.
-- Follow `docs/repo-readiness.md`, `docs/tool-adapters/codex.md`, and
+- Follow `docs/repo-readiness.md`, the matching executor adapter, and
   repo-local `AGENTS.md` for interaction mode, command form, worktree,
   validation, and delivery.
 - Report blockers, validation failures, residual risks, and uncertainty.
@@ -331,6 +332,7 @@ Startup:
   available and follow its repository startup route.
 Governing issue:
 - [issue identifier or durable authority source]
+[resolved thread-name section when applicable]
 Authoritative state:
 - [Repository or History artifact locations and exact identities when needed]
 Authorized action:
@@ -351,22 +353,9 @@ Required inputs:
 - `validation_path`
 - `delivery_expectation`
 
-Apply the model-and-reasoning routing guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
-to the bounded task. The first block below is operator metadata for the human
-or operator. It is not part of the executable prompt and should not be copied
-into the downstream agent. Copy or deliver only the second block. Emit the two
-blocks consecutively with no intervening heading or explanation.
-
-```text
-Operator metadata (do not include in prompt)
-Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
-Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
-
-Reason:
-[one concise task-specific explanation]
-```
+Use the matching executor adapter to select model and reasoning/thinking
+configuration. For a complete generated prompt, precede this executable body
+with the shared operator-metadata block in [Complete Prompt Shape](#complete-prompt-shape).
 
 ```text
 Role:
@@ -394,16 +383,7 @@ Inputs:
 - Delivery expectation: [delivery_expectation]
 - Dependencies: [none or required predecessors, inputs, or services]
 
-Thread name:
-- Include this section for a FRESH THREAD; before substantive work, set this
-  execution thread's visible name to: `[exact visible name]`.
-- Include it for a CHILD TASK only when the child is separately visible and
-  nameable; set that child's visible name to: `[exact child visible name]`
-  before its substantive work.
-- Omit this section for a SAME THREAD unless this task explicitly authorizes a
-  rename; otherwise preserve the established visible name.
-- If this surface cannot apply the name, continue and report the limitation;
-  do not ask the operator to set it manually.
+[resolved thread-name section when applicable]
 
 Retrieval:
 - Read the shared playbook startup guidance and repo-local `AGENTS.md` first.
@@ -454,7 +434,7 @@ expected.
 ```text
 Delivery:
 - Follow the branch, worktree, validation, and PR delivery rules in
-  `docs/repo-readiness.md`, `docs/tool-adapters/codex.md`, and repo-local
+  `docs/repo-readiness.md`, the matching executor adapter, and repo-local
   `AGENTS.md`.
 - Stage, commit, push, and open or update the intended PR only with relevant
   changes.
@@ -475,22 +455,9 @@ Required inputs:
 - `task_or_issue_context` (`none` when unavailable)
 - `summary_only` (`yes` or `no`)
 
-Apply the model-and-reasoning routing guidance in
-[`tool-adapters/codex.md`](tool-adapters/codex.md#gpt-56-model-and-reasoning-routing)
-to the bounded task. The first block below is operator metadata for the human
-or operator. It is not part of the executable prompt and should not be copied
-into the downstream agent. Copy or deliver only the second block. Emit the two
-blocks consecutively with no intervening heading or explanation.
-
-```text
-Operator metadata (do not include in prompt)
-Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
-Recommended model: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread model and observe effective runtime model]
-Recommended reasoning/thinking: [FRESH THREAD/CHILD TASK: executor adapter selection; SAME THREAD: Preserve requested thread setting and observe effective runtime setting]
-
-Reason:
-[one concise task-specific explanation]
-```
+Use the matching executor adapter to select model and reasoning/thinking
+configuration. For a complete generated prompt, precede this executable body
+with the shared operator-metadata block in [Complete Prompt Shape](#complete-prompt-shape).
 
 ```text
 Task:
@@ -502,16 +469,7 @@ Inputs:
 - Task or issue context: [task_or_issue_context]
 - Summary-only requested: [summary_only]
 
-Thread name:
-- Include this section for a FRESH THREAD; before substantive work, set this
-  execution thread's visible name to: `[exact visible name]`.
-- Include it for a CHILD TASK only when the child is separately visible and
-  nameable; set that child's visible name to: `[exact child visible name]`
-  before its substantive work.
-- Omit this section for a SAME THREAD unless this task explicitly authorizes a
-  rename; otherwise preserve the established visible name.
-- If this surface cannot apply the name, continue and report the limitation;
-  do not ask the operator to set it manually.
+[resolved thread-name section when applicable]
 
 Success criteria:
 - Review feedback is grounded in direct PR evidence.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -100,6 +100,47 @@ runtime model evidence, detecting a disallowed substitution, or writing an
 execution receipt when that information is part of the task's validation or
 qualification boundary.
 
+### Executor-Applied Visible Thread Names
+
+Use a visible thread name only as human navigation. It is not task authority,
+durable continuity, execution identity, or evidence of current planning,
+repository, branch, pull-request, validation, or review state. Retrieve each
+of those facts from its owning current source.
+
+The name is an executor action, not an operator configuration. Put an exact
+`Thread name` instruction in an applicable executable prompt; do not put a
+`Recommended thread name` field in operator metadata. The operator is not
+expected to set or copy the name manually, while the active executor can apply
+it when its surface exposes that control.
+
+When one planning item governs the current intent and completion boundary, use
+`[planning-id] — [short bounded task]`. Preserve the planning identifier exactly
+as represented by its owning planning system. When there is no governing
+planning identifier, use only the concise bounded task name. When several
+identifiers are related, use only the identifier governing the current intent
+and completion boundary; keep predecessors, related items, implementation
+references, and secondary identifiers in normal prompt context. If no single
+governing identifier can be selected without inventing precedence, omit the
+identifier. This convention is planning-system-neutral and does not require
+Linear.
+
+Apply the instruction by route:
+
+- `FRESH THREAD`: include the executable `Thread name` instruction and have
+  the capable executor apply the exact name before substantive work.
+- `CHILD TASK`: include it only when the child has its own separately visible,
+  nameable thread or task and its execution surface can apply the name.
+- `SAME THREAD`: preserve the established visible name unless an explicit
+  rename is part of the task; do not inject a routine rename instruction.
+
+If the execution surface cannot apply the name, continue the substantive task
+and report that limitation. Naming failure is non-blocking because the name is
+navigation only.
+
+When rendering an applicable prompt, replace the thread-name placeholder with
+the exact computed visible name. Do not ask the downstream executor to infer
+or recover it from planning or repository context.
+
 When a complete prompt materially changes, emit a complete replacement
 operator-metadata block and executable prompt. Do not emit a partial prompt
 patch that requires the operator to splice text into an older prompt.
@@ -200,6 +241,17 @@ Context:
 - Relevant background: [short context]
 - GitHub issues or planning references: [none or identifiers]
 - Dependencies: [none or required predecessors, inputs, or services]
+
+Thread name:
+- Include this section for a FRESH THREAD; before substantive work, set this
+  execution thread's visible name to: `[exact visible name]`.
+- Include it for a CHILD TASK only when the child is separately visible and
+  nameable; set that child's visible name to: `[exact child visible name]`
+  before its substantive work.
+- Omit this section for a SAME THREAD unless this task explicitly authorizes a
+  rename; otherwise preserve the established visible name.
+- If this surface cannot apply the name, continue and report the limitation;
+  do not ask the operator to set it manually.
 
 Retrieval:
 - Read `ai-workflow-playbook/docs/start-here.md`, the target repo's
@@ -342,6 +394,17 @@ Inputs:
 - Delivery expectation: [delivery_expectation]
 - Dependencies: [none or required predecessors, inputs, or services]
 
+Thread name:
+- Include this section for a FRESH THREAD; before substantive work, set this
+  execution thread's visible name to: `[exact visible name]`.
+- Include it for a CHILD TASK only when the child is separately visible and
+  nameable; set that child's visible name to: `[exact child visible name]`
+  before its substantive work.
+- Omit this section for a SAME THREAD unless this task explicitly authorizes a
+  rename; otherwise preserve the established visible name.
+- If this surface cannot apply the name, continue and report the limitation;
+  do not ask the operator to set it manually.
+
 Retrieval:
 - Read the shared playbook startup guidance and repo-local `AGENTS.md` first.
 - Retrieve authoritative state from only the files, issues, PRs, docs, or
@@ -438,6 +501,17 @@ Inputs:
 - Pull request: [pull_request]
 - Task or issue context: [task_or_issue_context]
 - Summary-only requested: [summary_only]
+
+Thread name:
+- Include this section for a FRESH THREAD; before substantive work, set this
+  execution thread's visible name to: `[exact visible name]`.
+- Include it for a CHILD TASK only when the child is separately visible and
+  nameable; set that child's visible name to: `[exact child visible name]`
+  before its substantive work.
+- Omit this section for a SAME THREAD unless this task explicitly authorizes a
+  rename; otherwise preserve the established visible name.
+- If this surface cannot apply the name, continue and report the limitation;
+  do not ask the operator to set it manually.
 
 Success criteria:
 - Review feedback is grounded in direct PR evidence.

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -117,6 +117,17 @@ evidence. Use [`prompts.md`](../prompts.md),
 [`orchestration-and-parallelism.md`](../orchestration-and-parallelism.md) for
 the applicable prompt and downstream-context contract.
 
+### Prompt presentation
+
+For a complete prompt prepared in ChatGPT/Work, present the shared
+operator-metadata block followed immediately by the complete executable block
+as consecutive copyable code blocks. Keep the executable block complete without
+metadata so the operator can copy only that block. Do not nest Markdown code
+fences inside the executable block; represent any embedded example with
+indentation or plain text. Optimize this client rendering for reliable
+copy/paste without changing the shared prompt meaning in
+[`prompts.md`](../prompts.md).
+
 ## Generated artifacts
 
 Creating a ChatGPT or Work artifact does not make it current authoritative

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -107,6 +107,17 @@ Keep the selected substantive external reviewer (for example, qualified Claude)
 when the review contract requires it. Internal or mechanical review follows
 this matrix; Sol is not automatic for a narrow, deterministic fallback.
 
+### Visible Thread Names
+
+Apply the shared visible-thread-name semantics in
+[`prompts.md`](../prompts.md#executor-applied-visible-thread-names). When an
+applicable executable prompt supplies a `Thread name` and the active Codex
+surface exposes a visible-name control, Codex applies that exact name itself
+before substantive work. Codex must not ask the operator to set or copy the
+name manually. If the control is unavailable, Codex continues the substantive
+task and reports the limitation; naming remains non-blocking and navigation
+only.
+
 The CAK-106 experience supports this split as observed workflow evidence, not
 a benchmark: protocol ambiguity, authority architecture, controller semantics,
 and architecture synthesis justified stronger reasoning, while repeated focused

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -246,8 +246,8 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         claude = (DOCS / "tool-adapters/claude.md").read_text(encoding="utf-8")
 
         self.assertIn("Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]", prompts)
-        self.assertIn("Preserve requested thread model", prompts)
-        self.assertIn("observe effective runtime model", prompts)
+        self.assertIn("Preserve the requested parent configuration", prompts)
+        self.assertIn("matching executor adapter selection", prompts)
         self.assertNotIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", prompts)
         self.assertIn("Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>", codex)
         self.assertIn("effective model and effort separately", codex)
@@ -282,6 +282,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
     def test_executor_applied_planning_first_thread_names(self):
         prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
         codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")
+        chatgpt = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
         normalized_prompts = " ".join(prompts.split())
         normalized_codex = " ".join(codex.split())
 
@@ -293,18 +294,44 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         self.assertIn("not task authority, durable continuity, execution identity", normalized_prompts)
         self.assertIn("`Thread name` instruction", prompts)
         self.assertNotIn("Recommended thread name:", prompts)
-        self.assertIn("Include this section for a FRESH THREAD", prompts)
+        self.assertEqual(prompts.count("Thread name:"), 1)
+        self.assertIn("Before substantive work, set this thread's visible name", prompts)
+        self.assertIn("[resolved thread-name section when applicable]", prompts)
+        self.assertIn("Replace it with nothing for an ordinary `SAME THREAD`", prompts)
         self.assertIn(
-            "only when the child is separately visible and nameable",
+            "separately visible, nameable `CHILD TASK`",
             normalized_prompts,
         )
-        self.assertIn("Omit this section for a SAME THREAD", prompts)
+        self.assertIn("exact computed name", normalized_prompts)
+        self.assertNotIn("Include this section for a FRESH THREAD", prompts)
+        self.assertNotIn("Omit this section for a SAME THREAD", prompts)
         self.assertIn("continue and report the limitation", normalized_prompts)
         self.assertIn("do not ask the operator to set it manually", prompts)
-        self.assertGreaterEqual(prompts.count("Thread name:"), 3)
+        self.assertIn(
+            "Governing issue:\n- [issue identifier or durable authority source]\n"
+            "[resolved thread-name section when applicable]",
+            prompts,
+        )
+        self.assertIn(
+            "Dependencies: [none or required predecessors, inputs, or services]\n\n"
+            "[resolved thread-name section when applicable]\n\nRetrieval:",
+            prompts,
+        )
+        self.assertIn(
+            "Summary-only requested: [summary_only]\n\n"
+            "[resolved thread-name section when applicable]\n\nSuccess criteria:",
+            prompts,
+        )
+        self.assertIn("Repository Implementation Task", prompts)
+        self.assertNotIn("Codex", prompts)
+        self.assertNotIn("ChatGPT", prompts)
+        self.assertIn("matching executor adapter", prompts)
         self.assertIn("Codex applies that exact name itself", codex)
         self.assertIn("Codex must not ask the operator", codex)
         self.assertIn("naming remains non-blocking and navigation only", normalized_codex)
+        self.assertIn("### Prompt presentation", chatgpt)
+        self.assertIn("consecutive copyable code blocks", chatgpt)
+        self.assertIn("Do not nest Markdown code fences", " ".join(chatgpt.split()))
 
 
 class PromptContractCanonicalizationVectorTests(unittest.TestCase):

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -279,6 +279,33 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         self.assertIn("does not expose the control", normalized_claude)
         self.assertIn("requested/effective runtime evidence", normalized_claude)
 
+    def test_executor_applied_planning_first_thread_names(self):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")
+        normalized_prompts = " ".join(prompts.split())
+        normalized_codex = " ".join(codex.split())
+
+        self.assertIn("Executor-Applied Visible Thread Names", prompts)
+        self.assertIn("`[planning-id] — [short bounded task]`", prompts)
+        self.assertIn("use only the concise bounded task name", normalized_prompts)
+        self.assertIn("only the identifier governing the current intent", normalized_prompts)
+        self.assertIn("planning-system-neutral", prompts)
+        self.assertIn("not task authority, durable continuity, execution identity", normalized_prompts)
+        self.assertIn("`Thread name` instruction", prompts)
+        self.assertNotIn("Recommended thread name:", prompts)
+        self.assertIn("Include this section for a FRESH THREAD", prompts)
+        self.assertIn(
+            "only when the child is separately visible and nameable",
+            normalized_prompts,
+        )
+        self.assertIn("Omit this section for a SAME THREAD", prompts)
+        self.assertIn("continue and report the limitation", normalized_prompts)
+        self.assertIn("do not ask the operator to set it manually", prompts)
+        self.assertGreaterEqual(prompts.count("Thread name:"), 3)
+        self.assertIn("Codex applies that exact name itself", codex)
+        self.assertIn("Codex must not ask the operator", codex)
+        self.assertIn("naming remains non-blocking and navigation only", normalized_codex)
+
 
 class PromptContractCanonicalizationVectorTests(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
## Summary
- define one shared planning-first naming contract and canonical executable fragment in `docs/prompts.md`
- compose the resolved fragment into repository implementation, orchestration, compact fresh-thread handoff, and PR-review prompts only when applicable
- keep Codex self-renaming and concrete operator configuration in the Codex adapter
- keep ChatGPT/Work copyable-block and Markdown-fence presentation mechanics in the ChatGPT/Work adapter
- add focused ownership and composition regression coverage

## Ownership and behavior
- Shared prompt guidance owns routing, naming semantics, governing-identifier selection, non-authority meaning, and executor-neutral envelopes.
- A FRESH THREAD and supported separately visible CHILD TASK receive the exact resolved fragment; ordinary SAME THREAD output omits it.
- Naming remains best-effort navigation only and operator metadata has no `Recommended thread name` field.
- `docs/tool-adapters/claude.md` was inspected and remains unchanged: no supported Claude-specific visible-thread-name capability was established.

## Validation
- `make check`
- `make authoritative-source-check`
- `git diff --check`

## Classification
Non-material Playbook guidance refactor. It preserves authority, lifecycle, validation, ownership, and versioned prompt-contract boundaries.

## Files
- `docs/prompts.md`
- `docs/tool-adapters/codex.md`
- `docs/tool-adapters/chatgpt.md`
- `tests/test_prompt_contract_semantics.py`

Planning: CAK-126