### PR TITLE
ci: bound authoritative source check runtime

### DIFF
--- a/.github/workflows/authoritative-source-check.yml
+++ b/.github/workflows/authoritative-source-check.yml
@@ -27,6 +27,7 @@ jobs:
   authoritative-source-check:
     name: authoritative-source-check
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     continue-on-error: true
 
     steps:


### PR DESCRIPTION
## What changed

- Add a five-minute timeout to the reusable authoritative-source-check job.

## Why

The advisory scan checks out two repositories and runs a small local scanner. A job-level bound prevents a stalled hosted runner from consuming capacity indefinitely while preserving the existing advisory behavior.

## Scope check

- [x] This PR contains one logical change.
- [x] No application or project-specific automation was added.

## Interaction mode

Implementation

## Validation

- `make check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/authoritative-source-check.yml"); puts "workflow YAML parses"'`
- `git diff --check`

## Source evidence

Current reusable workflow job configuration in `.github/workflows/authoritative-source-check.yml`.

## Residual risks / follow-ups

GitHub Actions will enforce the runtime bound on the next workflow invocation.

## Issue closure

No issue.