### PR TITLE
docs: clarify ChatGPT and Codex routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/alignment-checkpoints.md`](docs/alignment-checkpoints.md): pause points and branch/PR rules
 - [`docs/review-packet.md`](docs/review-packet.md): standard human review packet
 - [`docs/knowledge-ingestion-patterns.md`](docs/knowledge-ingestion-patterns.md): reusable patterns for provenance-aware ingestion and retained-knowledge governance boundaries
-- [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md), Claude runs must apply [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md), and repository-scoped ChatGPT/Work runs must apply [`docs/tool-adapters/chatgpt.md`](docs/tool-adapters/chatgpt.md)
+- [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md), Claude runs must apply [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md), and repository-scoped ChatGPT runs must apply [`docs/tool-adapters/chatgpt.md`](docs/tool-adapters/chatgpt.md)
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check
 - [`docs/new-repo-bootstrap.md`](docs/new-repo-bootstrap.md): reusable bootstrap pattern for brand-new repositories
 - [`docs/maintenance-automations.md`](docs/maintenance-automations.md):

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -127,7 +127,7 @@ scoped analysis, review, planning, advice, prompting, or mutation.
 - `docs/tool-adapters/<executor>.md` -> executor-specific deltas when a matching
   adapter exists; Codex runs must read `docs/tool-adapters/codex.md`, Claude
   runs must read `docs/tool-adapters/claude.md`, and repository-scoped
-  ChatGPT/Work runs must read `docs/tool-adapters/chatgpt.md`
+  ChatGPT runs must read `docs/tool-adapters/chatgpt.md`
 - `docs/engineering-baseline.md` -> foundational engineering expectations
 - `docs/source-first-retrieval.md` -> repository triggers, retrieval ordering,
   verification gates, and recovery
@@ -172,7 +172,7 @@ Apply overlapping repository instructions in this order:
    for repository-specific execution details.
 3. The matching executor adapter, such as `docs/tool-adapters/codex.md` for
    Codex-specific behavior or `docs/tool-adapters/chatgpt.md` for
-   ChatGPT/Work-specific behavior.
+   ChatGPT-specific behavior.
 4. Shared Playbook docs as reusable workflow defaults.
 
 Repo-local instructions are authoritative for allowed tools, Git usage,
@@ -208,8 +208,8 @@ recommendations, and "what changed?" or "what next?" requests:
 2. Read the target repository's repo-local `AGENTS.md`.
 3. Apply the matching executor adapter. Codex runs must apply
    `docs/tool-adapters/codex.md`; Claude runs must apply
-   `docs/tool-adapters/claude.md`; repository-scoped ChatGPT/Work runs must
-   apply `docs/tool-adapters/chatgpt.md`.
+   `docs/tool-adapters/claude.md`; repository-scoped ChatGPT runs must apply
+   `docs/tool-adapters/chatgpt.md`.
 4. Identify the repository or workspace's primary purpose.
 5. Select the interaction mode from `docs/repo-readiness.md`: implementation,
    review/audit, or orchestration/prompt-authoring.

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -1,10 +1,15 @@
-# ChatGPT/Work Adapter
+# ChatGPT Adapter
 
-This adapter projects the Playbook onto repository-scoped ChatGPT and Work
-use. It begins after repository work has been activated; ordinary conceptual
-Chat remains outside repository startup. Shared operating rules remain owned
-by [`start-here.md`](../start-here.md) and
-[`core-model.md`](../core-model.md).
+This adapter projects the Playbook onto repository-scoped ChatGPT use. Chat
+and Work are nested task-shape or capability modes under that one ChatGPT
+adapter, not separate durable executor identities or adapters. It begins after
+repository work has been activated; ordinary conceptual Chat remains outside
+repository startup. Shared operating rules remain owned by
+[`start-here.md`](../start-here.md) and [`core-model.md`](../core-model.md).
+
+The durable ChatGPT-versus-Codex routing reflects operator-observed client
+behavior checked 2026-08-14. It is Playbook classification rather than a
+provider guarantee about client layout, history, or mode behavior.
 
 ## Repository-bootstrap boundary
 
@@ -60,7 +65,7 @@ by [`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence
 
 ## Workspace Agents
 
-Workspace Agents are a ChatGPT/Work execution surface, not a second adapter.
+Workspace Agents are a ChatGPT execution surface, not a second adapter.
 
 ### Trigger initiation and durable run authority
 
@@ -119,7 +124,7 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-For a complete prompt prepared in ChatGPT/Work, present the shared
+For a complete prompt prepared in ChatGPT, present the shared
 operator-metadata block followed immediately by the complete executable block
 as consecutive copyable code blocks. Keep the executable block complete without
 metadata so the operator can copy only that block. Do not nest Markdown code
@@ -130,15 +135,15 @@ copy/paste without changing the shared prompt meaning in
 
 ## Generated artifacts
 
-Creating a ChatGPT or Work artifact does not make it current authoritative
-state or grant publication, sharing, overwrite, or adoption authority. Apply
-the derived-artifact and consequential-action boundaries in
+Creating a ChatGPT artifact in Chat or Work does not make it current
+authoritative state or grant publication, sharing, overwrite, or adoption
+authority. Apply the derived-artifact and consequential-action boundaries in
 [`core-model.md`](../core-model.md) and the material-artifact contract in
 [`prompt-contracts.md`](../prompt-contracts.md) when activated.
 
 ## Scheduled and unattended execution
 
-Scheduled or unattended ChatGPT/Work must project the current automation,
+Scheduled or unattended ChatGPT execution must project the current automation,
 source, and locality rules for each run. A standalone run cannot assume an
 originating conversation; an in-chat run may use conversation as context but
 not as proof of current canonical or provider state. Do not depend on an
@@ -151,7 +156,7 @@ retrieval in [`source-first-retrieval.md`](../source-first-retrieval.md).
 If persistent context proves under-hydrated, stop continuity-based drafting or
 action and re-enter current canonical routing. Retrieve the missing activated
 owners, revalidate mutable sources, and replace or correct the affected
-artifact as a whole before resuming. This is a ChatGPT/Work projection of
+artifact as a whole before resuming. This is a ChatGPT projection of
 [`source-first-retrieval.md`](../source-first-retrieval.md) and, for prompts,
 [`prompts.md`](../prompts.md); it is not symptom-by-symptom repair from
 conversation memory.

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -7,9 +7,12 @@ repository work has been activated; ordinary conceptual Chat remains outside
 repository startup. Shared operating rules remain owned by
 [`start-here.md`](../start-here.md) and [`core-model.md`](../core-model.md).
 
-The durable ChatGPT-versus-Codex routing reflects operator-observed client
-behavior checked 2026-08-14. It is Playbook classification rather than a
-provider guarantee about client layout, history, or mode behavior.
+Current [OpenAI Help Center guidance](https://help.openai.com/en/articles/20001275-chatgpt-work-and-codex)
+places Chat and Work under ChatGPT and identifies Codex as a distinct view with
+history separate from ChatGPT history. [ChatGPT Work guidance](https://learn.chatgpt.com/docs/get-started-with-work)
+describes Work as delegated work to ChatGPT and an alternative to Codex for
+non-coding tasks. The Playbook uses that documented persistence boundary for
+adapter selection.
 
 ## Repository-bootstrap boundary
 
@@ -164,6 +167,7 @@ conversation memory.
 ## Evidence and provider-reference boundary
 
 This adapter defines Playbook behavior, not a provider guarantee about how
-ChatGPT context, memory, permissions, or Work execution operates. Re-check
-provider behavior through authoritative current evidence when a task depends
-on it; keep observed runtime behavior separate from that evidence.
+ChatGPT context, memory, permissions, or Work execution operates. The current
+sources above establish only their documented selector, mode, and history
+behavior; other client details remain runtime evidence. Re-check provider
+behavior through authoritative current evidence when a task depends on it.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -1,10 +1,10 @@
 # Codex Adapter
 
 This adapter records Codex-specific deltas on top of the core playbook. Apply
-it to Codex runs wherever Codex is the selected executor, including the Codex
-area of a unified client and other supported Codex interfaces. Codex identifies
-a distinct run/executor boundary with specialized repository mechanics, not a
-separate desktop application. Use it with `docs/start-here.md`,
+it to Codex runs wherever Codex is the selected executor. The adapter boundary
+follows the selected Codex run or executor and does not depend on how a
+particular client packages that surface. It records the specialized repository
+mechanics for that distinct run/executor boundary. Use it with `docs/start-here.md`,
 `docs/core-model.md`, `docs/source-first-retrieval.md`,
 `docs/repo-readiness.md`, and the target repo's `AGENTS.md`; do not treat it as
 a second copy of those rules.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -1,7 +1,11 @@
 # Codex Adapter
 
-This adapter records Codex-specific deltas on top of the core playbook. Use it
-with `docs/start-here.md`, `docs/core-model.md`, `docs/source-first-retrieval.md`,
+This adapter records Codex-specific deltas on top of the core playbook. Apply
+it to Codex runs wherever Codex is the selected executor, including the Codex
+area of a unified client and other supported Codex interfaces. Codex identifies
+a distinct run/executor boundary with specialized repository mechanics, not a
+separate desktop application. Use it with `docs/start-here.md`,
+`docs/core-model.md`, `docs/source-first-retrieval.md`,
 `docs/repo-readiness.md`, and the target repo's `AGENTS.md`; do not treat it as
 a second copy of those rules.
 

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -7,11 +7,12 @@ DOCS = ROOT / "docs"
 
 
 class ChatGPTAdapterTests(unittest.TestCase):
-    def test_start_here_activates_chatgpt_work_and_rechecks_sources(self):
+    def test_start_here_activates_chatgpt_and_rechecks_sources(self):
         contents = (DOCS / "start-here.md").read_text(encoding="utf-8")
 
-        self.assertIn("ChatGPT/Work runs must read", contents)
+        self.assertIn("repository-scoped\n  ChatGPT runs must read", contents)
         self.assertIn("docs/tool-adapters/chatgpt.md", contents)
+        self.assertNotIn("ChatGPT/Work runs must read", contents)
         self.assertIn("Repository operating-mode persistence does not freeze", contents)
         self.assertIn("re-evaluate activation routing", contents)
         self.assertIn("Reuse still-current verified sources", contents)
@@ -51,6 +52,23 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "does not expand the human-authorized task", " ".join(contents.split())
         )
         self.assertIn("not symptom-by-symptom repair", contents)
+
+    def test_adapter_keeps_chat_and_work_under_chatgpt(self):
+        chatgpt = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
+        codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")
+        normalized_chatgpt = " ".join(chatgpt.split())
+        normalized_codex = " ".join(codex.split())
+
+        self.assertTrue(chatgpt.startswith("# ChatGPT Adapter\n"))
+        self.assertNotIn("# ChatGPT/Work Adapter", chatgpt)
+        self.assertIn("nested task-shape or capability modes", normalized_chatgpt)
+        self.assertIn("under that one ChatGPT adapter", normalized_chatgpt)
+        self.assertIn(
+            "not separate durable executor identities or adapters", normalized_chatgpt
+        )
+        self.assertIn("not separate authority contracts", normalized_chatgpt)
+        self.assertIn("not a separate desktop application", normalized_codex)
+        self.assertNotIn("Codex is a separate application", codex)
 
     def test_workspace_agents_projection_preserves_existing_owners(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -9,8 +9,11 @@ DOCS = ROOT / "docs"
 class ChatGPTAdapterTests(unittest.TestCase):
     def test_start_here_activates_chatgpt_and_rechecks_sources(self):
         contents = (DOCS / "start-here.md").read_text(encoding="utf-8")
+        normalized_start_here = " ".join(contents.split())
 
-        self.assertIn("repository-scoped\n  ChatGPT runs must read", contents)
+        self.assertIn(
+            "repository-scoped ChatGPT runs must read", normalized_start_here
+        )
         self.assertIn("docs/tool-adapters/chatgpt.md", contents)
         self.assertNotIn("ChatGPT/Work runs must read", contents)
         self.assertIn("Repository operating-mode persistence does not freeze", contents)
@@ -67,8 +70,10 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "not separate durable executor identities or adapters", normalized_chatgpt
         )
         self.assertIn("not separate authority contracts", normalized_chatgpt)
-        self.assertIn("not a separate desktop application", normalized_codex)
-        self.assertNotIn("Codex is a separate application", codex)
+        self.assertIn(
+            "does not depend on how a particular client packages that surface",
+            normalized_codex,
+        )
 
     def test_workspace_agents_projection_preserves_existing_owners(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Route repository-scoped ChatGPT use to the ChatGPT adapter and retain Codex runs as the Codex adapter boundary.
- Clarify that Chat and Work are nested ChatGPT modes, not durable executor identities or separate authority contracts.
- Clarify that the Codex adapter follows the selected Codex run or executor and is independent of client packaging.

## Rationale

The Playbook now matches the documented ChatGPT-versus-Codex persistence distinction while preserving legitimate Chat/Work locality and capability guidance.

## Materiality

Non-material clarification. Adapter files, activation obligations, authority boundaries, canonical owners, lifecycle gates, validation requirements, and prompt-contract semantics are unchanged.

## Validation

- `make check` — passed: markdownlint-cli2 found 0 issues across 54 files; 87 unit tests passed.
- `make authoritative-source-check` — passed: no non-authoritative source URLs found.
- `git diff --check` — passed.

## Files changed

- README.md
- docs/start-here.md
- docs/tool-adapters/chatgpt.md
- docs/tool-adapters/codex.md
- tests/test_chatgpt_adapter.py

## Evidence boundary and residual limitations

Current [OpenAI Help Center guidance](https://help.openai.com/en/articles/20001275-chatgpt-work-and-codex), checked 2026-08-14, documents the desktop selector, Chat and Work under ChatGPT, their shared Recents surface, and Codex as a distinct view with history separate from ChatGPT history. Current [ChatGPT Work guidance](https://learn.chatgpt.com/docs/get-started-with-work) documents Work as delegated work to ChatGPT and an alternative to Codex for non-coding tasks. The Playbook uses that documented persistence boundary for adapter selection.

Client packaging, eligibility, availability, and any client detail not established by those sources remain provider-controlled mutable state or runtime evidence and must be rechecked when a task depends on them.