### PR TITLE
docs: link external reviewer guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ The first core module is delivery. Additional workflow families may be added lat
 - [`docs/feature-lifecycle.md`](docs/feature-lifecycle.md): delivery lifecycle, branch behavior, and PR completion expectations
 - [`docs/alignment-checkpoints.md`](docs/alignment-checkpoints.md): pause points and branch/PR rules
 - [`docs/review-packet.md`](docs/review-packet.md): standard human review packet
+- [`docs/external-ai-reviewer.md`](docs/external-ai-reviewer.md): selecting,
+  governing, and completing independent external-AI review
 - [`docs/knowledge-ingestion-patterns.md`](docs/knowledge-ingestion-patterns.md): reusable patterns for provenance-aware ingestion and retained-knowledge governance boundaries
 - [`docs/tool-adapters/`](docs/tool-adapters/): documented executor-specific adapter guidance; Codex runs must apply [`docs/tool-adapters/codex.md`](docs/tool-adapters/codex.md), Claude runs must apply [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md), and repository-scoped ChatGPT runs must apply [`docs/tool-adapters/chatgpt.md`](docs/tool-adapters/chatgpt.md)
 - [`docs/playbook-integrity-check.md`](docs/playbook-integrity-check.md): lightweight anti-drift check


### PR DESCRIPTION
## Summary
- add the external AI reviewer guide to the README's initial map
- align top-level navigation with the guide that owns current governed reviewer-launch guidance

## Validation
- Running markdownlint-cli2
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md
Linting: 54 files
Summary: 0 issues in 0 files
PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests
Removing __pycache__/
authoritative-source-check: skipped symbolic link /tmp/tmpuuk26tjf/linked.md