### PR TITLE
fix: ignore malformed source URL tokens

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -151,6 +151,16 @@ def scan_text(
     for index, line in enumerate(lines):
         for match in URL_RE.findall(line):
             url = clean_url(match)
+            try:
+                parsed_url = urlparse(url)
+            except ValueError:
+                # URL-like text can still contain malformed hosts (for
+                # example, an unmatched IPv6 bracket). It is not actionable
+                # source evidence, so do not emit a warning with an empty or
+                # misleading domain.
+                continue
+            if not parsed_url.hostname:
+                continue
             if is_official(url, official_suffixes) or justified(lines, index):
                 continue
             context = public_api_context(lines, index)

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -49,6 +49,14 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
 
         self.assertEqual(findings, [])
 
+    def test_ignores_malformed_url_like_tokens(self) -> None:
+        findings = scanner.scan_text(
+            "docs/example.md",
+            "REST API references include https://:bad and https://[broken.",
+        )
+
+        self.assertEqual(findings, [])
+
     def test_ignores_official_url_in_public_api_context(self) -> None:
         findings = scanner.scan_text(
             "docs/example.md",


### PR DESCRIPTION
## Summary
- Ignore URL-like tokens whose parsed host is invalid or absent before authoritative-source classification.
- Keep advisory scanner output actionable instead of emitting empty or misleading domains.
- Add focused regression coverage for malformed host forms.

## Validation
- `make check` (115 tests, Markdown lint clean)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_check_authoritative_sources` (24 tests)
- `git diff --check`

## Lane evidence
- Selected model configuration: GPT-5.6 Luna, medium reasoning (lowest-cost sufficient for localized deterministic hardening).
- Task execution identity: bounded implementation lane on the dedicated automation branch.
- Authority boundary: proposal-only delivery; human review and merge remain required.