### PR TITLE
Clarify kickoff mutation boundaries for orchestration

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -162,6 +162,52 @@ and current authority, refresh mutable facts from their owning sources, and
 fail closed where the applicable contract or exact recoverable state cannot be
 resolved.
 
+## Kickoff Mutation Boundaries
+
+Kickoff is neither a universally read-only phase nor permission to begin every
+later phase. A controller or generated prompt must state the task-appropriate
+mutation boundary explicitly and keep these three classes distinct:
+
+1. **Task-owned orchestration and evidence mutations may be permitted.** When
+   current authority and prerequisites support them, a controller may update
+   the governing task, append concise task-owned progress or source
+   assessments, produce and preserve a decision package or exact downstream
+   prompt and its receipt, verify read-back, and record exact identities. The
+   applicable planning, evidence, and storage owners still decide whether and
+   how each write is admitted.
+2. **Delegated substantive execution is not implied.** Kickoff bookkeeping or
+   evidence capture does not authorize repository mutation, implementation,
+   migration, destructive cleanup, production execution, provider
+   reconfiguration, or other task substance assigned to a later executor or
+   phase. That work requires its own bounded authority and satisfied
+   prerequisites.
+3. **Human-gated transitions remain separately human-gated.** Architecture or
+   operational adoption, destructive approval, merge, release, publication,
+   scientific adoption, and any task-specific human decision gate require the
+   authorized human decision against the exact reviewed identity.
+
+The existence of a thread does not establish readiness. If authority or a
+prerequisite fails, the controller must not mark the governing work in progress
+merely because kickoff occurred. It may record the exact blocker only when that
+task-owned write is useful and authorized. Unrelated planning items,
+repositories, providers, and execution state remain untouched.
+
+A genuinely read-only kickoff remains valid when the owning workflow requires
+it. State why the restriction is needed and scope it to the applicable actor,
+phase, and mutation surfaces instead of relying on a vague blanket phrase.
+
+Controller-owned orchestration is distinct from prompt-contract machinery.
+Hydrators, representation adapters, renderers, validators, receipts, and
+checkpoints remain evidence-only under
+[`prompt-contracts.md`](prompt-contracts.md#ownership-and-live-authority) and
+must not drive lifecycle state or orchestration.
+
+A prompt, digest, receipt, artifact, planning status, successful call, storage
+object, comment, validation result, retrieval, review verdict, branch, commit,
+or pull request creates zero authority. These records may exercise or evidence
+authority that already exists; they cannot authorize a later phase or cross a
+human gate.
+
 ## Authority And Transitions
 
 Authority is permission to make a decision or cross a workflow boundary. It is

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -490,7 +490,8 @@ Kickoff mutation boundary:
 - Orchestration/evidence mutations: [task-owned writes allowed now, their
   prerequisites, and the authority that permits them; or none]
 - Delegated substantive execution: [work reserved for a later executor or
-  phase and prohibited here, or work separately authorized here]
+  phase and prohibited here, or work separately authorized here under its own
+  bounded authority]
 - Human-gated transitions: [decisions requiring separate human authorization]
 - Unrelated state: [planning items, repositories, providers, and execution
   state that remain untouched]
@@ -577,7 +578,8 @@ Permissions and completion boundary:
   - Orchestration/evidence mutations: [task-owned writes allowed now, their
     prerequisites, and the authority that permits them; or none]
   - Delegated substantive execution: [work reserved for a later executor or
-    phase and prohibited here, or work separately authorized here]
+    phase and prohibited here, or work separately authorized here under its own
+    bounded authority]
   - Human-gated transitions: [decisions requiring separate human authorization]
   - Unrelated state: [planning items, repositories, providers, and execution
     state that remain untouched]
@@ -668,8 +670,9 @@ Instructions:
   feedback from already-present information.
 
 Kickoff mutation boundary:
-- Orchestration/evidence mutations: none; this reviewer only inspects and
-  reports in chat because the task is review/audit mode.
+- Orchestration/evidence mutations: [none for review-only, or the exact
+  separately authorized PR comment or review action]; this reviewer otherwise
+  only inspects and reports in chat because the task is review/audit mode.
 - Delegated substantive execution: none; implementation is outside this review.
 - Human-gated transitions: PR comments, approvals, change requests, merge, and
   every other PR mutation require separate authorization.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -131,7 +131,8 @@ Kickoff mutation boundary:
 - Orchestration/evidence mutations: [task-owned writes allowed now, their
   prerequisites, and the authority that permits them; or none]
 - Delegated substantive execution: [work reserved for a later executor or
-  phase and therefore prohibited during kickoff]
+  phase and prohibited here, or work separately authorized here under its own
+  bounded authority]
 - Human-gated transitions: [decisions that still require a separate exact
   human authorization]
 - Unrelated state: [planning items, repositories, providers, and execution
@@ -159,7 +160,7 @@ drive lifecycle state or orchestration.
 
 | Situation | Explicit kickoff boundary |
 | --- | --- |
-| Ready kickoff | Prerequisites pass, so the controller may advance the governing task, preserve the exact downstream prompt and receipt under the applicable evidence contract, verify their identities, and return the handoff. It performs none of the delegated repository execution. |
+| Ready kickoff | Current authority and prerequisites pass, so the controller may advance the governing task, preserve the exact downstream prompt and receipt under the applicable evidence contract, verify their identities, and return the handoff. It performs none of the delegated repository execution. |
 | Blocked kickoff | A prerequisite or authority check fails. The controller does not falsely advance the task; it may record the exact blocker when that task-owned write is useful and authorized. No downstream execution is implied. |
 | Architecture thread | The controller may write and preserve the task-owned decision package. Architecture adoption remains a separate human decision against the reviewed package identity. |
 | Destructive workflow | The controller may produce and preserve a read-only manifest. Deletion remains separately human-approved and is not authorized by the manifest. |
@@ -423,8 +424,16 @@ Delivery:
 
 Permissions and completion boundary:
 - Authorized actions: [local edits, validation, commit, push, PR, or narrower]
-- Kickoff mutation boundary: [task-owned orchestration/evidence writes allowed;
-  delegated substantive execution boundary; separately human-gated transitions]
+- Kickoff mutation boundary:
+  - Orchestration/evidence mutations: [task-owned writes allowed now, their
+    prerequisites, and the authority that permits them; or none]
+  - Delegated substantive execution: [work separately authorized here under
+    its own bounded authority, or reserved for a later executor or phase]
+  - Human-gated transitions: [decisions requiring separate human authorization]
+  - Unrelated state: [planning items, repositories, providers, and execution
+    state that remain untouched]
+  - Blocked kickoff: [do not falsely advance the governing task; record the
+    exact blocker only when useful and authorized]
 - Completion ends at: [validated artifact, review packet, draft PR, or other]
 
 Stop rules:
@@ -478,8 +487,15 @@ Constraints:
 Completion and stop boundary:
 - [required result, validation, delivery, and conditions that require stopping]
 Kickoff mutation boundary:
-- [task-owned orchestration/evidence writes allowed; delegated substantive
-  execution boundary; separately human-gated transitions; blocked behavior]
+- Orchestration/evidence mutations: [task-owned writes allowed now, their
+  prerequisites, and the authority that permits them; or none]
+- Delegated substantive execution: [work reserved for a later executor or
+  phase and prohibited here, or work separately authorized here]
+- Human-gated transitions: [decisions requiring separate human authorization]
+- Unrelated state: [planning items, repositories, providers, and execution
+  state that remain untouched]
+- Blocked kickoff: [do not falsely advance the governing task; record the exact
+  blocker only when useful and authorized]
 ```
 
 Required inputs:
@@ -557,8 +573,16 @@ Delivery:
 
 Permissions and completion boundary:
 - Authorized actions: [read-only inspection, local edits, delivery, or narrower]
-- Kickoff mutation boundary: [task-owned orchestration/evidence writes allowed;
-  delegated substantive execution boundary; separately human-gated transitions]
+- Kickoff mutation boundary:
+  - Orchestration/evidence mutations: [task-owned writes allowed now, their
+    prerequisites, and the authority that permits them; or none]
+  - Delegated substantive execution: [work reserved for a later executor or
+    phase and prohibited here, or work separately authorized here]
+  - Human-gated transitions: [decisions requiring separate human authorization]
+  - Unrelated state: [planning items, repositories, providers, and execution
+    state that remain untouched]
+  - Blocked kickoff: [do not falsely advance the governing task; record the
+    exact blocker only when useful and authorized]
 - Completion ends at: [artifact, review packet, PR, report, or other]
 
 Stop rules:
@@ -640,9 +664,19 @@ Instructions:
 - Stay in review/audit mode unless the human explicitly changes the task.
 - Treat user summaries, completion reports, and pasted excerpts as navigation,
   not PR evidence.
-- Do not mutate the PR unless explicitly asked.
 - If required PR evidence is unavailable, state that blocker and caveat any
   feedback from already-present information.
+
+Kickoff mutation boundary:
+- Orchestration/evidence mutations: none; this reviewer only inspects and
+  reports in chat because the task is review/audit mode.
+- Delegated substantive execution: none; implementation is outside this review.
+- Human-gated transitions: PR comments, approvals, change requests, merge, and
+  every other PR mutation require separate authorization.
+- Unrelated state: the repository, planning items, providers, and execution
+  state remain untouched.
+- Blocked kickoff: report missing evidence without mutating state or inferring
+  readiness.
 
 Output format:
 1. Review findings: severity-ordered findings with file or PR references where

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -115,6 +115,56 @@ form, quality checks, and return boundary. A repository-executor projection
 also makes repository identity and locality, repository tools, canonical
 validation, delivery, and the stop-before-merge boundary explicit.
 
+## Explicit Kickoff Mutation Boundary
+
+Every generated kickoff or orchestration prompt must declare an explicit,
+task-appropriate mutation boundary. Apply the three-class model in
+[`core-model.md`](core-model.md#kickoff-mutation-boundaries); do not use vague
+blanket phrases such as `read-only first response`, `no mutation on kickoff`,
+`do not touch anything yet`, or `do not mutate the planning or artifact system
+in the first response` as substitutes for the actual boundary.
+
+Use this provider-neutral projection and resolve each field for the task:
+
+```text
+Kickoff mutation boundary:
+- Orchestration/evidence mutations: [task-owned writes allowed now, their
+  prerequisites, and the authority that permits them; or none]
+- Delegated substantive execution: [work reserved for a later executor or
+  phase and therefore prohibited during kickoff]
+- Human-gated transitions: [decisions that still require a separate exact
+  human authorization]
+- Unrelated state: [planning items, repositories, providers, and execution
+  state that remain untouched]
+- Blocked kickoff: [do not falsely advance the governing task; record the exact
+  blocker only when that task-owned write is useful and authorized]
+```
+
+When the kickoff is genuinely fully read-only, say why, name the actor and
+mutation surfaces covered, and keep the restriction no broader or longer than
+the owning workflow requires. When orchestration or evidence writes are
+allowed, state that they do not authorize delegated substantive execution or a
+human-gated transition. Prompt text, digests, receipts, artifacts, planning
+status, successful calls, storage objects, comments, validation, retrieval,
+review, branches, commits, and pull requests create zero authority.
+
+This prompt projection does not redefine interactive-control or target-surface
+routing, artifact storage admission, transport, delivery, retention, cleanup,
+or replay, or operator-visible progress and client behavior. It governs the
+controller's declared boundary, not prompt-contract machinery: hydrators,
+adapters, renderers, validators, receipts, and checkpoints remain unable to
+drive lifecycle state or orchestration.
+
+### Provider-neutral examples
+
+| Situation | Explicit kickoff boundary |
+| --- | --- |
+| Ready kickoff | Prerequisites pass, so the controller may advance the governing task, preserve the exact downstream prompt and receipt under the applicable evidence contract, verify their identities, and return the handoff. It performs none of the delegated repository execution. |
+| Blocked kickoff | A prerequisite or authority check fails. The controller does not falsely advance the task; it may record the exact blocker when that task-owned write is useful and authorized. No downstream execution is implied. |
+| Architecture thread | The controller may write and preserve the task-owned decision package. Architecture adoption remains a separate human decision against the reviewed package identity. |
+| Destructive workflow | The controller may produce and preserve a read-only manifest. Deletion remains separately human-approved and is not authorized by the manifest. |
+| Delegated repository implementation | The controller may preserve the downstream prompt and task-owned planning evidence. The repository executor owns repository mutation only under its own bounded authority and prerequisites. |
+
 ## Thread Routing And Configuration Continuity
 
 Model selection, reasoning or thinking configuration, and thread routing are
@@ -373,6 +423,8 @@ Delivery:
 
 Permissions and completion boundary:
 - Authorized actions: [local edits, validation, commit, push, PR, or narrower]
+- Kickoff mutation boundary: [task-owned orchestration/evidence writes allowed;
+  delegated substantive execution boundary; separately human-gated transitions]
 - Completion ends at: [validated artifact, review packet, draft PR, or other]
 
 Stop rules:
@@ -425,6 +477,9 @@ Constraints:
 - [only task-specific constraints not already owned by the referenced sources]
 Completion and stop boundary:
 - [required result, validation, delivery, and conditions that require stopping]
+Kickoff mutation boundary:
+- [task-owned orchestration/evidence writes allowed; delegated substantive
+  execution boundary; separately human-gated transitions; blocked behavior]
 ```
 
 Required inputs:
@@ -434,6 +489,7 @@ Required inputs:
 - `canonical_source`
 - `source_evidence`
 - `interaction_mode`
+- `kickoff_mutation_boundary`
 - `validation_path`
 - `delivery_expectation`
 
@@ -501,6 +557,8 @@ Delivery:
 
 Permissions and completion boundary:
 - Authorized actions: [read-only inspection, local edits, delivery, or narrower]
+- Kickoff mutation boundary: [task-owned orchestration/evidence writes allowed;
+  delegated substantive execution boundary; separately human-gated transitions]
 - Completion ends at: [artifact, review packet, PR, report, or other]
 
 Stop rules:

--- a/tests/test_kickoff_mutation_boundaries.py
+++ b/tests/test_kickoff_mutation_boundaries.py
@@ -27,7 +27,9 @@ class KickoffMutationBoundaryTests(unittest.TestCase):
 
         core_start = cls.core_raw.index("## Kickoff Mutation Boundaries")
         core_end = cls.core_raw.index("## Authority And Transitions")
-        cls.core_boundary_section = cls.core_raw[core_start:core_end]
+        cls.core_boundary_section = " ".join(
+            cls.core_raw[core_start:core_end].split()
+        )
 
     def test_core_owns_the_three_class_authority_boundary(self):
         for phrase in (
@@ -95,7 +97,7 @@ class KickoffMutationBoundaryTests(unittest.TestCase):
             "pull request",
             "creates zero authority",
         ):
-            self.assertIn(phrase, self.core)
+            self.assertIn(phrase, self.core_boundary_section)
 
     def test_shared_prompt_doctrine_is_provider_neutral(self):
         for provider_name in ("Dropbox", "Linear", "ChatGPT", "Codex"):

--- a/tests/test_kickoff_mutation_boundaries.py
+++ b/tests/test_kickoff_mutation_boundaries.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+
+def normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+class KickoffMutationBoundaryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.core_raw = (DOCS / "core-model.md").read_text(encoding="utf-8")
+        cls.prompts_raw = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        cls.core = " ".join(cls.core_raw.split())
+        cls.prompts = " ".join(cls.prompts_raw.split())
+        cls.prompt_contracts = normalized(DOCS / "prompt-contracts.md")
+
+        start = cls.prompts_raw.index("## Explicit Kickoff Mutation Boundary")
+        end = cls.prompts_raw.index("## Thread Routing And Configuration Continuity")
+        cls.boundary_section = cls.prompts_raw[start:end]
+
+    def test_core_owns_the_three_class_authority_boundary(self):
+        for phrase in (
+            "Kickoff Mutation Boundaries",
+            "Task-owned orchestration and evidence mutations may be permitted",
+            "Delegated substantive execution is not implied",
+            "Human-gated transitions remain separately human-gated",
+            "requires its own bounded authority and satisfied prerequisites",
+            "Unrelated planning items, repositories, providers, and execution state remain untouched",
+        ):
+            self.assertIn(phrase, self.core)
+
+    def test_generated_prompts_require_an_explicit_boundary(self):
+        for phrase in (
+            "Every generated kickoff or orchestration prompt must declare an explicit",
+            "Orchestration/evidence mutations",
+            "Delegated substantive execution",
+            "Human-gated transitions",
+            "Unrelated state",
+            "Blocked kickoff",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+        self.assertGreaterEqual(
+            self.prompts_raw.count("- Kickoff mutation boundary:"), 2
+        )
+        self.assertIn("`kickoff_mutation_boundary`", self.prompts_raw)
+
+    def test_read_only_and_blocked_kickoffs_are_narrow_and_fail_closed(self):
+        for phrase in (
+            "genuinely fully read-only, say why",
+            "name the actor and mutation surfaces covered",
+            "do not falsely advance the governing task",
+            "record the exact blocker only when that task-owned write is useful and authorized",
+            "must not mark the governing work in progress merely because kickoff occurred",
+        ):
+            self.assertIn(phrase, f"{self.core} {self.prompts}")
+
+    def test_zero_authority_boundary_covers_execution_evidence(self):
+        for phrase in (
+            "planning status",
+            "successful call",
+            "storage object",
+            "comment",
+            "validation result",
+            "retrieval",
+            "review verdict",
+            "branch",
+            "commit",
+            "pull request",
+            "creates zero authority",
+        ):
+            self.assertIn(phrase, self.core)
+
+    def test_shared_prompt_doctrine_is_provider_neutral(self):
+        for provider_name in ("Dropbox", "Linear", "ChatGPT", "Codex"):
+            self.assertNotIn(provider_name, self.boundary_section)
+
+    def test_adjacent_owner_boundaries_remain_explicit(self):
+        for phrase in (
+            "does not redefine interactive-control or target-surface routing",
+            "artifact storage admission, transport, delivery, retention, cleanup, or replay",
+            "operator-visible progress and client behavior",
+            "not prompt-contract machinery",
+            "remain unable to drive lifecycle state or orchestration",
+        ):
+            self.assertIn(phrase, self.prompts)
+
+        self.assertIn(
+            "This is the no-authority, no-state-transition, and no-orchestration boundary",
+            self.prompt_contracts,
+        )
+
+    def test_required_provider_neutral_examples_are_present(self):
+        for phrase in (
+            "Ready kickoff",
+            "Blocked kickoff",
+            "Architecture thread",
+            "Destructive workflow",
+            "Delegated repository implementation",
+        ):
+            self.assertIn(phrase, self.boundary_section)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_kickoff_mutation_boundaries.py
+++ b/tests/test_kickoff_mutation_boundaries.py
@@ -19,9 +19,15 @@ class KickoffMutationBoundaryTests(unittest.TestCase):
         cls.prompts = " ".join(cls.prompts_raw.split())
         cls.prompt_contracts = normalized(DOCS / "prompt-contracts.md")
 
-        start = cls.prompts_raw.index("## Explicit Kickoff Mutation Boundary")
-        end = cls.prompts_raw.index("## Thread Routing And Configuration Continuity")
-        cls.boundary_section = cls.prompts_raw[start:end]
+        prompt_start = cls.prompts_raw.index("## Explicit Kickoff Mutation Boundary")
+        prompt_end = cls.prompts_raw.index(
+            "## Thread Routing And Configuration Continuity"
+        )
+        cls.boundary_section = cls.prompts_raw[prompt_start:prompt_end]
+
+        core_start = cls.core_raw.index("## Kickoff Mutation Boundaries")
+        core_end = cls.core_raw.index("## Authority And Transitions")
+        cls.core_boundary_section = cls.core_raw[core_start:core_end]
 
     def test_core_owns_the_three_class_authority_boundary(self):
         for phrase in (
@@ -45,10 +51,25 @@ class KickoffMutationBoundaryTests(unittest.TestCase):
         ):
             self.assertIn(phrase, self.prompts)
 
-        self.assertGreaterEqual(
-            self.prompts_raw.count("- Kickoff mutation boundary:"), 2
-        )
+        self.assertGreaterEqual(self.prompts_raw.count("Kickoff mutation boundary:"), 5)
         self.assertIn("`kickoff_mutation_boundary`", self.prompts_raw)
+
+        for heading, next_heading in (
+            ("## Repository Implementation Task", "## Parallel Batch Add-On"),
+            ("## Orchestration Handoff", "## Governed Artifact Capture Add-On"),
+            ("## PR Review", None),
+        ):
+            start = self.prompts_raw.index(heading)
+            end = self.prompts_raw.index(next_heading) if next_heading else None
+            template = self.prompts_raw[start:end]
+            for field in (
+                "Orchestration/evidence mutations:",
+                "Delegated substantive execution:",
+                "Human-gated transitions:",
+                "Unrelated state:",
+                "Blocked kickoff:",
+            ):
+                self.assertIn(field, template, f"{heading}: {field}")
 
     def test_read_only_and_blocked_kickoffs_are_narrow_and_fail_closed(self):
         for phrase in (
@@ -79,6 +100,16 @@ class KickoffMutationBoundaryTests(unittest.TestCase):
     def test_shared_prompt_doctrine_is_provider_neutral(self):
         for provider_name in ("Dropbox", "Linear", "ChatGPT", "Codex"):
             self.assertNotIn(provider_name, self.boundary_section)
+            self.assertNotIn(provider_name, self.core_boundary_section)
+
+    def test_blanket_phrases_are_examples_not_instruction_substitutes(self):
+        for phrase in (
+            "`read-only first response`",
+            "`no mutation on kickoff`",
+            "`do not touch anything yet`",
+            "as substitutes for the actual boundary",
+        ):
+            self.assertIn(phrase, self.boundary_section)
 
     def test_adjacent_owner_boundaries_remain_explicit(self):
         for phrase in (


### PR DESCRIPTION
## Summary

- define one provider-neutral explicit kickoff mutation boundary with permitted orchestration and evidence writes, delegated substantive execution, and separate human gates
- apply the boundary to reusable prompt templates and five provider-neutral examples without changing prompt-contract machinery or provider adapters
- add focused semantic regression coverage for provider neutrality, blocked kickoff behavior, zero-authority effects, and adjacent-owner exclusions

## Validation

- `python3 -m unittest discover -s tests -p test_kickoff_mutation_boundaries.py` — 8 tests passed
- `git diff --check` — passed
- `make check` — markdownlint passed; 122 tests passed
- targeted blanket-mutation phrase classification — passed
- final merge-base and diff inspection against `origin/main` — base `1789162737ab11f222d7bf0f1493fdecc5c18fed`, passed

## Independent review

Claude Opus independently reviewed exact candidate `a8742ee33ec5fb1d32e3e833a856c5a27d4e963b` under the governed read-only contract and returned ACCEPT with no residual or new substantive findings.

Linear: CAK-161

This PR does not authorize merge, doctrine adoption or promotion, release, publication, or issue closure.