### PR TITLE
docs: route prompts by recipient capability

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -332,11 +332,11 @@ interpreted as inline HTML by Markdown tooling.
 
 ## Complete Prompt Shape
 
-For a complete generated prompt, emit one shared operator-metadata block and
-one complete executable block consecutively. The executable block must remain
-complete and actionable without the metadata, so the operator can copy only
-that block. Matching executor adapters own concrete metadata fields and client
-presentation mechanics.
+When inline presentation is selected for a complete generated prompt, emit one
+shared operator-metadata block and one complete executable block consecutively.
+The executable block must remain complete and actionable without the metadata,
+so the operator can copy only that block. Matching executor adapters own
+concrete metadata fields and client presentation mechanics.
 
 ```text
 Operator metadata (do not include in prompt)
@@ -350,9 +350,8 @@ Reason:
 
 ## Cross-Executor Prompt Presentation
 
-For a complete prompt intended for another machine, agent, thread, or system,
-select presentation by currently qualified recipient capability, independently
-of prompt materiality:
+For any complete prompt, select presentation by the recipient's currently
+qualified capability, independently of prompt materiality:
 
 - When the recipient has a qualified Dropbox retrieval route and the current
   storage contract supplies a permitted destination, place the prompt in a

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -356,13 +356,15 @@ of prompt materiality:
 
 - When the recipient has a qualified Dropbox retrieval route and the current
   storage contract supplies a permitted destination, place the prompt in a
-  Dropbox-backed file, present its file card or preview, and immediately provide
-  the target-shaped retrieval handoff. Preview is optional and does not block
-  the handoff or require prompt approval.
+  Dropbox-backed file, present the file surface produced by that operation, and
+  immediately provide the target-shaped retrieval handoff. A separate preview
+  or open action is optional under the matching client adapter and does not
+  block the handoff or require prompt approval.
 - For a human recipient, or when the receiving system has no qualified Dropbox
   route, present the complete prompt inline through the matching client
-  adapter. When access is unknown, inspect or attempt the route before choosing
-  this fallback; do not claim unavailability from memory.
+  adapter. When access is unknown, apply the
+  [connector-availability rule](start-here.md#connector-availability-is-runtime-evidence)
+  before choosing this fallback.
 
 Preview is not raw-byte verification, approval, a send gate, delivery evidence,
 executor acknowledgement, a coordination state, or authority. A connector

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -348,77 +348,40 @@ Reason:
 [one concise task-specific explanation]
 ```
 
-## Material Cross-Executor Prompt Presentation
+## Cross-Executor Prompt Presentation
 
-Use this presentation sequence when the output is one complete prompt or task
-envelope for a different thread, child task, or execution surface; exact
-identity, operator review, recovery, citation, or replay materially matters;
-the six-condition issue-owned durable-prompt admission test passes; ownership,
-privacy, visibility, retention, and destination are unambiguous; and currently
-qualified absent-create, raw-readback, operator-preview, and downstream-
-delivery routes are available. Routine short prompts, brainstorming,
-incomplete fragments, and ordinary same-thread deltas remain lightweight and
-inline.
+For a complete prompt intended for another machine, agent, thread, or system,
+select presentation by currently qualified recipient capability, independently
+of prompt materiality:
 
-The required order is:
+- When the recipient has a qualified Dropbox retrieval route and the current
+  storage contract supplies a permitted destination, place the prompt in a
+  Dropbox-backed file, present its file card or preview, and immediately provide
+  the target-shaped retrieval handoff. Preview is optional and does not block
+  the handoff or require prompt approval.
+- For a human recipient, or when the receiving system has no qualified Dropbox
+  route, present the complete prompt inline through the matching client
+  adapter. When access is unknown, inspect or attempt the route before choosing
+  this fallback; do not claim unavailability from memory.
 
-```text
-render -> admit -> absent-create -> raw verify -> operator preview ->
-explicit approval -> fresh delivery route -> thin bootstrap ->
-executor exact verification -> execution
-```
+Preview is not raw-byte verification, approval, a send gate, delivery evidence,
+executor acknowledgement, a coordination state, or authority. A connector
+confirmation needed to create or preview the file authorizes only that
+connector operation, not a separate prompt-approval workflow.
 
-Raw provider readback and exact identity verification must finish before the
-preview is presented. The preview route and the executor-delivery route are
-distinct operations: preview must not prefetch, unfurl, scan, or consume a
-bounded delivery URL, and the executor route is not minted until explicit
-approval.
-
-After raw verification, normally present compact removable operator metadata,
-the provider-backed preview or file object, the semantic filename and
-issue-owned path, exact byte size and whole-file SHA-256, provider object ID
-and revision when available, the downstream executor or prompt role, and one
-explicit `Approve`, `Revise`, or `Reject` boundary. Do not print the full
-executable prompt inline by default after this path succeeds. The operator may
-request the complete prompt inline without changing the durable identity, and
-removing the operator metadata must still leave the executable prompt
-complete.
-
-Preview is a human-readable convenience surface. It is not raw-byte
-verification; does not prove size, SHA-256, provider content hash, revision,
-or equality; does not imply approval; is not delivery, acknowledgement,
-execution start, or attempt completion; creates no coordination state; and
-transfers zero authority.
-
-An operator revision leaves the previewed version immutable and unsent. Record
-predecessor lineage, absent-create the next semantic version at a unique
-immutable identity, repeat raw verification and preview, and obtain fresh
-explicit approval. If rejected v1 is followed by approved v2, the eventual
-bootstrap names only v2. Never overwrite or silently reuse v1, and never add a
-mutable `latest`, `current`, or `final` locator.
-
-Only after approval, mint a fresh bounded delivery route and emit a thin
-target-shaped bootstrap that omits the full prompt body. Name the approved
-durable path, provider object ID and revision when available, expected byte
-size and whole-file SHA-256, provider content hash when available and
-applicable, retrieval mechanism, lifetime, consumption behavior, and the
-requirement to verify exact bytes before reading or execution. Expiry, prior
-consumption, or failed retrieval requires a new delivery operation for the
-same durable prompt, not a new prompt version. Never reconstruct missing bytes
-from the bootstrap, conversation history, or memory.
-
-If any required capability or admission condition is unavailable or
-unqualified, stop before provider creation when admission has not passed, name
-the precise gap, and make no capture, readback, preview, approval, or delivery
-claim. Use the complete inline presentation only when the prompt is safe to
-display and the operator can review every byte before manual send; keep
-operator metadata outside that executable prompt. Otherwise stop with a
-non-authorizing capability blocker.
+Prompt governance is a separate selection. A material prompt that passes its
+admission test additionally applies the
+[`issue-owned durable rendered-prompt handoff profile`](prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile).
+Complete that profile before reporting preservation or providing an
+exact-identity handoff. A routine prompt delivered through a file does not
+thereby acquire its durable capture, recovery, replay, receipt,
+immutable-version, or governance ceremony. When no permitted file destination
+exists, use inline presentation rather than inventing a storage surface.
 
 ## Quick Navigation
 
 - [Task-Shape Surface Selection And Thin Handoffs](#task-shape-surface-selection-and-thin-handoffs)
-- [Material Cross-Executor Prompt Presentation](#material-cross-executor-prompt-presentation)
+- [Cross-Executor Prompt Presentation](#cross-executor-prompt-presentation)
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Orchestration Handoff](#orchestration-handoff)

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -8,20 +8,21 @@ Prompts should remain routing and execution envelopes, not duplicated workflow
 doctrine. For the rationale, see
 [`sparse-rehydration-and-source-grounding.md`](sparse-rehydration-and-source-grounding.md).
 
-For a fresh repository-scoped thread, explicitly route through current
+For repository-scoped prompts, route through current
 [`start-here.md`](start-here.md) and hydrate established state from
-authoritative Repository or History artifacts instead of replaying it in the
-prompt. The prompt carries the current delta: goal, governing authority or
-issue, authoritative artifact references, authorization, constraints,
-completion boundary, and stop rules.
-Self-contained means complete routing and authorization, not embedding every
-referenced artifact.
+authoritative Repository or History artifacts instead of copying doctrine into
+the prompt. Every generated prompt or handoff is a complete drop-in artifact:
+it is self-contained for its intended receiving context and directly usable.
+Thread routing and still-current context may reduce duplicated background, but
+never produce a partial executable artifact. Apply the governing
+[complete-prompt rule](repo-readiness.md#interaction-mode-preflight) rather
+than reconstructing the requested action from conversation history or another
+prompt.
 
-A same-thread continuation may carry only the changed delta while established
-source state remains current. Keep exact values prompt-local when required for
-identity, authority, safety, validation, or unambiguous retrieval. Reducing
-redundant context is execution engineering, not methodology or architecture
-evidence.
+Keep exact values prompt-local when identity, authority, safety, validation, or
+unambiguous retrieval requires them. Complete does not mean reproducing all
+doctrine, history, or durable state. Reducing redundant context is execution
+engineering, not methodology or architecture evidence.
 
 ## Task-Shape Surface Selection And Thin Handoffs
 
@@ -72,8 +73,8 @@ change does not require blanket rehydration or replay of unchanged doctrine.
 ### Thin semantic handoff envelope
 
 When complete recoverable state is held outside the conversation, a thin
-role-specific envelope carries only the current routing delta. Include, as
-applicable:
+role-specific envelope remains a complete current handoff while pointing to
+that state instead of reproducing it. Include, as applicable:
 
 - target surface or executor role;
 - bounded requested outcome;
@@ -181,6 +182,18 @@ separate decisions. Declare one of these routing values in operator metadata:
 - `CHILD TASK`: select the lowest-cost sufficient configuration for the bounded
   child, and preserve its model/configuration, inputs, execution identity,
   durable result, and authority boundary where the workflow requires it.
+
+Thread routing never relaxes prompt completeness:
+
+- A `FRESH THREAD` receives a complete prompt suitable for its fresh receiving
+  context.
+- A `SAME THREAD` receives the complete instruction for its next bounded
+  action. It may reference still-current established state available to that
+  thread, but remains directly usable without another prompt.
+- A `CHILD TASK` receives a complete bounded child prompt.
+
+The [recipient-capability selector](#cross-executor-prompt-presentation)
+applies to every complete prompt across these routing modes.
 
 Use the executor adapter for vendor-specific routing. For an existing task that
 exceeds its assigned capability, prefer a bounded stronger child or an explicit

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -348,9 +348,77 @@ Reason:
 [one concise task-specific explanation]
 ```
 
+## Material Cross-Executor Prompt Presentation
+
+Use this presentation sequence when the output is one complete prompt or task
+envelope for a different thread, child task, or execution surface; exact
+identity, operator review, recovery, citation, or replay materially matters;
+the six-condition issue-owned durable-prompt admission test passes; ownership,
+privacy, visibility, retention, and destination are unambiguous; and currently
+qualified absent-create, raw-readback, operator-preview, and downstream-
+delivery routes are available. Routine short prompts, brainstorming,
+incomplete fragments, and ordinary same-thread deltas remain lightweight and
+inline.
+
+The required order is:
+
+```text
+render -> admit -> absent-create -> raw verify -> operator preview ->
+explicit approval -> fresh delivery route -> thin bootstrap ->
+executor exact verification -> execution
+```
+
+Raw provider readback and exact identity verification must finish before the
+preview is presented. The preview route and the executor-delivery route are
+distinct operations: preview must not prefetch, unfurl, scan, or consume a
+bounded delivery URL, and the executor route is not minted until explicit
+approval.
+
+After raw verification, normally present compact removable operator metadata,
+the provider-backed preview or file object, the semantic filename and
+issue-owned path, exact byte size and whole-file SHA-256, provider object ID
+and revision when available, the downstream executor or prompt role, and one
+explicit `Approve`, `Revise`, or `Reject` boundary. Do not print the full
+executable prompt inline by default after this path succeeds. The operator may
+request the complete prompt inline without changing the durable identity, and
+removing the operator metadata must still leave the executable prompt
+complete.
+
+Preview is a human-readable convenience surface. It is not raw-byte
+verification; does not prove size, SHA-256, provider content hash, revision,
+or equality; does not imply approval; is not delivery, acknowledgement,
+execution start, or attempt completion; creates no coordination state; and
+transfers zero authority.
+
+An operator revision leaves the previewed version immutable and unsent. Record
+predecessor lineage, absent-create the next semantic version at a unique
+immutable identity, repeat raw verification and preview, and obtain fresh
+explicit approval. If rejected v1 is followed by approved v2, the eventual
+bootstrap names only v2. Never overwrite or silently reuse v1, and never add a
+mutable `latest`, `current`, or `final` locator.
+
+Only after approval, mint a fresh bounded delivery route and emit a thin
+target-shaped bootstrap that omits the full prompt body. Name the approved
+durable path, provider object ID and revision when available, expected byte
+size and whole-file SHA-256, provider content hash when available and
+applicable, retrieval mechanism, lifetime, consumption behavior, and the
+requirement to verify exact bytes before reading or execution. Expiry, prior
+consumption, or failed retrieval requires a new delivery operation for the
+same durable prompt, not a new prompt version. Never reconstruct missing bytes
+from the bootstrap, conversation history, or memory.
+
+If any required capability or admission condition is unavailable or
+unqualified, stop before provider creation when admission has not passed, name
+the precise gap, and make no capture, readback, preview, approval, or delivery
+claim. Use the complete inline presentation only when the prompt is safe to
+display and the operator can review every byte before manual send; keep
+operator metadata outside that executable prompt. Otherwise stop with a
+non-authorizing capability blocker.
+
 ## Quick Navigation
 
 - [Task-Shape Surface Selection And Thin Handoffs](#task-shape-surface-selection-and-thin-handoffs)
+- [Material Cross-Executor Prompt Presentation](#material-cross-executor-prompt-presentation)
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)
 - [Orchestration Handoff](#orchestration-handoff)

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -282,7 +282,8 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-For a complete, copy-ready prompt or downstream handoff prepared in ChatGPT,
+When the shared recipient-capability selector chooses inline presentation for
+a complete, copy-ready prompt or downstream handoff prepared in ChatGPT,
 present the shared operator-metadata block followed immediately by the complete
 executable block as consecutive copyable code blocks, with no intervening
 prose. Immediately after the executable block, outside both code blocks, emit

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -180,11 +180,13 @@ establish a universal per-action client-rendering suppression control.
 Apply the shared
 [`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation)
 selector. For a machine recipient with qualified Dropbox retrieval and a
-permitted destination, use the authorized file route, present its file card or
-preview, and immediately provide the target-shaped handoff. Do not wait for
-prompt approval or require the operator to open the preview; connector
-confirmation authorizes only its file operation. File-card and preview behavior
-is product-dependent runtime evidence, so recheck the relevant action.
+permitted destination, use the authorized file route, present the card produced
+by the write when available, and immediately provide the target-shaped handoff.
+A separate preview or open action remains optional under the connected-app
+rules above. Do not wait for prompt approval or require the operator to open a
+preview; connector confirmation authorizes only its file operation. File-card
+and preview behavior is product-dependent runtime evidence, so recheck the
+relevant action.
 
 For a human recipient or a system without a qualified Dropbox route, use the
 existing [two-block inline presentation](#prompt-presentation). If access is

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -123,7 +123,7 @@ These shapes project the shared owner in
 they do not redefine its package, authority, source-refresh, or failure
 semantics.
 
-#### Examples
+#### Prompt handoff examples
 
 1. **Difficult architecture discussion remains in Chat.** The human and Chat
    are still comparing authority boundaries and tradeoffs. No bounded
@@ -189,6 +189,108 @@ before reporting `PRESERVED`. When the provider does not expose revision
 metadata, record that unavailability explicitly and never fabricate a revision.
 Overwrite, autorename, a destination collision, or an identity mismatch fails
 closed. Extracted text alone is not exact-byte readback.
+
+For an admitted material cross-executor prompt, project the default
+presentation sequence in
+[`prompts.md`](../prompts.md#material-cross-executor-prompt-presentation):
+
+```text
+render -> admit -> absent-create -> raw verify -> Dropbox preview ->
+explicit approval -> fresh executor download -> thin bootstrap ->
+executor exact verification -> execution
+```
+
+Do not present preview before raw verification, and do not mint the executor's
+bounded download before explicit approval. The write response, metadata,
+provider content hash, extracted text, and preview are useful evidence at
+their own boundaries, but none substitutes for raw provider bytes and a
+whole-file SHA-256 exact match.
+
+#### Dropbox preview and operator approval
+
+After raw verification, use the connected Dropbox file-preview widget as the
+intentional human review surface. Present the file object with compact
+operator metadata: semantic filename, issue-owned path, exact size and
+whole-file SHA-256, file ID and revision when exposed, downstream executor or
+prompt role, and an explicit `Approve`, `Revise`, or `Reject` request. Do not
+also print the full executable prompt unless the operator asks for it or the
+safe fallback below applies.
+
+The current connected preview action returns an in-chat preview/open surface
+and states that it always generates a private shared link. That link creation
+or reuse is a provider-side preview effect, not universal Dropbox behavior and
+not the executor-delivery identity. Before treating the route as qualified,
+inspect the effective audience, view or edit access, download setting,
+expiration, password setting, persistence or reuse behavior, and any
+visibility or retention consequence. Bracket the preview with provider
+metadata and revision inspection when the workflow must establish whether the
+preview changed file bytes or revision. If link creation requires a separate
+confirmation, or its visibility, retention, mutation, or cleanup boundary is
+unclear, stop before preview rather than weakening the gate.
+
+On one exercised current route, the private preview link was observed with
+`audience=no_one`, view access, and downloads permitted. Treat that as
+product-dependent runtime evidence to revalidate, not as a provider guarantee.
+Dropbox's
+[file-access documentation](https://developers.dropbox.com/dbx-file-access-guide)
+separately establishes file IDs, revisions, content hashes, and provider
+preview endpoints; it does not establish this ChatGPT widget or its
+private-link effect. The current OpenAI apps guidance linked above documents
+rich in-chat experiences and confirmation behavior for consequential actions,
+but not a universal Dropbox preview implementation.
+
+Preview remains convenience only. It does not prove exact bytes, size,
+SHA-256, Dropbox content hash, revision, or equality; is not approval,
+delivery, acknowledgement, execution start, or completion; creates no new
+coordination state; and transfers zero authority. Opening the preview, elapsed
+time, upload success, validation, review, issue status, a hash match, or prior
+approval of another version never implies approval.
+
+If the operator requests changed wording, leave the previewed version
+immutable and unsent. Create a unique successor with predecessor lineage,
+repeat raw verification and preview, and require fresh explicit approval. The
+eventual bootstrap names only the approved version.
+
+#### Approved delivery and safe fallback
+
+Only after approval, create a fresh bounded executor-consumable download and
+emit the Codex-, Work-, Claude-, or other target-shaped bootstrap without the
+full prompt body. Include the approved durable path, file ID, revision when
+available, expected size and whole-file SHA-256, Dropbox content hash when
+available and applicable, retrieval mechanism, lifetime, observed consumption
+behavior, and a fail-closed exact-verification instruction. Keep the durable
+prompt, preview operation, human approval, delivery operation, executor
+acknowledgement, attempt, receipt, output, and human disposition as separate
+identities.
+
+The currently exposed temporary-download action accepts a requested lifetime
+from 60 through 900 seconds and states that the first HTTP request of any
+method, including `HEAD` or a range request, consumes the URL. This is a
+current connected-action contract, not a universal Dropbox API guarantee.
+Preview, unfurlers, scanners, and preflight requests must never receive that
+URL. Expiry, prior consumption, or failed retrieval requires a fresh link for
+the same durable object and a new delivery-operation identity; it does not
+create a prompt version.
+
+When absent-create, raw readback, preview, private-link effects, or downstream
+delivery cannot be qualified, name the exact gap. Use the shared complete
+inline fallback only when every prompt byte is safe to display and review
+before manual send, with operator metadata outside the executable prompt;
+otherwise stop. Do not claim preservation, raw verification, preview,
+approval, or delivery that did not occur.
+
+#### Examples
+
+| Case | ChatGPT projection |
+| --- | --- |
+| Material ChatGPT to Codex prompt | Preserve and raw-verify the admitted prompt, show the Dropbox preview, obtain explicit approval, then issue a new bounded URL and a thin bootstrap. Codex performs one intended download, exact-verifies it, and executes only from the verified bytes. |
+| Revision after preview | Rejected v1 remains immutable and unsent. Absent-create and raw-verify v2, preview it, obtain fresh approval, and name only v2 in the bootstrap. |
+| Preview and delivery separation | Preview uses the provider-backed file widget before any executor URL exists. The post-approval URL is newly minted and is never exposed to preview or unfurling. |
+| Expired or consumed URL | Mint a replacement for the same durable file and record a new delivery operation; do not create a prompt version. |
+| Preview or raw readback unavailable | Do not claim the gate passed. Show the complete safe prompt inline for operator review or stop with the exact non-authorizing blocker. |
+| Routine or same-thread prompt | Keep a routine short prompt or ordinary same-thread delta inline; do not add durable capture or preview ceremony. |
+| Admission failure | Stop before Dropbox creation on a secret, retention, ownership, visibility, or identity failure. |
+| Claude or another executor | Preserve the same durable, preview, approval, and delivery identities, but use only that executor's currently qualified retrieval and verification route. |
 
 Prefer a receiving executor's qualified direct retrieval of that durable object.
 When the receiver cannot directly retrieve and verify it, ChatGPT may coordinate

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -123,7 +123,7 @@ These shapes project the shared owner in
 they do not redefine its package, authority, source-refresh, or failure
 semantics.
 
-#### Prompt handoff examples
+#### Examples
 
 1. **Difficult architecture discussion remains in Chat.** The human and Chat
    are still comparing authority boundaries and tradeoffs. No bounded
@@ -175,6 +175,22 @@ the card was suppressed. Current
 documents rich in-chat app experiences and write confirmations, but does not
 establish a universal per-action client-rendering suppression control.
 
+### Recipient-Capability Prompt Presentation
+
+Apply the shared
+[`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation)
+selector. For a machine recipient with qualified Dropbox retrieval and a
+permitted destination, use the authorized file route, present its file card or
+preview, and immediately provide the target-shaped handoff. Do not wait for
+prompt approval or require the operator to open the preview; connector
+confirmation authorizes only its file operation. File-card and preview behavior
+is product-dependent runtime evidence, so recheck the relevant action.
+
+For a human recipient or a system without a qualified Dropbox route, use the
+existing [two-block inline presentation](#prompt-presentation). If access is
+unknown, inspect or attempt it before falling back. Material prompts also apply
+the durable profile below; routine prompts do not inherit it from transport.
+
 ### Issue-Owned Durable Prompt Capture And Handoff
 
 Apply the shared
@@ -189,108 +205,6 @@ before reporting `PRESERVED`. When the provider does not expose revision
 metadata, record that unavailability explicitly and never fabricate a revision.
 Overwrite, autorename, a destination collision, or an identity mismatch fails
 closed. Extracted text alone is not exact-byte readback.
-
-For an admitted material cross-executor prompt, project the default
-presentation sequence in
-[`prompts.md`](../prompts.md#material-cross-executor-prompt-presentation):
-
-```text
-render -> admit -> absent-create -> raw verify -> Dropbox preview ->
-explicit approval -> fresh executor download -> thin bootstrap ->
-executor exact verification -> execution
-```
-
-Do not present preview before raw verification, and do not mint the executor's
-bounded download before explicit approval. The write response, metadata,
-provider content hash, extracted text, and preview are useful evidence at
-their own boundaries, but none substitutes for raw provider bytes and a
-whole-file SHA-256 exact match.
-
-#### Dropbox preview and operator approval
-
-After raw verification, use the connected Dropbox file-preview widget as the
-intentional human review surface. Present the file object with compact
-operator metadata: semantic filename, issue-owned path, exact size and
-whole-file SHA-256, file ID and revision when exposed, downstream executor or
-prompt role, and an explicit `Approve`, `Revise`, or `Reject` request. Do not
-also print the full executable prompt unless the operator asks for it or the
-safe fallback below applies.
-
-The current connected preview action returns an in-chat preview/open surface
-and states that it always generates a private shared link. That link creation
-or reuse is a provider-side preview effect, not universal Dropbox behavior and
-not the executor-delivery identity. Before treating the route as qualified,
-inspect the effective audience, view or edit access, download setting,
-expiration, password setting, persistence or reuse behavior, and any
-visibility or retention consequence. Bracket the preview with provider
-metadata and revision inspection when the workflow must establish whether the
-preview changed file bytes or revision. If link creation requires a separate
-confirmation, or its visibility, retention, mutation, or cleanup boundary is
-unclear, stop before preview rather than weakening the gate.
-
-On one exercised current route, the private preview link was observed with
-`audience=no_one`, view access, and downloads permitted. Treat that as
-product-dependent runtime evidence to revalidate, not as a provider guarantee.
-Dropbox's
-[file-access documentation](https://developers.dropbox.com/dbx-file-access-guide)
-separately establishes file IDs, revisions, content hashes, and provider
-preview endpoints; it does not establish this ChatGPT widget or its
-private-link effect. The current OpenAI apps guidance linked above documents
-rich in-chat experiences and confirmation behavior for consequential actions,
-but not a universal Dropbox preview implementation.
-
-Preview remains convenience only. It does not prove exact bytes, size,
-SHA-256, Dropbox content hash, revision, or equality; is not approval,
-delivery, acknowledgement, execution start, or completion; creates no new
-coordination state; and transfers zero authority. Opening the preview, elapsed
-time, upload success, validation, review, issue status, a hash match, or prior
-approval of another version never implies approval.
-
-If the operator requests changed wording, leave the previewed version
-immutable and unsent. Create a unique successor with predecessor lineage,
-repeat raw verification and preview, and require fresh explicit approval. The
-eventual bootstrap names only the approved version.
-
-#### Approved delivery and safe fallback
-
-Only after approval, create a fresh bounded executor-consumable download and
-emit the Codex-, Work-, Claude-, or other target-shaped bootstrap without the
-full prompt body. Include the approved durable path, file ID, revision when
-available, expected size and whole-file SHA-256, Dropbox content hash when
-available and applicable, retrieval mechanism, lifetime, observed consumption
-behavior, and a fail-closed exact-verification instruction. Keep the durable
-prompt, preview operation, human approval, delivery operation, executor
-acknowledgement, attempt, receipt, output, and human disposition as separate
-identities.
-
-The currently exposed temporary-download action accepts a requested lifetime
-from 60 through 900 seconds and states that the first HTTP request of any
-method, including `HEAD` or a range request, consumes the URL. This is a
-current connected-action contract, not a universal Dropbox API guarantee.
-Preview, unfurlers, scanners, and preflight requests must never receive that
-URL. Expiry, prior consumption, or failed retrieval requires a fresh link for
-the same durable object and a new delivery-operation identity; it does not
-create a prompt version.
-
-When absent-create, raw readback, preview, private-link effects, or downstream
-delivery cannot be qualified, name the exact gap. Use the shared complete
-inline fallback only when every prompt byte is safe to display and review
-before manual send, with operator metadata outside the executable prompt;
-otherwise stop. Do not claim preservation, raw verification, preview,
-approval, or delivery that did not occur.
-
-#### Examples
-
-| Case | ChatGPT projection |
-| --- | --- |
-| Material ChatGPT to Codex prompt | Preserve and raw-verify the admitted prompt, show the Dropbox preview, obtain explicit approval, then issue a new bounded URL and a thin bootstrap. Codex performs one intended download, exact-verifies it, and executes only from the verified bytes. |
-| Revision after preview | Rejected v1 remains immutable and unsent. Absent-create and raw-verify v2, preview it, obtain fresh approval, and name only v2 in the bootstrap. |
-| Preview and delivery separation | Preview uses the provider-backed file widget before any executor URL exists. The post-approval URL is newly minted and is never exposed to preview or unfurling. |
-| Expired or consumed URL | Mint a replacement for the same durable file and record a new delivery operation; do not create a prompt version. |
-| Preview or raw readback unavailable | Do not claim the gate passed. Show the complete safe prompt inline for operator review or stop with the exact non-authorizing blocker. |
-| Routine or same-thread prompt | Keep a routine short prompt or ordinary same-thread delta inline; do not add durable capture or preview ceremony. |
-| Admission failure | Stop before Dropbox creation on a secret, retention, ownership, visibility, or identity failure. |
-| Claude or another executor | Preserve the same durable, preview, approval, and delivery identities, but use only that executor's currently qualified retrieval and verification route. |
 
 Prefer a receiving executor's qualified direct retrieval of that durable object.
 When the receiver cannot directly retrieve and verify it, ChatGPT may coordinate

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -314,6 +314,31 @@ consumed local bytes and declared text format before acceptance. Do not use a
 locally synchronized provider mount as provider identity, treat the local
 retrieval as durable, or create an exchange root.
 
+For a bounded single-use URL, allocate one fresh private executor-owned
+attempt-local destination through the currently qualified OS-managed scratch
+projection. Perform exactly one intended `GET`; do not send `HEAD`, range
+probes, previews, unfurlers, scanners, or other preflight traffic that could
+spend the route. Follow redirects only when the qualified delivery contract
+permits them. Before reading or executing the prompt, verify the expected byte
+size and whole-file SHA-256, UTF-8, no BOM, LF-only line endings, and the
+declared final-newline rule. Verify the Dropbox content hash when the delivery
+contract requires it and the attempt has a qualified computation or exact
+comparison route.
+
+Fail closed before prompt interpretation on expiry, prior consumption, network
+failure, redirect ambiguity, inaccessible identity, size or digest mismatch,
+required content-hash mismatch, encoding or newline mismatch, or ambiguous
+bytes. Never reconstruct the payload from bootstrap text, conversation
+history, or memory. A replacement URL is a new delivery operation for the same
+durable prompt, not a new prompt version.
+
+The current connected Dropbox download action states that the first HTTP
+request of any method consumes its URL and that requested lifetimes range from
+60 through 900 seconds. Treat those values as a product-dependent action
+contract to revalidate for the attempt, not a universal Dropbox guarantee.
+The bootstrap must omit the full prompt body and bind only the exact approved
+durable identity and verification requirements.
+
 Record the delivery operation and Codex attempt separately from the durable
 prompt. Distinguish `DELIVERED`, `ACCEPTED`, `STARTED`, and the terminal
 attempt outcome rather than inferring one from another. Preserve required

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -314,31 +314,6 @@ consumed local bytes and declared text format before acceptance. Do not use a
 locally synchronized provider mount as provider identity, treat the local
 retrieval as durable, or create an exchange root.
 
-For a bounded single-use URL, allocate one fresh private executor-owned
-attempt-local destination through the currently qualified OS-managed scratch
-projection. Perform exactly one intended `GET`; do not send `HEAD`, range
-probes, previews, unfurlers, scanners, or other preflight traffic that could
-spend the route. Follow redirects only when the qualified delivery contract
-permits them. Before reading or executing the prompt, verify the expected byte
-size and whole-file SHA-256, UTF-8, no BOM, LF-only line endings, and the
-declared final-newline rule. Verify the Dropbox content hash when the delivery
-contract requires it and the attempt has a qualified computation or exact
-comparison route.
-
-Fail closed before prompt interpretation on expiry, prior consumption, network
-failure, redirect ambiguity, inaccessible identity, size or digest mismatch,
-required content-hash mismatch, encoding or newline mismatch, or ambiguous
-bytes. Never reconstruct the payload from bootstrap text, conversation
-history, or memory. A replacement URL is a new delivery operation for the same
-durable prompt, not a new prompt version.
-
-The current connected Dropbox download action states that the first HTTP
-request of any method consumes its URL and that requested lifetimes range from
-60 through 900 seconds. Treat those values as a product-dependent action
-contract to revalidate for the attempt, not a universal Dropbox guarantee.
-The bootstrap must omit the full prompt body and bind only the exact approved
-durable identity and verification requirements.
-
 Record the delivery operation and Codex attempt separately from the durable
 prompt. Distinguish `DELIVERED`, `ACCEPTED`, `STARTED`, and the terminal
 attempt outcome rather than inferring one from another. Preserve required

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -47,9 +47,17 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             DOCS / "prompts.md",
             "## Issue-Owned Durable Prompt Delivery Envelope Add-On",
         )
+        cls.complete_prompt_shape = markdown_section(
+            DOCS / "prompts.md",
+            "## Complete Prompt Shape",
+        )
         cls.presentation = markdown_section(
             DOCS / "prompts.md",
             "## Cross-Executor Prompt Presentation",
+        )
+        cls.chatgpt_prompt_presentation = markdown_section(
+            DOCS / "tool-adapters" / "chatgpt.md",
+            "### Prompt presentation",
         )
         cls.chatgpt_presentation = markdown_section(
             DOCS / "tool-adapters" / "chatgpt.md",
@@ -231,11 +239,29 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_qualified_machine_recipient_uses_file_first_presentation(self):
         presentation = " ".join(self.presentation.split())
+        self.assertIn(
+            "For any complete prompt, select presentation by the recipient's "
+            "currently qualified capability, independently of prompt materiality",
+            presentation,
+        )
         route = presentation.index("qualified Dropbox retrieval route")
         file = presentation.index("Dropbox-backed file")
         handoff = presentation.index("target-shaped retrieval handoff")
         self.assertLess(route, file)
         self.assertLess(file, handoff)
+
+    def test_two_block_format_is_conditional_on_inline_presentation(self):
+        complete_shape = " ".join(self.complete_prompt_shape.split())
+        chatgpt_prompt = " ".join(self.chatgpt_prompt_presentation.split())
+        self.assertIn(
+            "When inline presentation is selected for a complete generated prompt",
+            complete_shape,
+        )
+        self.assertIn(
+            "When the shared recipient-capability selector chooses inline "
+            "presentation for a complete, copy-ready prompt or downstream handoff",
+            chatgpt_prompt,
+        )
 
     def test_preview_does_not_gate_machine_handoff(self):
         presentation = " ".join(self.presentation.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import json
 import re
 import unittest
 
@@ -30,11 +29,6 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
         cls.claude = normalized(DOCS / "tool-adapters" / "claude.md")
         cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
-        cls.anchor = json.loads(
-            (DOCS / "prompt-contract-semantic-anchors-v2.json").read_text(
-                encoding="utf-8"
-            )
-        )
         cls.adapter_profiles = (
             markdown_section(
                 DOCS / "tool-adapters" / "codex.md",
@@ -55,7 +49,11 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         )
         cls.presentation = markdown_section(
             DOCS / "prompts.md",
-            "## Material Cross-Executor Prompt Presentation",
+            "## Cross-Executor Prompt Presentation",
+        )
+        cls.chatgpt_presentation = markdown_section(
+            DOCS / "tool-adapters" / "chatgpt.md",
+            "### Recipient-Capability Prompt Presentation",
         )
 
     def test_prompt_contract_is_the_profile_owner(self):
@@ -231,130 +229,34 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         for phrase in ("Overwrite", "autorename", "destination collision", "fails closed"):
             self.assertIn(phrase, self.chatgpt)
 
-    def test_material_prompt_presentation_order_is_mechanically_explicit(self):
-        order = (
-            "render -> admit -> absent-create -> raw verify -> operator preview -> "
-            "explicit approval -> fresh delivery route -> thin bootstrap -> "
-            "executor exact verification -> execution"
-        )
-        self.assertIn(order, " ".join(self.presentation.split()))
-        for phrase in (
-            "Raw provider readback and exact identity verification must finish before the preview",
-            "preview route and the executor-delivery route are distinct operations",
-            "executor route is not minted until explicit approval",
-        ):
-            self.assertIn(phrase, " ".join(self.presentation.split()))
-
-    def test_preview_is_convenience_not_evidence_approval_or_state(self):
-        for phrase in (
-            "human-readable convenience surface",
-            "not raw-byte verification",
-            "does not prove size, SHA-256, provider content hash, revision, or equality",
-            "does not imply approval",
-            "is not delivery, acknowledgement, execution start, or attempt completion",
-            "creates no coordination state",
-            "transfers zero authority",
-        ):
-            self.assertIn(phrase, " ".join(self.presentation.split()))
-
-    def test_preview_revision_and_delivery_retry_preserve_identities(self):
+    def test_qualified_machine_recipient_uses_file_first_presentation(self):
         presentation = " ".join(self.presentation.split())
-        for phrase in (
-            "previewed version immutable and unsent",
-            "rejected v1 is followed by approved v2",
-            "bootstrap names only v2",
-            "Never overwrite or silently reuse v1",
-            "new delivery operation for the same durable prompt, not a new prompt version",
-            "mutable `latest`, `current`, or `final` locator",
-        ):
-            self.assertIn(phrase, presentation)
+        route = presentation.index("qualified Dropbox retrieval route")
+        file = presentation.index("Dropbox-backed file")
+        handoff = presentation.index("target-shaped retrieval handoff")
+        self.assertLess(route, file)
+        self.assertLess(file, handoff)
 
-    def test_default_omits_prompt_body_but_routine_and_fallback_stay_inline(self):
+    def test_preview_does_not_gate_machine_handoff(self):
         presentation = " ".join(self.presentation.split())
-        for phrase in (
-            "Do not print the full executable prompt inline by default",
-            "thin target-shaped bootstrap that omits the full prompt body",
-            "Routine short prompts, brainstorming, incomplete fragments, and ordinary same-thread deltas remain lightweight and inline",
-            "complete inline presentation only when the prompt is safe to display",
-            "keep operator metadata outside that executable prompt",
-            "stop before provider creation when admission has not passed",
-        ):
-            self.assertIn(phrase, presentation)
+        chatgpt_presentation = " ".join(self.chatgpt_presentation.split())
+        self.assertIn("does not block the handoff or require prompt approval", presentation)
+        self.assertNotIn("explicit approval", presentation)
+        self.assertIn("Do not wait for prompt approval", chatgpt_presentation)
 
-    def test_chatgpt_examples_cover_default_revision_retry_and_fallback(self):
-        for phrase in (
-            "Material ChatGPT to Codex prompt",
-            "Rejected v1 remains immutable and unsent",
-            "before any executor URL exists",
-            "replacement for the same durable file",
-            "Preview or raw readback unavailable",
-            "Routine or same-thread prompt",
-            "Stop before Dropbox creation",
-            "Claude or another executor",
-        ):
-            self.assertIn(phrase, self.chatgpt)
-
-    def test_chatgpt_preview_link_effect_is_bounded_and_product_dependent(self):
-        for phrase in (
-            "always generates a private shared link",
-            "provider-side preview effect",
-            "not universal Dropbox behavior",
-            "effective audience",
-            "view or edit access",
-            "download setting",
-            "persistence or reuse behavior",
-            "preview changed file bytes or revision",
-            "`audience=no_one`, view access, and downloads permitted",
-            "product-dependent runtime evidence to revalidate",
-        ):
-            self.assertIn(phrase, self.chatgpt)
-
-    def test_approval_and_thin_bootstrap_remain_separate_identities(self):
-        for phrase in (
-            "Only after approval",
-            "without the full prompt body",
-            "approved durable path",
-            "file ID",
-            "whole-file SHA-256",
-            "Dropbox content hash",
-            "preview operation, human approval, delivery operation",
-            "executor acknowledgement, attempt, receipt, output, and human disposition",
-        ):
-            self.assertIn(phrase, self.chatgpt)
-
-    def test_codex_single_use_retrieval_verifies_before_interpretation(self):
-        for phrase in (
-            "Perform exactly one intended `GET`",
-            "do not send `HEAD`, range probes, previews, unfurlers, scanners",
-            "Before reading or executing the prompt",
-            "expected byte size and whole-file SHA-256",
-            "UTF-8, no BOM, LF-only line endings",
-            "Verify the Dropbox content hash when",
-            "Fail closed before prompt interpretation",
-            "Never reconstruct the payload",
-            "replacement URL is a new delivery operation for the same durable prompt",
-        ):
-            self.assertIn(phrase, self.codex)
-
-    def test_provider_action_contracts_are_not_universal_guarantees(self):
-        for adapter in (self.chatgpt, self.codex):
-            self.assertIn("60 through 900 seconds", adapter)
-            self.assertIn("first HTTP request of any method", adapter)
-            self.assertIn("not a universal Dropbox", adapter)
-
-    def test_presentation_does_not_take_cak_168_or_semantic_anchor_ownership(self):
+    def test_human_or_unqualified_recipient_uses_inline_presentation(self):
         presentation = " ".join(self.presentation.split())
-        for cak_168_term in (
-            "current receiving surface",
-            "first downstream deliverable",
-        ):
-            self.assertNotIn(cak_168_term, presentation.lower())
-        self.assertNotIn(
-            "## Material Cross-Executor Prompt Presentation",
-            self.contract,
-        )
-        self.assertNotIn("operator_preview", self.anchor)
-        self.assertNotIn("operator_approval", self.anchor)
+        self.assertIn("For a human recipient", presentation)
+        self.assertIn("no qualified Dropbox route", presentation)
+        self.assertIn("present the complete prompt inline", presentation)
+        self.assertIn("consecutive copyable code blocks", self.chatgpt)
+
+    def test_material_governance_layers_without_capturing_routine_prompts(self):
+        presentation = " ".join(self.presentation.split())
+        self.assertIn("issue-owned durable rendered-prompt handoff profile", presentation)
+        self.assertIn("A routine prompt delivered through a file does not", presentation)
+        self.assertIn("use inline presentation rather than inventing a storage surface", presentation)
+        self.assertIn("two-block inline presentation", self.chatgpt_presentation)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import json
 import re
 import unittest
 
@@ -29,6 +30,11 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
         cls.claude = normalized(DOCS / "tool-adapters" / "claude.md")
         cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
+        cls.anchor = json.loads(
+            (DOCS / "prompt-contract-semantic-anchors-v2.json").read_text(
+                encoding="utf-8"
+            )
+        )
         cls.adapter_profiles = (
             markdown_section(
                 DOCS / "tool-adapters" / "codex.md",
@@ -46,6 +52,10 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         cls.delivery_envelope = markdown_section(
             DOCS / "prompts.md",
             "## Issue-Owned Durable Prompt Delivery Envelope Add-On",
+        )
+        cls.presentation = markdown_section(
+            DOCS / "prompts.md",
+            "## Material Cross-Executor Prompt Presentation",
         )
 
     def test_prompt_contract_is_the_profile_owner(self):
@@ -220,6 +230,131 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
     def test_chatgpt_creation_fails_closed_on_collision(self):
         for phrase in ("Overwrite", "autorename", "destination collision", "fails closed"):
             self.assertIn(phrase, self.chatgpt)
+
+    def test_material_prompt_presentation_order_is_mechanically_explicit(self):
+        order = (
+            "render -> admit -> absent-create -> raw verify -> operator preview -> "
+            "explicit approval -> fresh delivery route -> thin bootstrap -> "
+            "executor exact verification -> execution"
+        )
+        self.assertIn(order, " ".join(self.presentation.split()))
+        for phrase in (
+            "Raw provider readback and exact identity verification must finish before the preview",
+            "preview route and the executor-delivery route are distinct operations",
+            "executor route is not minted until explicit approval",
+        ):
+            self.assertIn(phrase, " ".join(self.presentation.split()))
+
+    def test_preview_is_convenience_not_evidence_approval_or_state(self):
+        for phrase in (
+            "human-readable convenience surface",
+            "not raw-byte verification",
+            "does not prove size, SHA-256, provider content hash, revision, or equality",
+            "does not imply approval",
+            "is not delivery, acknowledgement, execution start, or attempt completion",
+            "creates no coordination state",
+            "transfers zero authority",
+        ):
+            self.assertIn(phrase, " ".join(self.presentation.split()))
+
+    def test_preview_revision_and_delivery_retry_preserve_identities(self):
+        presentation = " ".join(self.presentation.split())
+        for phrase in (
+            "previewed version immutable and unsent",
+            "rejected v1 is followed by approved v2",
+            "bootstrap names only v2",
+            "Never overwrite or silently reuse v1",
+            "new delivery operation for the same durable prompt, not a new prompt version",
+            "mutable `latest`, `current`, or `final` locator",
+        ):
+            self.assertIn(phrase, presentation)
+
+    def test_default_omits_prompt_body_but_routine_and_fallback_stay_inline(self):
+        presentation = " ".join(self.presentation.split())
+        for phrase in (
+            "Do not print the full executable prompt inline by default",
+            "thin target-shaped bootstrap that omits the full prompt body",
+            "Routine short prompts, brainstorming, incomplete fragments, and ordinary same-thread deltas remain lightweight and inline",
+            "complete inline presentation only when the prompt is safe to display",
+            "keep operator metadata outside that executable prompt",
+            "stop before provider creation when admission has not passed",
+        ):
+            self.assertIn(phrase, presentation)
+
+    def test_chatgpt_examples_cover_default_revision_retry_and_fallback(self):
+        for phrase in (
+            "Material ChatGPT to Codex prompt",
+            "Rejected v1 remains immutable and unsent",
+            "before any executor URL exists",
+            "replacement for the same durable file",
+            "Preview or raw readback unavailable",
+            "Routine or same-thread prompt",
+            "Stop before Dropbox creation",
+            "Claude or another executor",
+        ):
+            self.assertIn(phrase, self.chatgpt)
+
+    def test_chatgpt_preview_link_effect_is_bounded_and_product_dependent(self):
+        for phrase in (
+            "always generates a private shared link",
+            "provider-side preview effect",
+            "not universal Dropbox behavior",
+            "effective audience",
+            "view or edit access",
+            "download setting",
+            "persistence or reuse behavior",
+            "preview changed file bytes or revision",
+            "`audience=no_one`, view access, and downloads permitted",
+            "product-dependent runtime evidence to revalidate",
+        ):
+            self.assertIn(phrase, self.chatgpt)
+
+    def test_approval_and_thin_bootstrap_remain_separate_identities(self):
+        for phrase in (
+            "Only after approval",
+            "without the full prompt body",
+            "approved durable path",
+            "file ID",
+            "whole-file SHA-256",
+            "Dropbox content hash",
+            "preview operation, human approval, delivery operation",
+            "executor acknowledgement, attempt, receipt, output, and human disposition",
+        ):
+            self.assertIn(phrase, self.chatgpt)
+
+    def test_codex_single_use_retrieval_verifies_before_interpretation(self):
+        for phrase in (
+            "Perform exactly one intended `GET`",
+            "do not send `HEAD`, range probes, previews, unfurlers, scanners",
+            "Before reading or executing the prompt",
+            "expected byte size and whole-file SHA-256",
+            "UTF-8, no BOM, LF-only line endings",
+            "Verify the Dropbox content hash when",
+            "Fail closed before prompt interpretation",
+            "Never reconstruct the payload",
+            "replacement URL is a new delivery operation for the same durable prompt",
+        ):
+            self.assertIn(phrase, self.codex)
+
+    def test_provider_action_contracts_are_not_universal_guarantees(self):
+        for adapter in (self.chatgpt, self.codex):
+            self.assertIn("60 through 900 seconds", adapter)
+            self.assertIn("first HTTP request of any method", adapter)
+            self.assertIn("not a universal Dropbox", adapter)
+
+    def test_presentation_does_not_take_cak_168_or_semantic_anchor_ownership(self):
+        presentation = " ".join(self.presentation.split())
+        for cak_168_term in (
+            "current receiving surface",
+            "first downstream deliverable",
+        ):
+            self.assertNotIn(cak_168_term, presentation.lower())
+        self.assertNotIn(
+            "## Material Cross-Executor Prompt Presentation",
+            self.contract,
+        )
+        self.assertNotIn("operator_preview", self.anchor)
+        self.assertNotIn("operator_approval", self.anchor)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -241,7 +241,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         presentation = " ".join(self.presentation.split())
         chatgpt_presentation = " ".join(self.chatgpt_presentation.split())
         self.assertIn("does not block the handoff or require prompt approval", presentation)
-        self.assertNotIn("explicit approval", presentation)
+        for gate_phrase in ("Approve", "Revise", "Reject", "explicit approval", "before sending"):
+            self.assertNotIn(gate_phrase, presentation)
         self.assertIn("Do not wait for prompt approval", chatgpt_presentation)
 
     def test_human_or_unqualified_recipient_uses_inline_presentation(self):

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -388,6 +388,71 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
         self.assertIn("A child task spawned by the reviewed party", reviewer)
         self.assertIn("the external-review role", reviewer)
 
+    def test_generated_prompts_remain_complete_across_thread_routing(self):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        readiness = (DOCS / "repo-readiness.md").read_text(encoding="utf-8")
+        normalized_prompts = " ".join(prompts.split())
+        normalized_readiness = " ".join(readiness.split())
+
+        for partial_prompt_phrase in (
+            "current delta",
+            "changed delta",
+            "routing delta",
+        ):
+            self.assertNotIn(partial_prompt_phrase, prompts)
+
+        self.assertIn(
+            "Every generated prompt or handoff is a complete drop-in artifact",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "self-contained for its intended receiving context and directly usable",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "Thread routing never relaxes prompt completeness",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "A `FRESH THREAD` receives a complete prompt",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "A `SAME THREAD` receives the complete instruction for its next bounded action",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "reference still-current established state",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "A `CHILD TASK` receives a complete bounded child prompt",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "a thin role-specific envelope remains a complete current handoff while "
+            "pointing to that state instead of reproducing it",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "Do not produce partial prompts, continuation fragments",
+            normalized_readiness,
+        )
+        self.assertIn(
+            'or "change X to Y" pseudo-prompts unless the human explicitly requested',
+            normalized_readiness,
+        )
+        self.assertIn(
+            "The [recipient-capability selector](#cross-executor-prompt-presentation) "
+            "applies to every complete prompt",
+            normalized_prompts,
+        )
+        self.assertIn(
+            "For any complete prompt, select presentation by the recipient's "
+            "currently qualified capability",
+            normalized_prompts,
+        )
+
     def test_operator_metadata_stays_outside_complete_executable_prompts(self):
         prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
         codex = (DOCS / "tool-adapters/codex.md").read_text(encoding="utf-8")

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -399,7 +399,7 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             "changed delta",
             "routing delta",
         ):
-            self.assertNotIn(partial_prompt_phrase, prompts)
+            self.assertNotIn(partial_prompt_phrase, normalized_prompts)
 
         self.assertIn(
             "Every generated prompt or handoff is a complete drop-in artifact",


### PR DESCRIPTION
## Summary

- select complete prompt presentation by the recipient's currently qualified capability, independently of prompt materiality
- use Dropbox-backed file presentation for a machine recipient with qualified retrieval and a permitted destination, presenting the write-produced file surface and retrieval handoff without an approval pause
- retain complete inline presentation for a human recipient or a recipient without qualified Dropbox retrieval
- scope the shared operator-metadata plus executable two-block format, and ChatGPT's consecutive copyable blocks, specifically to cases where inline presentation is selected
- require every generated prompt or handoff to remain a complete, directly usable drop-in artifact for its intended receiving context
- make thread routing explicit without relaxing completeness: fresh threads receive complete fresh-context prompts, same threads receive complete next-action prompts that may reference still-current state, and child tasks receive complete bounded child prompts
- make thin semantic handoffs compact by externalizing recoverable state, never by emitting partial instructions
- remove the prompt-fragment doctrine expressed as `current delta`, `changed delta`, and `routing delta`
- retain the existing issue-owned durable rendered-prompt profile only when material-prompt admission applies; routine file transport does not add durable governance ceremony

Linear: CAK-173

## Scope

Exact head: `5c1dfa5afa6093dcb89954bd61fb318de57b4fb2`.

Final diff: 214 additions and 21 deletions across four natural owners:

- `docs/prompts.md`
- `docs/tool-adapters/chatgpt.md`
- `tests/test_issue_owned_prompt_handoff.py`
- `tests/test_prompt_contract_semantics.py`

The complete-prompt correction adds no Dropbox-specific behavior. The Codex adapter, semantic-anchor JSON, connector behavior, and CAK-168 receiving-surface/downstream-deliverable ownership remain unchanged from `main`. CAK-174 was not modified or coordinated through this PR.

## Complete-prompt invariant

Every generated prompt or handoff is a complete drop-in artifact: self-contained for its intended receiving context and directly usable. Thread routing and still-current context may reduce duplicated background but never produce a partial executable artifact.

- `FRESH THREAD`: complete prompt suitable for fresh receiving context
- `SAME THREAD`: complete instruction for the next bounded action; it may reference still-current established state but remains directly usable without another prompt
- `CHILD TASK`: complete bounded child prompt

The recipient-capability selector applies to every complete prompt across these routing modes. The existing `docs/repo-readiness.md` rule remains the governing owner, including its explicit-human-request exception for deliberately requested diffs, patches, or fragments.

## Validation

- focused prompt semantic and Dropbox handoff modules: 33 tests passed
- `git diff --check`: passed
- `make check`: Markdown lint clean and all 215 tests passed
- `make authoritative-source-check`: no non-authoritative source URLs found
- remote `authoritative-source-check`: passed at exact head
- remote `markdownlint`: passed at exact head

## Materiality

This remains a material presentation-selector change. It does not alter the issue-owned durable-prompt semantic profile, so no v1 or v2 semantic-anchor successor is required.

## Independent review

The earlier governed review chain covered exact head `81cb86cdde55b68faa4dcea4dc2fff78a8a70798`.

Claude Code 2.1.246 / Opus high performed a governed read-only review of both `81cb86c..408c57b` and the complete `c523abb..408c57b` comparison. It returned `ACCEPT` with one low-severity test-hardening suggestion: normalize whitespace before checking for the three prohibited prompt-delta phrases. That suggestion was accepted in commit `5c1dfa5afa6093dcb89954bd61fb318de57b4fb2`.

Claude then performed a final governed read-only review of both `408c57b..5c1dfa5` and the complete `c523abb..5c1dfa5` comparison. It returned `ACCEPT` with no findings and explicitly stated that the existing review chain plus the final focused review fully covers exact final commit `5c1dfa5afa6093dcb89954bd61fb318de57b4fb2` across both comparisons.

One earlier non-qualifying attempt correctly failed closed on unrelated shared Git-administration churn, produced no verdict, and left the candidate unchanged. CAK-175 tracks the launcher's over-broad common-Git monitoring separately.

## Live runtime qualification

The live non-secret CAK-173 exercise passed on 2026-08-27 against the dedicated `ai@much.email` Dropbox account and issue-owned destination.

- Immutable file: `/artifacts/issues/CAK-173/2026-08-27-cak-173-codex-recipient-retrieval-live-exercise-v1.md`
- Provider object: `id:FHKdoRfTdTUAAAAAAAAIjw`; revision `0165a086ef87977000000037bda8cd3`
- Exact identity: 2,508 bytes; SHA-256 `3199378b265f45e625e0e76b04b8336b101f1ba12971cd62f7ab49e3ac63dd58`
- Dropbox content hash: `cd23247062d92111accbe7c892f00e18e3340eb19ff8c24b16d8f2e4bc9ae98b`
- Raw delivery: one 300-second single-use route and exactly one GET; the retrieved bytes matched the frozen producer bytes byte-for-byte, including UTF-8/no-BOM, LF-only, and final-newline rules
- File surface: the create action returned metadata but no rendered card in its connector response; one explicit provider preview action by file ID produced the visible file surface, which Keith confirmed was usable
- Separation: preview used the provider file identity after raw verification and did not use the executor's single-use delivery URL
- Recipient execution: after exact verification, the bounded prompt completed its required read-only observation of this PR
- Producing receipt: CAK-173 Linear comment `c32a2ce9-e83b-4f8b-9dba-2e8ee0666b47`

The create-versus-preview UI behavior is observed product/runtime evidence, not a universal provider guarantee. Extracted text was observed separately and was not treated as raw-byte evidence. The private attempt-local producer/retrieval copies were exact-verified, removed, and their removal verified.

## Current review boundary

Independent review, canonical validation, hosted checks, and the live CAK-173 Dropbox recipient-retrieval exercise are complete at exact head `5c1dfa5afa6093dcb89954bd61fb318de57b4fb2`.

This PR is ready for human review. Ready-for-review status does not authorize merge, auto-merge, issue acceptance, release, or CAK-173 completion. Those remain separate human gates.
