### PR TITLE
docs: route work by execution surface

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -135,6 +135,33 @@ semantic change.
 - Summarize changes, evidence, and open questions
 - Help capture reusable patterns after delivery
 
+## Interactive Control And Bounded Execution
+
+Interactive control and bounded execution are semantic roles, not universal
+product identities or authority classes. An interactive controller supports
+human-led clarification, scoping, authority decisions, decomposition,
+steering, review, and disposition. A bounded executor performs a defined
+outcome under an explicit execution contract. Difficult or consequential
+reasoning may remain with the controller while it is still interactive
+judgment; a bounded deliverable and execution contract, not difficulty or
+model choice, establish the execution handoff.
+
+The controller does not become canonical, universally authoritative, or a
+required intermediary for every workflow. Human direction and the source that
+owns each fact or decision retain their existing authority. Independently
+initiated or automated work may begin under another owning contract without an
+interactive controller.
+
+A semantic handoff declares the current bounded action, the existing human
+authority and its owning reference, the sources and constraints that apply,
+and the completion boundary. It may point to exact durable recoverable state
+instead of reproducing that state in conversation. The handoff, its pointer,
+the recovered payload, a recorded next action, validation, and successful
+retrieval create zero authority. The receiving actor must verify its identity
+and current authority, refresh mutable facts from their owning sources, and
+fail closed where the applicable contract or exact recoverable state cannot be
+resolved.
+
 ## Authority And Transitions
 
 Authority is permission to make a decision or cross a workflow boundary. It is

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -23,6 +23,160 @@ identity, authority, safety, validation, or unambiguous retrieval. Reducing
 redundant context is execution engineering, not methodology or architecture
 evidence.
 
+## Task-Shape Surface Selection And Thin Handoffs
+
+When Chat is the current interactive surface, use it as the normal control
+plane for human-led clarification, scoping, authority decisions, decomposition,
+steering, review, and disposition. Keep hard reasoning in Chat while that
+semantic role remains interactive. Move work only after a bounded outcome and
+execution contract have emerged:
+
+- choose Work for a bounded general-purpose multi-step outcome or
+  non-repository deliverable;
+- choose Codex when completion materially depends on repository locality,
+  terminal commands, tests, Git, worktrees, commits, pull requests, or code
+  review; and
+- keep work in Chat when the next useful result is discussion, judgment,
+  clarification, steering, or review rather than delegated execution.
+
+Select by semantic role, execution locality, required tools, and deliverable.
+Difficulty, model tier, and reasoning setting do not select a surface. Chat is
+the normal interactive controller, not a mandatory mediator for every
+automated or independently initiated workflow, a universal authority, a
+canonical record, or a project system of record. Ordinary chat, brainstorming,
+and conceptual discussion remain lightweight and do not inherit repository
+ceremony.
+
+Keep these dimensions distinct:
+
+| Dimension | Meaning |
+| --- | --- |
+| Interaction surface | Where a human discusses, steers, reviews, or delegates. |
+| Executor identity | The runtime or agent that performs the bounded work. |
+| Task shape | Interactive reasoning, a general delegated outcome, or repository execution. |
+| Model or reasoning choice | An execution setting that does not by itself change semantic role. |
+| Handoff contract | Current sources, authority declaration and owning reference, constraints, locality, validation, outputs, and stop boundary. |
+| Durable package pointer | The exact external manifest or sealed-package identity used to hydrate recoverable state. |
+| Durable continuity | The owning authoritative sources and records from which the work can be recovered. |
+
+Moving between Chat and Work does not create a new durable executor identity or
+authority contract merely because the interface changed. Moving to Codex is a
+distinct repository-execution handoff and must make repository, locality,
+tools, validation, delivery, and stop boundaries explicit. Shared application
+chrome, project membership, conversation history, product branding, or a
+folder name does not prove that context or authority transferred.
+
+### Surface-transition check
+
+At a surface transition, re-evaluate context sufficiency and any materially
+changed source, authority, locality, acting identity, tool, validation, output,
+or completion boundary. Retrieve newly activated owners and refresh mutable
+repository, GitHub, planning-system, and provider facts from the systems that
+own them before relying on those facts. Reuse still-current verified context;
+a surface change does not require blanket rehydration or replay of unchanged
+doctrine.
+
+### Thin semantic handoff envelope
+
+When complete recoverable state is held outside the conversation, a thin
+role-specific envelope carries only the current routing delta. Include, as
+applicable:
+
+- target surface or executor role;
+- bounded requested outcome;
+- exact self-describing governed manifest or sealed-package identity;
+- current human direction and bounded authority declaration, its owning
+  authority reference, and prohibited actions;
+- mutable sources that the target must refresh from their owners;
+- required locality and tools;
+- validation, outputs, and completion or stop boundary.
+
+These are semantic fields, not an operational package schema. The pointed
+package may preserve the complete contract, accepted inputs, source and
+artifact identities, prior decisions, receipts, validation evidence, and a
+recorded next permitted action. The target must retrieve and verify the exact
+manifest or sealed-package identity before relying on that payload. For
+material execution, use the exact identity evidence required by the owning
+package contract, such as an immutable path plus digest, file identity, attempt
+identity, or version. A mutable issue directory, package root, or bare folder
+path is navigation only; it is not the governing package identity.
+
+The envelope declares human direction, bounded authority, and the owning
+authority reference but creates zero authority itself. Stored contracts,
+next-action statements, paths, digests, packages, prompts, receipts,
+validation, and successful retrieval also create or transfer zero authority. A
+recorded next action remains historical or asserted instruction until the
+current acting identity and live authority are verified from their owner.
+
+If the exact package identity is inaccessible, unresolved, stale, mismatched,
+or ambiguous, stop before affected execution or return an explicit
+non-authorizing partial result. Do not reconstruct missing contract, authority,
+or evidence from conversation memory.
+
+### Target-shaped projections
+
+Shape the thin envelope for the selected target rather than sending a generic
+prompt.
+
+For Work, emphasize the delegated outcome, permitted connected sources and
+tools, source refresh, output form, quality checks, and return boundary:
+
+```text
+Target: Work — bounded general-purpose outcome
+Outcome: [source-backed non-repository deliverable]
+Governed payload: [exact manifest or sealed-package identity]
+Human direction and authority: [bounded declaration, owning reference, prohibitions]
+Refresh: [mutable sources to retrieve from their owners]
+Tools and locality: [permitted connected sources and execution location]
+Validation and output: [quality checks and deliverable form]
+Return boundary: [return to Chat for review or stop condition]
+```
+
+For Codex, emphasize repository execution, exact locality, terminal and Git
+tools, canonical validation, delivery, and the stop-before-merge boundary:
+
+```text
+Target: Codex — repository execution
+Outcome: [bounded repository change or review]
+Repository and locality: [repository, worktree, branch, relevant surface]
+Governed payload: [exact manifest or sealed-package identity]
+Human direction and authority: [bounded declaration, owning reference, prohibitions]
+Refresh: [repository, GitHub, planning, and provider facts to re-read]
+Tools: [terminal, tests, Git, worktrees, commits, PR, or code review as applicable]
+Validation and delivery: [canonical command, outputs, commit/push/PR expectation]
+Stop boundary: [including no merge or other prohibited transition]
+```
+
+### Examples
+
+1. **Difficult architecture discussion remains in Chat.** The human and Chat
+   are still comparing authority boundaries and tradeoffs. No bounded
+   deliverable or execution contract exists, so difficulty does not trigger a
+   move to Work or Codex.
+2. **Source-backed report moves from Chat to Work.** Chat establishes the
+   question and authority boundary, then sends a Work-shaped envelope for a
+   cited report with `Governed payload: [immutable manifest path plus exact
+   digest or file identity]`, current source-refresh instructions, output
+   checks, and return-to-Chat boundary. It does not paste the recoverable
+   package into the conversation.
+3. **Repository implementation moves from Chat to Codex.** Chat establishes a
+   bounded repository outcome, then sends a Codex-shaped envelope naming the
+   repository and worktree expectations, terminal and Git tools, canonical
+   validation, PR delivery, stop-before-merge boundary, and `Governed payload:
+   [exact sealed-package identity]`.
+4. **Discussion becomes delegated execution.** A task begins in Chat as an
+   open-ended product discussion. It stays there until the human selects a
+   bounded comparison report with accepted sources and review criteria; only
+   then does it move to Work.
+5. **Worker result returns to Chat.** Work returns the report identity,
+   validation evidence, limitations, and output—not new authority. Chat is
+   again the interactive surface for human review, interpretation,
+   disposition, or next-step selection.
+6. **Package reference fails closed.** A target receives only a mutable folder,
+   or the named manifest is inaccessible, stale, digest-mismatched, or
+   ambiguous. It stops the affected work or reports a non-authorizing partial
+   result without rebuilding the missing payload from conversation memory.
+
 ## Thread Routing And Configuration Continuity
 
 Model selection, reasoning or thinking configuration, and thread routing are
@@ -207,6 +361,7 @@ Reason:
 
 ## Quick Navigation
 
+- [Task-Shape Surface Selection And Thin Handoffs](#task-shape-surface-selection-and-thin-handoffs)
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Orchestration Handoff](#orchestration-handoff)

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -25,27 +25,20 @@ evidence.
 
 ## Task-Shape Surface Selection And Thin Handoffs
 
-When Chat is the current interactive surface, use it as the normal control
-plane for human-led clarification, scoping, authority decisions, decomposition,
-steering, review, and disposition. Keep hard reasoning in Chat while that
-semantic role remains interactive. Move work only after a bounded outcome and
-execution contract have emerged:
+Select a target surface or execution role by semantic role, execution locality,
+required tools, and deliverable. Keep work with an interactive controller while
+the next useful result is discussion, judgment, clarification, steering, or
+review. Move to a general-purpose bounded executor when a bounded multi-step
+outcome or non-repository deliverable has emerged. Move to a repository
+executor when completion materially depends on repository locality, terminal
+commands, tests, version control, worktrees, commits, pull requests, or code
+review.
 
-- choose Work for a bounded general-purpose multi-step outcome or
-  non-repository deliverable;
-- choose Codex when completion materially depends on repository locality,
-  terminal commands, tests, Git, worktrees, commits, pull requests, or code
-  review; and
-- keep work in Chat when the next useful result is discussion, judgment,
-  clarification, steering, or review rather than delegated execution.
-
-Select by semantic role, execution locality, required tools, and deliverable.
-Difficulty, model tier, and reasoning setting do not select a surface. Chat is
-the normal interactive controller, not a mandatory mediator for every
-automated or independently initiated workflow, a universal authority, a
-canonical record, or a project system of record. Ordinary chat, brainstorming,
-and conceptual discussion remain lightweight and do not inherit repository
-ceremony.
+Difficulty, model tier, and reasoning setting do not select a surface. A task
+changes surface only after a bounded outcome and execution contract have
+emerged. Ordinary discussion, brainstorming, and conceptual work remain
+lightweight and do not inherit repository ceremony. The matching target adapter
+owns each concrete product or executor projection.
 
 Keep these dimensions distinct:
 
@@ -59,22 +52,22 @@ Keep these dimensions distinct:
 | Durable package pointer | The exact external manifest or sealed-package identity used to hydrate recoverable state. |
 | Durable continuity | The owning authoritative sources and records from which the work can be recovered. |
 
-Moving between Chat and Work does not create a new durable executor identity or
-authority contract merely because the interface changed. Moving to Codex is a
-distinct repository-execution handoff and must make repository, locality,
-tools, validation, delivery, and stop boundaries explicit. Shared application
-chrome, project membership, conversation history, product branding, or a
-folder name does not prove that context or authority transferred.
+An interface change does not create a new durable executor identity or
+authority contract when the underlying executor identity and authority remain
+the same. A transition to a distinct repository executor is a repository-
+execution handoff and must make repository, locality, tools, validation,
+delivery, and stop boundaries explicit. Shared application chrome, project
+membership, conversation history, product branding, or a folder name does not
+prove that context or authority transferred.
 
 ### Surface-transition check
 
 At a surface transition, re-evaluate context sufficiency and any materially
 changed source, authority, locality, acting identity, tool, validation, output,
 or completion boundary. Retrieve newly activated owners and refresh mutable
-repository, GitHub, planning-system, and provider facts from the systems that
-own them before relying on those facts. Reuse still-current verified context;
-a surface change does not require blanket rehydration or replay of unchanged
-doctrine.
+repository, planning-system, and provider facts from the systems that own them
+before relying on those facts. Reuse still-current verified context; a surface
+change does not require blanket rehydration or replay of unchanged doctrine.
 
 ### Thin semantic handoff envelope
 
@@ -115,67 +108,12 @@ or evidence from conversation memory.
 
 ### Target-shaped projections
 
-Shape the thin envelope for the selected target rather than sending a generic
-prompt.
-
-For Work, emphasize the delegated outcome, permitted connected sources and
-tools, source refresh, output form, quality checks, and return boundary:
-
-```text
-Target: Work — bounded general-purpose outcome
-Outcome: [source-backed non-repository deliverable]
-Governed payload: [exact manifest or sealed-package identity]
-Human direction and authority: [bounded declaration, owning reference, prohibitions]
-Refresh: [mutable sources to retrieve from their owners]
-Tools and locality: [permitted connected sources and execution location]
-Validation and output: [quality checks and deliverable form]
-Return boundary: [return to Chat for review or stop condition]
-```
-
-For Codex, emphasize repository execution, exact locality, terminal and Git
-tools, canonical validation, delivery, and the stop-before-merge boundary:
-
-```text
-Target: Codex — repository execution
-Outcome: [bounded repository change or review]
-Repository and locality: [repository, worktree, branch, relevant surface]
-Governed payload: [exact manifest or sealed-package identity]
-Human direction and authority: [bounded declaration, owning reference, prohibitions]
-Refresh: [repository, GitHub, planning, and provider facts to re-read]
-Tools: [terminal, tests, Git, worktrees, commits, PR, or code review as applicable]
-Validation and delivery: [canonical command, outputs, commit/push/PR expectation]
-Stop boundary: [including no merge or other prohibited transition]
-```
-
-### Examples
-
-1. **Difficult architecture discussion remains in Chat.** The human and Chat
-   are still comparing authority boundaries and tradeoffs. No bounded
-   deliverable or execution contract exists, so difficulty does not trigger a
-   move to Work or Codex.
-2. **Source-backed report moves from Chat to Work.** Chat establishes the
-   question and authority boundary, then sends a Work-shaped envelope for a
-   cited report with `Governed payload: [immutable manifest path plus exact
-   digest or file identity]`, current source-refresh instructions, output
-   checks, and return-to-Chat boundary. It does not paste the recoverable
-   package into the conversation.
-3. **Repository implementation moves from Chat to Codex.** Chat establishes a
-   bounded repository outcome, then sends a Codex-shaped envelope naming the
-   repository and worktree expectations, terminal and Git tools, canonical
-   validation, PR delivery, stop-before-merge boundary, and `Governed payload:
-   [exact sealed-package identity]`.
-4. **Discussion becomes delegated execution.** A task begins in Chat as an
-   open-ended product discussion. It stays there until the human selects a
-   bounded comparison report with accepted sources and review criteria; only
-   then does it move to Work.
-5. **Worker result returns to Chat.** Work returns the report identity,
-   validation evidence, limitations, and output—not new authority. Chat is
-   again the interactive surface for human review, interpretation,
-   disposition, or next-step selection.
-6. **Package reference fails closed.** A target receives only a mutable folder,
-   or the named manifest is inaccessible, stale, digest-mismatched, or
-   ambiguous. It stops the affected work or reports a non-authorizing partial
-   result without rebuilding the missing payload from conversation memory.
+Shape the thin envelope through the matching target adapter rather than sending
+one generic prompt. A general-purpose bounded-executor projection emphasizes
+the delegated outcome, permitted sources and tools, source refresh, output
+form, quality checks, and return boundary. A repository-executor projection
+also makes repository identity and locality, repository tools, canonical
+validation, delivery, and the stop-before-merge boundary explicit.
 
 ## Thread Routing And Configuration Continuity
 

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -56,6 +56,30 @@ repository execution posture and
 [`maintenance-automations.md`](../maintenance-automations.md) when locality or
 unattended-work guidance is activated.
 
+### Interactive control-plane projection
+
+Chat is the normal interactive control plane for human-led clarification,
+scoping, authority decisions, decomposition, steering, review, and disposition.
+Work is the preferred ChatGPT surface for a bounded general-purpose multi-step
+outcome or non-repository deliverable. Hard reasoning may remain in Chat while
+the task is still interactive; difficulty, model tier, or reasoning setting
+does not select Work or Codex.
+
+This is a default task-shape projection, not a claim that Chat is canonical,
+universally authoritative, or required to mediate every workflow. Chat and
+Work remain nested surfaces under one ChatGPT adapter. Use the shared routing,
+surface-transition, thin-envelope, and target-shaping rules in
+[`prompts.md`](../prompts.md#task-shape-surface-selection-and-thin-handoffs).
+
+When a handoff points to an exact package through a connected app, treat access
+as runtime evidence. Inspect or attempt retrieval of the named manifest or
+sealed-package identity before claiming it is accessible, and verify the exact
+identity before relying on its payload. Listing a folder or reaching a mutable
+package root proves neither exact-package access nor current authority. If the
+identity cannot be accessed, resolved, or verified, fail closed or return an
+explicit non-authorizing partial result without reconstructing it from Chat or
+Work memory.
+
 ## Connected apps, approvals, and consequential actions
 
 An installed or authenticated app, available action, or product approval

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -61,9 +61,12 @@ unattended-work guidance is activated.
 Chat is the normal interactive control plane for human-led clarification,
 scoping, authority decisions, decomposition, steering, review, and disposition.
 Work is the preferred ChatGPT surface for a bounded general-purpose multi-step
-outcome or non-repository deliverable. Hard reasoning may remain in Chat while
-the task is still interactive; difficulty, model tier, or reasoning setting
-does not select Work or Codex.
+outcome or non-repository deliverable. Codex is the preferred distinct
+repository-oriented executor when completion materially depends on repository
+locality, terminal commands, tests, Git, worktrees, commits, pull requests, or
+code review. Hard reasoning may remain in Chat while the task is still
+interactive; difficulty, model tier, or reasoning setting does not select Work
+or Codex.
 
 This is a default task-shape projection, not a claim that Chat is canonical,
 universally authoritative, or required to mediate every workflow. Chat and
@@ -79,6 +82,75 @@ package root proves neither exact-package access nor current authority. If the
 identity cannot be accessed, resolved, or verified, fail closed or return an
 explicit non-authorizing partial result without reconstructing it from Chat or
 Work memory.
+
+#### Work-shaped handoff
+
+Project the shared thin-envelope semantics for a delegated general-purpose
+outcome by emphasizing permitted connected sources and tools, output form,
+quality checks, and the return-to-Chat boundary:
+
+```text
+Target: Work — bounded general-purpose outcome
+Outcome: [source-backed non-repository deliverable]
+Governed payload: [exact manifest or sealed-package identity]
+Human direction and authority: [bounded declaration, owning reference, prohibitions]
+Refresh: [mutable sources to retrieve from their owners]
+Tools and locality: [permitted connected sources and execution location]
+Validation and output: [quality checks and deliverable form]
+Return boundary: [return to Chat for review or stop condition]
+```
+
+#### Codex-shaped handoff
+
+Project the shared thin-envelope semantics for repository execution by adding
+exact repository locality, terminal and Git tools, canonical validation,
+delivery, and the stop-before-merge boundary:
+
+```text
+Target: Codex — repository execution
+Outcome: [bounded repository change or review]
+Repository and locality: [repository, worktree, branch, relevant surface]
+Governed payload: [exact manifest or sealed-package identity]
+Human direction and authority: [bounded declaration, owning reference, prohibitions]
+Refresh: [repository, GitHub, planning, and provider facts to re-read]
+Tools: [terminal, tests, Git, worktrees, commits, PR, or code review as applicable]
+Validation and delivery: [canonical command, outputs, commit/push/PR expectation]
+Stop boundary: [including no merge or other prohibited transition]
+```
+
+These shapes project the shared owner in
+[`prompts.md`](../prompts.md#task-shape-surface-selection-and-thin-handoffs);
+they do not redefine its package, authority, source-refresh, or failure
+semantics.
+
+#### Examples
+
+1. **Difficult architecture discussion remains in Chat.** The human and Chat
+   are still comparing authority boundaries and tradeoffs. No bounded
+   deliverable or execution contract exists, so difficulty does not trigger a
+   move to Work or Codex.
+2. **Source-backed report moves from Chat to Work.** Chat establishes the
+   question and authority boundary, then sends the Work-shaped envelope with
+   an exact manifest identity, current source-refresh instructions, output
+   checks, and return-to-Chat boundary. The complete recoverable package is not
+   pasted into conversation.
+3. **Repository implementation moves from Chat to Codex.** Chat establishes a
+   bounded repository outcome, then sends the Codex-shaped envelope with the
+   exact sealed-package identity, repository and worktree expectations,
+   terminal and Git tools, canonical validation, PR delivery, and a
+   stop-before-merge boundary.
+4. **Discussion becomes delegated execution.** A task begins in Chat as an
+   open-ended product discussion. It stays there until the human selects a
+   bounded comparison report with accepted sources and review criteria; only
+   then does it move to Work.
+5. **Worker result returns to Chat.** Work returns the report identity,
+   validation evidence, limitations, and output—not new authority. Chat is
+   again the interactive surface for human review, interpretation,
+   disposition, or next-step selection.
+6. **Package reference fails closed.** A target receives only a mutable folder,
+   or the named manifest is inaccessible, stale, digest-mismatched, or
+   ambiguous. It stops the affected work or reports a non-authorizing partial
+   result without rebuilding the missing payload from conversation memory.
 
 ## Connected apps, approvals, and consequential actions
 

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -289,6 +289,9 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         normalized_codex = " ".join(codex.split())
         normalized_chatgpt = " ".join(chatgpt.split())
         normalized_claude = " ".join(claude.split())
+        naming_section = prompts.split(
+            "### Executor-Applied Visible Thread Names", 1
+        )[1].split("\n## ", 1)[0]
         canonical_fragment = (
             "Thread name:\n"
             "- Before substantive work, set this thread's visible name to: `[exact visible name]`.\n"
@@ -336,8 +339,8 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             prompts,
         )
         self.assertIn("Repository Implementation Task", prompts)
-        self.assertNotIn("Codex", prompts)
-        self.assertNotIn("ChatGPT", prompts)
+        self.assertNotIn("Codex", naming_section)
+        self.assertNotIn("ChatGPT", naming_section)
         self.assertIn("matching executor adapter", prompts)
         self.assertIn("Codex is currently the Playbook adapter", normalized_codex)
         self.assertEqual(codex.count(canonical_fragment), 1)

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -289,9 +289,6 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         normalized_codex = " ".join(codex.split())
         normalized_chatgpt = " ".join(chatgpt.split())
         normalized_claude = " ".join(claude.split())
-        naming_section = prompts.split(
-            "### Executor-Applied Visible Thread Names", 1
-        )[1].split("\n## ", 1)[0]
         canonical_fragment = (
             "Thread name:\n"
             "- Before substantive work, set this thread's visible name to: `[exact visible name]`.\n"
@@ -339,8 +336,8 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             prompts,
         )
         self.assertIn("Repository Implementation Task", prompts)
-        self.assertNotIn("Codex", naming_section)
-        self.assertNotIn("ChatGPT", naming_section)
+        self.assertNotIn("Codex", prompts)
+        self.assertNotIn("ChatGPT", prompts)
         self.assertIn("matching executor adapter", prompts)
         self.assertIn("Codex is currently the Playbook adapter", normalized_codex)
         self.assertEqual(codex.count(canonical_fragment), 1)

--- a/tests/test_surface_handoff_semantics.py
+++ b/tests/test_surface_handoff_semantics.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+
+def normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+class SurfaceHandoffSemanticTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.core = normalized(DOCS / "core-model.md")
+        cls.prompts = normalized(DOCS / "prompts.md")
+        cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
+
+    def test_core_owns_controller_executor_role_and_zero_authority_boundary(self):
+        for phrase in (
+            "Interactive Control And Bounded Execution",
+            "semantic roles, not universal product identities or authority classes",
+            "bounded deliverable and execution contract, not difficulty or model choice",
+            "does not become canonical, universally authoritative, or a required intermediary",
+            "fail closed where the applicable contract or exact recoverable state cannot be resolved",
+        ):
+            self.assertIn(phrase, self.core)
+
+    def test_surface_selection_preserves_distinct_dimensions_and_task_shape(self):
+        for phrase in (
+            "Interaction surface",
+            "Executor identity",
+            "Task shape",
+            "Model or reasoning choice",
+            "Handoff contract",
+            "Durable package pointer",
+            "Durable continuity",
+            "choose Work for a bounded general-purpose multi-step outcome",
+            "choose Codex when completion materially depends on repository locality",
+            "Difficulty, model tier, and reasoning setting do not select a surface",
+            "Ordinary chat, brainstorming, and conceptual discussion remain lightweight",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+    def test_transition_is_proportional_and_refreshes_mutable_owners(self):
+        for phrase in (
+            "Surface-transition check",
+            "re-evaluate context sufficiency",
+            "acting identity",
+            "refresh mutable repository, GitHub, planning-system, and provider facts",
+            "Reuse still-current verified context",
+            "does not require blanket rehydration",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+    def test_thin_envelope_requires_exact_identity_and_fails_closed(self):
+        for phrase in (
+            "exact self-describing governed manifest or sealed-package identity",
+            "These are semantic fields, not an operational package schema",
+            "exact identity evidence required by the owning package contract",
+            "bare folder path is navigation only",
+            "creates zero authority itself",
+            "recorded next action remains historical or asserted instruction",
+            "inaccessible, unresolved, stale, mismatched, or ambiguous",
+            "Do not reconstruct missing contract, authority, or evidence from conversation memory",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+    def test_work_and_codex_handoffs_are_target_shaped(self):
+        for phrase in (
+            "Target: Work — bounded general-purpose outcome",
+            "Tools and locality: [permitted connected sources and execution location]",
+            "Return boundary: [return to Chat for review or stop condition]",
+            "Target: Codex — repository execution",
+            "Repository and locality: [repository, worktree, branch, relevant surface]",
+            "Validation and delivery: [canonical command, outputs, commit/push/PR expectation]",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+    def test_all_required_examples_are_present(self):
+        for phrase in (
+            "Difficult architecture discussion remains in Chat",
+            "Source-backed report moves from Chat to Work",
+            "Repository implementation moves from Chat to Codex",
+            "Discussion becomes delegated execution",
+            "Worker result returns to Chat",
+            "Package reference fails closed",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+    def test_chatgpt_projection_keeps_one_adapter_and_verifies_package_access(self):
+        self.assertIn("Chat is the normal interactive control plane", self.chatgpt)
+        self.assertIn("Work is the preferred ChatGPT surface", self.chatgpt)
+        self.assertIn("nested surfaces under one ChatGPT adapter", self.chatgpt)
+        self.assertIn("Inspect or attempt retrieval", self.chatgpt)
+        self.assertIn("Listing a folder or reaching a mutable package root", self.chatgpt)
+        self.assertFalse((DOCS / "tool-adapters" / "work.md").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_surface_handoff_semantics.py
+++ b/tests/test_surface_handoff_semantics.py
@@ -14,6 +14,7 @@ class SurfaceHandoffSemanticTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.core = normalized(DOCS / "core-model.md")
+        cls.prompts_raw = (DOCS / "prompts.md").read_text(encoding="utf-8")
         cls.prompts = normalized(DOCS / "prompts.md")
         cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
 
@@ -36,19 +37,32 @@ class SurfaceHandoffSemanticTests(unittest.TestCase):
             "Handoff contract",
             "Durable package pointer",
             "Durable continuity",
-            "choose Work for a bounded general-purpose multi-step outcome",
-            "choose Codex when completion materially depends on repository locality",
+            "general-purpose bounded executor",
+            "repository executor when completion materially depends on repository locality",
             "Difficulty, model tier, and reasoning setting do not select a surface",
-            "Ordinary chat, brainstorming, and conceptual discussion remain lightweight",
+            "matching target adapter owns each concrete product or executor projection",
         ):
             self.assertIn(phrase, self.prompts)
+
+    def test_prompts_remains_executor_neutral(self):
+        for product_name in ("ChatGPT", "Codex"):
+            self.assertNotIn(product_name, self.prompts_raw)
+        for concrete_projection in (
+            "When Chat is the current interactive surface",
+            "choose Work for",
+            "Target: Work",
+            "Target: Codex",
+            "return to Chat",
+            "moves from Chat",
+        ):
+            self.assertNotIn(concrete_projection, self.prompts_raw)
 
     def test_transition_is_proportional_and_refreshes_mutable_owners(self):
         for phrase in (
             "Surface-transition check",
             "re-evaluate context sufficiency",
             "acting identity",
-            "refresh mutable repository, GitHub, planning-system, and provider facts",
+            "refresh mutable repository, planning-system, and provider facts",
             "Reuse still-current verified context",
             "does not require blanket rehydration",
         ):
@@ -76,7 +90,7 @@ class SurfaceHandoffSemanticTests(unittest.TestCase):
             "Repository and locality: [repository, worktree, branch, relevant surface]",
             "Validation and delivery: [canonical command, outputs, commit/push/PR expectation]",
         ):
-            self.assertIn(phrase, self.prompts)
+            self.assertIn(phrase, self.chatgpt)
 
     def test_all_required_examples_are_present(self):
         for phrase in (
@@ -87,11 +101,12 @@ class SurfaceHandoffSemanticTests(unittest.TestCase):
             "Worker result returns to Chat",
             "Package reference fails closed",
         ):
-            self.assertIn(phrase, self.prompts)
+            self.assertIn(phrase, self.chatgpt)
 
     def test_chatgpt_projection_keeps_one_adapter_and_verifies_package_access(self):
         self.assertIn("Chat is the normal interactive control plane", self.chatgpt)
         self.assertIn("Work is the preferred ChatGPT surface", self.chatgpt)
+        self.assertIn("Codex is the preferred distinct repository-oriented executor", self.chatgpt)
         self.assertIn("nested surfaces under one ChatGPT adapter", self.chatgpt)
         self.assertIn("Inspect or attempt retrieval", self.chatgpt)
         self.assertIn("Listing a folder or reaching a mutable package root", self.chatgpt)


### PR DESCRIPTION
## Summary

- make Chat explicit as the normal interactive control plane without making conversation canonical or universally authoritative
- route bounded outcomes to Work or Codex by semantic task shape, locality, tools, and deliverable
- define proportional surface-transition checks and thin target-shaped handoffs using exact governed manifest or sealed-package identities
- keep shared prompt semantics executor-neutral while placing concrete Chat, Work, and Chat-to-Codex projections in the ChatGPT adapter

## Review correction

Focused review of head 93a2a6a1c2441b23ab01615493dfb8638f4d9fea found that concrete product routing, templates, and examples contradicted the executor-neutral ownership contract in docs/prompts.md. The correction relocates that material to the ChatGPT adapter and restores the original global ChatGPT/Codex neutrality guard. The current candidate head is 47d644b6bf2a1fb120540426d6cdfd392bb39a3d and requires focused re-review; the prior reviewed head is historical evidence only.

## Canonical ownership decisions

- docs/core-model.md owns the provider-independent interactive-controller versus bounded-executor role boundary and zero-authority semantic handoff invariant.
- docs/prompts.md owns executor-neutral surface and execution-role transitions, proportional context re-evaluation, thin-envelope semantics, exact package-pointer requirements, and target-adapter projection requirements.
- docs/tool-adapters/chatgpt.md owns concrete Chat, Work, and Chat-to-Codex routing, Work- and Codex-shaped handoffs, runtime package-access verification, and all six CAK-152 examples.
- docs/tool-adapters/codex.md remains unchanged because existing repository locality, tool, validation, worktree, delivery, authority, and source-refresh guidance is sufficient for the receiving side.

## Files changed

- docs/core-model.md
- docs/prompts.md
- docs/tool-adapters/chatgpt.md
- tests/test_surface_handoff_semantics.py

The correction commit also restores tests/test_prompt_contract_semantics.py to its original global executor-neutrality assertion, so that file has no net diff from main.

## Validation

- focused surface, ChatGPT-adapter, and prompt-contract suite: 29 tests passed
- make check: passed
  - markdownlint-cli2: 54 Markdown files, 0 issues
  - unittest discovery: 102 tests passed
- final diff check: clean
- merge-tree check against origin/main 2821eec5a72bafaf7fa3055618434c0fc71e0d69: clean

## Examples in the ChatGPT adapter

1. Difficult architecture discussion remains in Chat.
2. Source-backed report moves from Chat to Work with an exact package pointer.
3. Repository implementation moves from Chat to Codex with an exact package pointer.
4. Discussion changes surface only after a bounded outcome exists.
5. Worker output returns to Chat for review or disposition.
6. Inaccessible, stale, mismatched, or ambiguous package identity fails closed.

## Deliberately unchanged

- docs/start-here.md: current activation routing and proportional rehydration invariant already cover the transition.
- docs/prompt-contracts.md: no semantic-contract identity or operational-schema gap was found.
- docs/orchestration-and-parallelism.md: the controller role does not imply a top-level Codex thread or change fan-out mechanics.
- docs/tool-adapters/codex.md: no additional receiving-side delta is needed.

## Residual risks and limitations

- The new exact head requires focused re-review and Keith's acceptance; validation and PR readiness create no promotion or merge authority.
- Runtime package access remains connector evidence and must be verified per handoff.
- Prompt retention, transport or exchange copies, delivery evidence, exact-byte consumption, cleanup, and replay mechanics remain intentionally unresolved under CAK-145.

Linear: CAK-152