### PR TITLE
docs: add ChatGPT prompt breadcrumbs

### DIFF
--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -127,13 +127,33 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-For a complete prompt prepared in ChatGPT, present the shared
-operator-metadata block followed immediately by the complete executable block
-as consecutive copyable code blocks. Keep the executable block complete without
-metadata so the operator can copy only that block. Do not nest Markdown code
-fences inside the executable block; represent any embedded example with
-indentation or plain text. Optimize this client rendering for reliable
-copy/paste without changing the shared prompt meaning in
+For a complete, copy-ready prompt or downstream handoff prepared in ChatGPT,
+present the shared operator-metadata block followed immediately by the complete
+executable block as consecutive copyable code blocks, with no intervening
+prose. Immediately after the executable block, outside both code blocks, emit
+this separate line exactly:
+
+`ChatGPT thread: [exact canonical title]`
+
+Keep the executable block complete without metadata or the breadcrumb so the
+operator can copy only that block. The breadcrumb is human navigation only: it
+is not task authority, execution identity, durable continuity, source
+evidence, or part of the downstream executable prompt. Do not add it to quoted
+prompts, source excerpts, incomplete fragments, or conceptual discussion that
+does not deliver a copy-ready prompt.
+
+When no canonical title exists for the current ChatGPT workstream, establish a
+concise one; reuse that exact title in later complete prompts from the same
+conversation. The emitted value is a canonical navigation title, not verified
+ChatGPT UI state when the UI title is not observable. For an applicable `FRESH
+THREAD` handoff, reuse the exact title in the existing executable `Thread
+name` instruction unless a task-specific naming requirement makes that
+inappropriate. This does not change the normal `SAME THREAD` or `CHILD TASK`
+routing behavior in [`prompts.md`](../prompts.md#executor-applied-visible-thread-names).
+
+Do not nest Markdown code fences inside the executable block; represent any
+embedded example with indentation or plain text. Optimize this client rendering
+for reliable copy/paste without changing the shared prompt meaning in
 [`prompts.md`](../prompts.md).
 
 ## Generated artifacts

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -103,3 +103,29 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "maintenance-automations.md",
         ):
             self.assertIn(owner, contents)
+
+    def test_copy_ready_prompt_breadcrumb_stays_outside_both_code_blocks(self):
+        contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
+        normalized = " ".join(contents.split())
+
+        self.assertIn("complete, copy-ready prompt or downstream handoff", contents)
+        self.assertIn("with no intervening prose", normalized)
+        self.assertIn(
+            "`ChatGPT thread: [exact canonical title]`",
+            contents,
+        )
+        self.assertIn("outside both code blocks", contents)
+        self.assertIn(
+            "not task authority, execution identity, durable continuity, source evidence",
+            normalized,
+        )
+        self.assertIn("or part of the downstream executable prompt", normalized)
+        self.assertIn(
+            "quoted prompts, source excerpts, incomplete fragments, or conceptual discussion",
+            normalized,
+        )
+        self.assertIn("reuse that exact title in later complete prompts", normalized)
+        self.assertIn("not verified ChatGPT UI state", normalized)
+        self.assertIn("applicable `FRESH THREAD` handoff", normalized)
+        self.assertIn("existing executable `Thread name` instruction", normalized)
+        self.assertIn("normal `SAME THREAD` or `CHILD TASK`", normalized)


### PR DESCRIPTION
## Summary

- Require ChatGPT copy-ready prompts and downstream handoffs to render a canonical ChatGPT-thread breadcrumb after the executable code block.
- Preserve the metadata block followed immediately by the executable block, with no intervening prose.
- Add focused adapter coverage for breadcrumb placement, navigation-only semantics, title reuse, routing, and the unobservable UI-title limitation.

## Ownership rationale

The breadcrumb is ChatGPT-specific presentation and identifies the originating ChatGPT conversation, so `docs/tool-adapters/chatgpt.md` is the narrowest canonical owner. Shared prompt and executor-applied visible-thread-name semantics remain in `docs/prompts.md`; no Codex adapter doctrine changed.

## Resulting behavior

Complete copy-ready output renders the metadata code block, then the executable code block, then:

`ChatGPT thread: [exact canonical title]`

The breadcrumb is outside both code blocks and is not downstream prompt content, authority, execution identity, durable continuity, or source evidence. A fresh downstream thread normally reuses the same canonical title in the existing executable `Thread name` instruction.

## Validation

- `make check` (Markdown lint: 0 issues; unit tests: 88 passed)

## Limitation

The emitted canonical navigation title is not presented as verified ChatGPT UI state when the actual UI title is not observable.