### PR TITLE
test: cover connector-backed PR evidence

### DIFF
--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -78,3 +78,16 @@ class CodexAdapterTests(unittest.TestCase):
             "narrowest available way to retrieve authoritative state",
         ):
             self.assertIn(phrase, self.contents)
+
+    def test_pr_evidence_requires_current_connector_backed_state(self):
+        for phrase in (
+            "## GitHub And PR Evidence",
+            "verify GitHub access instead of relying on cached context, summaries, or local branch state",
+            "follow the connector-first rule",
+            "Local checkout state, `git diff`, and `gh` output may supplement PR review",
+            "but they do not replace it",
+            "stop and report the access blocker instead of inferring remote state",
+            "Do not claim mergeability, required checks, or branch-protection state without",
+            "current PR or repository evidence",
+        ):
+            self.assertIn(phrase, self.contents)


### PR DESCRIPTION
## Summary

- Add focused Codex-adapter coverage for current connector-backed PR evidence.
- Preserve the boundary that local checkout state and `gh` output can supplement, but cannot replace, inspected remote state.

## Rationale

The adapter's GitHub and PR Evidence section had no direct regression coverage, despite governing high-value claims about mergeability, required checks, and branch protection.

## Validation

- `make check` — passed (Markdown lint clean; 89 unit tests)
- `git diff --check` — passed
- `git merge-tree --write-tree origin/main HEAD` — passed against `9c871da814be9f47e46d58066624c653ecc3b296`

## Scope

One test-only change in `tests/test_codex_adapter.py`; no workflow doctrine or production behavior changed.

## Follow-ups

None.