### PR TITLE
CAK-149: define connector progress economy

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -78,6 +78,16 @@ logging style, narrate hidden deliberation, or expose or request private
 chain-of-thought. Operator observability reports execution state and its
 behavioral consequence; it does not report internal reasoning.
 
+Routine successful item operations are not operator-observability events.
+During bounded bulk or connector-heavy work, prefer aggregate milestones and a
+compact final result. Surface material state transitions promptly, including
+blockers, authority or scope mismatches, drift, privacy or retention issues,
+collision or overwrite risk, validation failures, and permission, approval,
+destructive, or other safety boundaries. Preserve complete item-level evidence
+outside the conversation. Honor an operator's mid-run request for quieter or
+more verbose progress when the active runtime supports it, and report
+client-forced output as a limitation rather than claiming it was suppressed.
+
 ## Authority Follows The Question
 
 Do not select one universal system of record for a workflow. Classify the

--- a/docs/evidence-lifecycle.md
+++ b/docs/evidence-lifecycle.md
@@ -127,7 +127,10 @@ storage-contract evidence, not universal producing-receipt fields.
 Reserve *producing receipt* for the selected durable append-only receipt
 surface. Conversation is a compact summary or compact delivery surface, not a
 durable producing-receipt surface. Do not reproduce the complete durable
-artifact in chat merely for transport.
+artifact in chat merely for transport. Consistent with
+[`Operator Observability`](core-model.md#operator-observability), compact
+delivery does not require routine item-level success narration when the owning
+durable evidence preserves the complete item results.
 
 When evidence has a distinct identity, describe the operation as `evidenced
 separately`; do not imply an independent actor merely because the evidence is

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -354,6 +354,7 @@ Reason:
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Orchestration Handoff](#orchestration-handoff)
+- [Operator-Visible Progress Add-On](#operator-visible-progress-add-on)
 - [Governed Artifact Capture Add-On](#governed-artifact-capture-add-on)
 - [Issue-Owned Durable Prompt Delivery Envelope Add-On](#issue-owned-durable-prompt-delivery-envelope-add-on)
 - [Implementation Delivery Add-On](#implementation-delivery-add-on)
@@ -594,6 +595,18 @@ Stop rules:
 - Ask for human input when required evidence is unavailable or the next step
   depends on a human judgment call.
 ```
+
+## Operator-Visible Progress Add-On
+
+Append this only when the task needs an explicit progress-presentation
+contract. Apply the shared
+[`Operator Observability`](core-model.md#operator-observability) rule without
+copying its material-event taxonomy. Resolve the task-specific aggregate
+milestones, durable item-evidence location, supported mid-run presentation
+preferences, and any client-forced output limitation. This add-on changes
+presentation only; it does not weaken approval, permission, destructive,
+collision, overwrite, drift, privacy, retention, authority, scope, blocker, or
+validation boundaries.
 
 ## Governed Artifact Capture Add-On
 

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -162,6 +162,19 @@ authority, decision-boundary, and re-observation rules remain in
 [`core-model.md`](../core-model.md), while connector availability is governed
 by [`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence).
 
+For routine connected-app create or write operations, invoke only the write
+and the minimum verification required by the owning evidence contract. Do not
+invoke preview, thumbnail, open-in-provider, or share-link actions merely to
+confirm success. Preview remains appropriate when the operator explicitly
+requests visual inspection, rendered correctness requires it, or a narrower
+owning workflow requires it. If the client renders a card from the write action
+itself, classify that as client-enforced UI, avoid redundant preview calls or
+model narration, and report the limitation when material rather than claiming
+the card was suppressed. Current
+[OpenAI Apps guidance](https://help.openai.com/en/articles/11487775-connectors-in)
+documents rich in-chat app experiences and write confirmations, but does not
+establish a universal per-action client-rendering suppression control.
+
 ### Issue-Owned Durable Prompt Capture And Handoff
 
 Apply the shared

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -188,6 +188,15 @@ direct provider pid exits while another recorded group member remains live.
 Do not infer a portable SIGTERM result or exit-code mapping from Claude Code;
 record the observed local process outcome.
 
+Keep routine commands, provider retries, stream details, and successful
+per-step results in the governed stream and attempt evidence instead of
+duplicating them as operator narration. Authentication or execution-context
+mismatch, a failed capability canary, unauthorized mutation, source delta,
+terminal collection failure, or postflight failure remains an immediate
+material blocker. Treat product-rendered traces as runtime behavior unless
+current official evidence establishes control; do not claim provider or client
+trace suppression.
+
 ## Worktrees And Subagents
 
 Apply the one-repository, one-branch, one-worktree, one-PR rule and

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -612,6 +612,14 @@ the current boundary:
 - unmet transition criteria; and
 - the exact next permitted action or stop condition.
 
+For bounded bulk work, aggregate routine successful operations instead of
+narrating each item, and keep complete item results in the owning durable
+evidence. Surface blockers and human gates promptly. Honor a mid-run
+presentation preference without restarting when the active runtime supports
+it. When the client displays tool output that Codex cannot suppress, avoid
+duplicating it in model-authored updates and report the limitation without
+claiming control.
+
 Successful tool calls, model output, validation, and progress text are evidence
 of activity, not proof of completion or authority. Re-read current sources at
 source-first and post-merge boundaries rather than rendering stale planned

--- a/tests/test_operator_progress_economy.py
+++ b/tests/test_operator_progress_economy.py
@@ -1,0 +1,162 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+
+def normalized(path: Path) -> str:
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def progress_fixture() -> dict:
+    item_results = [
+        {"item": f"file-{number:02d}", "status": "created"}
+        for number in range(1, 65)
+    ]
+    return {
+        "fixture_scope": "contract-only-not-runtime-or-ui-conformance",
+        "attempt": "cak-149-fixture-attempt",
+        "durable_item_results": item_results,
+        "model_updates": [
+            "Started bounded 64-item create with aggregate progress.",
+            "32 of 64 items verified; no material blocker.",
+            "64 of 64 items created and verified; complete results evidenced separately.",
+        ],
+        "material_blocker": {
+            "visible_immediately": True,
+            "kind": "authority mismatch",
+        },
+        "safety_boundaries": {
+            boundary: "visible"
+            for boundary in (
+                "approval",
+                "permission",
+                "destructive",
+                "collision",
+                "overwrite",
+                "drift",
+                "privacy",
+                "retention",
+                "authority",
+                "scope",
+                "blocker",
+                "validation",
+            )
+        },
+        "create_without_preview": ["create", "raw-readback", "metadata"],
+        "requested_visual_inspection": [
+            "create",
+            "raw-readback",
+            "metadata",
+            "preview",
+        ],
+        "client_forced_card": {
+            "surface": "client-enforced-ui",
+            "preview_invoked": False,
+            "suppression_claimed": False,
+        },
+        "mid_run_preference": {
+            "attempt_before": "cak-149-fixture-attempt",
+            "attempt_after": "cak-149-fixture-attempt",
+            "runtime_supports_change": True,
+        },
+    }
+
+
+class OperatorProgressEconomyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.core = normalized(DOCS / "core-model.md")
+        cls.evidence = normalized(DOCS / "evidence-lifecycle.md")
+        cls.prompts = normalized(DOCS / "prompts.md")
+        cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
+        cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
+        cls.claude = normalized(DOCS / "tool-adapters" / "claude.md")
+        cls.fixture = progress_fixture()
+
+    def test_core_owns_the_provider_neutral_invariant(self):
+        for phrase in (
+            "Routine successful item operations are not operator-observability events",
+            "prefer aggregate milestones and a compact final result",
+            "authority or scope mismatches",
+            "drift, privacy or retention issues",
+            "collision or overwrite risk",
+            "validation failures",
+            "permission, approval, destructive, or other safety boundaries",
+            "Preserve complete item-level evidence outside the conversation",
+            "when the active runtime supports it",
+            "report client-forced output as a limitation",
+        ):
+            self.assertIn(phrase, self.core)
+
+        for provider_name in ("ChatGPT", "Codex", "Claude", "Dropbox"):
+            self.assertNotIn(provider_name, self.core)
+
+    def test_existing_owners_receive_thin_projections(self):
+        self.assertIn(
+            "compact delivery does not require routine item-level success narration",
+            self.evidence,
+        )
+        self.assertIn("Operator-Visible Progress Add-On", self.prompts)
+        self.assertIn("without copying its material-event taxonomy", self.prompts)
+
+        self.assertIn("Do not invoke preview", self.chatgpt)
+        self.assertIn("client-enforced UI", self.chatgpt)
+        self.assertIn("aggregate routine successful operations", self.codex)
+        self.assertIn("without restarting", self.codex)
+        self.assertIn("governed stream and attempt evidence", self.claude)
+        self.assertIn("execution-context mismatch", self.claude)
+
+    def test_64_item_success_fixture_is_aggregate_but_complete(self):
+        self.assertEqual(
+            "contract-only-not-runtime-or-ui-conformance",
+            self.fixture["fixture_scope"],
+        )
+        item_results = self.fixture["durable_item_results"]
+        updates = self.fixture["model_updates"]
+
+        self.assertEqual(64, len(item_results))
+        self.assertEqual(64, len({result["item"] for result in item_results}))
+        self.assertLess(len(updates), len(item_results))
+        for result in item_results:
+            self.assertFalse(any(result["item"] in update for update in updates))
+
+    def test_material_boundaries_remain_visible(self):
+        self.assertTrue(self.fixture["material_blocker"]["visible_immediately"])
+        self.assertEqual(
+            {"visible"}, set(self.fixture["safety_boundaries"].values())
+        )
+        for boundary in (
+            "approval",
+            "permission",
+            "destructive",
+            "collision",
+            "overwrite",
+            "drift",
+            "privacy",
+            "retention",
+            "authority",
+            "scope",
+            "blocker",
+            "validation",
+        ):
+            self.assertIn(boundary, self.fixture["safety_boundaries"])
+
+    def test_preview_and_client_forced_ui_are_separate(self):
+        self.assertNotIn("preview", self.fixture["create_without_preview"])
+        self.assertIn("preview", self.fixture["requested_visual_inspection"])
+        forced_card = self.fixture["client_forced_card"]
+        self.assertEqual("client-enforced-ui", forced_card["surface"])
+        self.assertFalse(forced_card["preview_invoked"])
+        self.assertFalse(forced_card["suppression_claimed"])
+
+    def test_supported_mid_run_preference_keeps_the_attempt(self):
+        preference = self.fixture["mid_run_preference"]
+        self.assertTrue(preference["runtime_supports_change"])
+        self.assertEqual(preference["attempt_before"], preference["attempt_after"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the provider-neutral operator-observability economy invariant
- project it narrowly into compact delivery, prompts, and ChatGPT/Codex/Claude adapters
- add deterministic contract regression coverage for aggregate 64-item progress, preserved gates, preview selection, client-forced UI, and same-attempt preference changes

## Validation
- make check: PASS (Markdown lint; 209 tests)
- focused regression: PASS (6 tests)
- proportional controller review: PASS, no findings
- governed independent review attempt: failed closed before verdict after a successful canary and read-only inspection; no candidate mutation; evidence preserved under the CAK-149 implementation-review package

## Scope
- no orchestration-and-parallelism change
- no CAK-148 or CAK-153 implementation
- no Dropbox or client UI change and no claim of client-output control

Linear: https://linear.app/ctrl-alt-keith/issue/CAK-149/define-compact-operator-visible-progress-for-connector-heavy