### PR TITLE
fix: decouple Claude reviewer identity qualification

### DIFF
--- a/.codex/rule-templates/claude-review.rules
+++ b/.codex/rule-templates/claude-review.rules
@@ -4,6 +4,7 @@ prefix_rule(
     pattern=[
         "__CLAUDE_REVIEW_LAUNCHER__",
         [
+            "--qualify-claude-identity",
             "--permission-hook",
             "--request-termination",
             "--decline-termination",
@@ -11,7 +12,7 @@ prefix_rule(
         ],
     ],
     decision="prompt",
-    justification="Claude reviewer lifecycle and permission-hook controls require separate authority.",
+    justification="Claude identity qualification, lifecycle, and permission-hook controls require separate authority.",
 )
 
 prefix_rule(

--- a/.codex/rules/claude-review.rules
+++ b/.codex/rules/claude-review.rules
@@ -5,6 +5,7 @@ prefix_rule(
     pattern=[
         "./scripts/claude-review",
         [
+            "--qualify-claude-identity",
             "--permission-hook",
             "--auth-preflight",
             "--review-config",

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -115,9 +115,14 @@ the exact machine-local installation rendered by
 launcher verifies its reviewed bytes, immutable schema-v2 entry contract,
 active Codex rule, singular current qualification receipt, and the exact
 absolute Claude selector plus resolved user-owned, non-writable executable
-identity; it does not select `claude` from inherited `PATH`. Before provider
-process creation it rechecks the canonical path, ownership, mode, executable
-status, device, inode, size, digest, and version against the current receipt.
+file identity without starting unqualified bytes; it does not select `claude`
+from inherited `PATH`. Only after that non-executing identity matches the
+schema-v2 qualification receipt may it query the recorded version. It then
+re-observes the file identity. Before provider process creation it repeats that
+ordering and compares the current receipt, entry contract, canonical path,
+ownership, mode, executable status, device, inode, size, digest, and version.
+The residual operating-system race between the final recheck and process
+creation remains explicit; the launcher does not claim to eliminate it.
 A versioned JSON review config binds the
 source graph, launch root and exact additional directories, guard roots,
 candidate and exact `HEAD`, disjoint evidence directory, immutable
@@ -133,13 +138,19 @@ A selector advance is capability drift, not a candidate finding. Ordinary auth
 and review fail closed before Claude receives substantive input and expose only
 the exact launcher's prompt-gated identity-qualification transition. The
 transition derives and re-observes the configured selector from the immutable
-entry contract, requires the expected current receipt and expected observed
-identity, writes one immutable predecessor-linked receipt, and atomically
-replaces the singular current selection under a private lock. It cannot accept
-an arbitrary executable or selector. Unchanged execution never rewrites this
-state. Historical receipts do not silently reauthorize rollback; returning to
-older bytes is a new transition. Qualification is evidence and capability
-gating only and grants no review, candidate, merge, or other task authority.
+entry contract, requires the expected current receipt and expected
+non-executing file-identity digest, and rejects a no-op. Only after the lock,
+predecessor, file, ownership, mode, digest, path, and forbidden-root checks pass
+does the prompted operation first query the new bytes for their version. It
+re-observes the file identity before writing one immutable predecessor-linked
+receipt and compare-and-swap replacing the singular current selection with an
+exact private, flushed temporary file. It cannot accept an arbitrary executable
+or selector. Ordinary drift diagnostics do not claim a version for unqualified
+bytes. Unchanged execution and identical-contract installer reruns never
+rewrite current selection. Historical receipts do not silently reauthorize
+rollback; returning to older bytes is a new transition. Qualification is
+evidence and capability gating only and grants no review, candidate, merge, or
+other task authority.
 
 The generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits
 `Bash` only when its command text exactly equals the shell rendering of one

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -112,9 +112,13 @@ The repository [`claude-review`](../../scripts/claude-review) source composes
 these controls for governed review. Production auth and review run only through
 the exact machine-local installation rendered by
 [`install-claude-review`](../../scripts/install-claude-review). That installed
-launcher verifies its reviewed bytes, active Codex rule, and the exact absolute
-Claude selector plus resolved user-owned, non-writable executable identity; it
-does not select `claude` from inherited `PATH`. A versioned JSON review config binds the
+launcher verifies its reviewed bytes, immutable schema-v2 entry contract,
+active Codex rule, singular current qualification receipt, and the exact
+absolute Claude selector plus resolved user-owned, non-writable executable
+identity; it does not select `claude` from inherited `PATH`. Before provider
+process creation it rechecks the canonical path, ownership, mode, executable
+status, device, inode, size, digest, and version against the current receipt.
+A versioned JSON review config binds the
 source graph, launch root and exact additional directories, guard roots,
 candidate and exact `HEAD`, disjoint evidence directory, immutable
 preflight-receipt and final-output paths, exact stream and terminal-receipt
@@ -124,6 +128,18 @@ live-state mechanics remain in private controller attempt-local scratch. The
 launcher accepts
 only model and supported effort selection after `--`; it owns the tool,
 permission, MCP, settings, hook, output, and persistence flags.
+
+A selector advance is capability drift, not a candidate finding. Ordinary auth
+and review fail closed before Claude receives substantive input and expose only
+the exact launcher's prompt-gated identity-qualification transition. The
+transition derives and re-observes the configured selector from the immutable
+entry contract, requires the expected current receipt and expected observed
+identity, writes one immutable predecessor-linked receipt, and atomically
+replaces the singular current selection under a private lock. It cannot accept
+an arbitrary executable or selector. Unchanged execution never rewrites this
+state. Historical receipts do not silently reauthorize rollback; returning to
+older bytes is a new transition. Qualification is evidence and capability
+gating only and grants no review, candidate, merge, or other task authority.
 
 The generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits
 `Bash` only when its command text exactly equals the shell rendering of one

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -767,7 +767,11 @@ creates the initial exact Claude qualification receipt and singular current
 selection in separate private state, and renders the user rule with the exact
 installed absolute path. It refuses a different existing installed object and
 requires the caller to name the expected digest before replacing an existing
-active rule. Schema-v1 installations remain historical state; do not reinterpret
+active rule. An identical-contract rerun securely validates and preserves any
+valid current receipt, including upgrade and rollback lineage, and appends only
+the new source provenance and requested activation evidence. Selector drift on
+a rerun is qualification-required and occurs before rule or activation-receipt
+mutation. Schema-v1 installations remain historical state; do not reinterpret
 or migrate them automatically. Supply every
 candidate, evidence, workspace, and attempt-scratch root as a forbidden root.
 The activation receipt's exact operator-controlled parent is also recorded as
@@ -792,20 +796,30 @@ prefixes for that installed path. The exact
 `--qualify-claude-identity` prefix is `prompt`, as are lifecycle and
 permission-hook controls; repository-relative, alternate-path, arbitrary
 Claude-selection, and shell-wrapped forms are not allowed. The installed
-launcher verifies its own bytes, immutable entry contract, active-rule hash,
+entry and rule are a one-time setup while their contract remains unchanged;
+a routine Claude update uses only the bounded qualification command emitted by
+the drift diagnostic, not another install, rule rewrite, or Codex restart. The
+installed launcher verifies its own bytes, immutable entry contract,
+active-rule hash,
 private current-selection record, immutable qualification receipt, and the
-selector's exact resolved executable identity before either allowed operation.
-It never resolves `claude` through inherited `PATH`.
+selector's exact non-executing file identity before either allowed operation.
+Only matching already-qualified bytes may be queried for their recorded version,
+followed by a repeated file observation. It never resolves `claude` through
+inherited `PATH`.
 
 When the configured selector resolves to a legitimate new identity, ordinary
 auth and review fail before provider launch with
 `reviewer_identity_qualification_required`. The bounded diagnostic names the
-current receipt digest, observed canonical path, version and digest, and the
-exact qualification command. That command accepts only the expected current
-receipt digest and expected observed-identity digest; it derives the selector
-from the immutable entry manifest, recomputes the target, serializes the
-transition under the entry's exact lock, creates one no-overwrite lineage
-receipt, and atomically compare-and-swap replaces the singular current record.
+current receipt digest, observed canonical path and file digest, the exact
+non-executing observation and its digest, and the exact qualification command;
+it does not claim a version for unqualified bytes. That command accepts only the
+expected current receipt digest and expected observed file-identity digest; it
+derives the selector from the immutable entry manifest, recomputes the target,
+serializes the transition under the entry's exact lock, rejects no-op requests,
+then performs the first permitted version query. After another exact file
+observation it creates one no-overwrite lineage receipt and atomically
+compare-and-swap replaces the singular current record through a private flushed
+temporary file.
 It cannot select another executable or change the selector. After the operator
 approves and the transition succeeds, rerun the unchanged auth or review
 command through the unchanged rule. Historical receipts are provenance, not an
@@ -831,7 +845,7 @@ codex execpolicy check --pretty \
   --rules /ABSOLUTE/PATH/TO/ACTIVE/claude-review.rules \
   -- /ABSOLUTE/INSTALLED/PATH/claude-review --qualify-claude-identity \
   --expected-current-receipt-sha256 EXPECTED_RECEIPT_SHA256 \
-  --expected-observed-identity-sha256 EXPECTED_IDENTITY_SHA256
+  --expected-observed-file-identity-sha256 EXPECTED_FILE_IDENTITY_SHA256
 ```
 
 The first check must report `allow`; the lifecycle and qualification checks

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -756,12 +756,19 @@ Never copy that template unchanged into the user layer: its placeholder is not
 an executable identity, and a relative allow prefix can match writable bytes in
 more than one repository.
 
-The installer verifies a clean exact source commit, copies the launcher to a
-commit-and-digest-qualified directory under an operator-controlled non-workspace
-root, records the source and installed hashes, exact Claude selector and resolved
-file identity, and renders the user rule with the exact installed absolute path.
-It refuses a different existing installed object and requires the caller to name
-the expected digest before replacing an existing active rule. Supply every
+The installer verifies a clean exact source commit and derives one immutable,
+content-addressed entry contract from the launcher bytes, installation and
+qualification schemas, Codex rule-template bytes, configured Claude selector,
+active-rule path, forbidden roots, and private state destinations. An unrelated
+source commit remains provenance and does not change the entry path when those
+execution-contract inputs are identical. The installer copies the launcher and
+immutable schema-v2 manifest under an operator-controlled non-workspace root,
+creates the initial exact Claude qualification receipt and singular current
+selection in separate private state, and renders the user rule with the exact
+installed absolute path. It refuses a different existing installed object and
+requires the caller to name the expected digest before replacing an existing
+active rule. Schema-v1 installations remain historical state; do not reinterpret
+or migrate them automatically. Supply every
 candidate, evidence, workspace, and attempt-scratch root as a forbidden root.
 The activation receipt's exact operator-controlled parent is also recorded as
 the auth-preflight diagnostics directory. An auto-approved auth preflight may
@@ -781,15 +788,34 @@ For example, using operator-selected absolute paths:
 ```
 
 The generated user rule allows only direct auth-preflight and governed-review
-prefixes for that installed path. Lifecycle and permission-hook prefixes remain
-`prompt`; repository-relative, alternate-path, and shell-wrapped forms are not
-allowed. The installed launcher verifies its own bytes, the active-rule hash,
-and the recorded Claude selector and resolved executable identity before either
-allowed operation. It never resolves `claude` through inherited `PATH`.
+prefixes for that installed path. The exact
+`--qualify-claude-identity` prefix is `prompt`, as are lifecycle and
+permission-hook controls; repository-relative, alternate-path, arbitrary
+Claude-selection, and shell-wrapped forms are not allowed. The installed
+launcher verifies its own bytes, immutable entry contract, active-rule hash,
+private current-selection record, immutable qualification receipt, and the
+selector's exact resolved executable identity before either allowed operation.
+It never resolves `claude` through inherited `PATH`.
 
-Codex loads rules at startup. After each explicit install or update, validate
-the rendered rule without launching Claude, then restart Codex before relying
-on it:
+When the configured selector resolves to a legitimate new identity, ordinary
+auth and review fail before provider launch with
+`reviewer_identity_qualification_required`. The bounded diagnostic names the
+current receipt digest, observed canonical path, version and digest, and the
+exact qualification command. That command accepts only the expected current
+receipt digest and expected observed-identity digest; it derives the selector
+from the immutable entry manifest, recomputes the target, serializes the
+transition under the entry's exact lock, creates one no-overwrite lineage
+receipt, and atomically compare-and-swap replaces the singular current record.
+It cannot select another executable or change the selector. After the operator
+approves and the transition succeeds, rerun the unchanged auth or review
+command through the unchanged rule. Historical receipts are provenance, not an
+allowlist: an upgrade, consecutive upgrade, or rollback each requires a new
+transition from the current receipt.
+
+Codex loads rules at startup. After a genuine entry-contract install or rule
+update, validate the rendered rule without launching Claude, then restart Codex
+before relying on it. A qualification-only transition does not edit the rule or
+launcher and does not require a restart:
 
 ```sh
 codex execpolicy check --pretty \
@@ -800,9 +826,16 @@ codex execpolicy check --pretty \
   --rules /ABSOLUTE/PATH/TO/ACTIVE/claude-review.rules \
   -- /ABSOLUTE/INSTALLED/PATH/claude-review --terminate /tmp/live-state.json \
   --termination-authority operator-approved
+
+codex execpolicy check --pretty \
+  --rules /ABSOLUTE/PATH/TO/ACTIVE/claude-review.rules \
+  -- /ABSOLUTE/INSTALLED/PATH/claude-review --qualify-claude-identity \
+  --expected-current-receipt-sha256 EXPECTED_RECEIPT_SHA256 \
+  --expected-observed-identity-sha256 EXPECTED_IDENTITY_SHA256
 ```
 
-The first check must report `allow`; the second must report `prompt`. Do not use
+The first check must report `allow`; the lifecycle and qualification checks
+must report `prompt`. Do not use
 shell wrappers, redirections, or pipelines for this path: they change policy
 evaluation and bypass the launcher's owned prompt/output flow. Supply the review
 prompt directly on standard input through an execution channel that remains open

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
+import fcntl
 import hashlib
 import json
 import os
@@ -37,6 +38,8 @@ MAX_GOVERNED_ATTEMPTS = 3
 TRANSIENT_OUTER_RETRY_ERRORS = {"overloaded", "server_error"}
 SAFE_EXECUTABLES = {"git", "shasum"}
 INSTALLATION_MANIFEST_NAME = "claude-review-installation.json"
+INSTALLATION_SCHEMA_VERSION = 2
+QUALIFICATION_SCHEMA_VERSION = 1
 REVISION_ATOM = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64}|HEAD|origin/main)")
 REQUIRED_TOOLS = {"Bash", "Glob", "Grep", "Read"}
 OAUTH_REAUTHENTICATION_DISPOSITION = (
@@ -68,6 +71,12 @@ NONTERMINATING_CONTROL_STATES = {
     "awaiting_process_group_terminal",
     "source_observation_failure_waiting_for_terminal",
 }
+
+
+class QualificationRequiredError(ValueError):
+    def __init__(self, message: str, details: dict[str, object]):
+        super().__init__(message)
+        self.details = details
 
 
 def qualified_attempt_scratch_parent_shape(
@@ -333,7 +342,7 @@ def executable_identity(path: Path, effective_uid: int) -> dict[str, object]:
     version = version_of(str(resolved), os.environ.copy(), cwd=str(resolved.parent))
     if version is None:
         raise ValueError("the resolved Claude executable did not provide an exact version identity")
-    return {
+    identity = {
         "requested_selector": str(path),
         "selector_kind": "symlink" if stat.S_ISLNK(selector_metadata.st_mode) else "file",
         "selector_target": os.readlink(path) if stat.S_ISLNK(selector_metadata.st_mode) else None,
@@ -348,6 +357,209 @@ def executable_identity(path: Path, effective_uid: int) -> dict[str, object]:
         "resolved_sha256": sha256_bytes(resolved.read_bytes()),
         "version": version,
     }
+    final_metadata = resolved.stat()
+    if (
+        final_metadata.st_dev != metadata.st_dev
+        or final_metadata.st_ino != metadata.st_ino
+        or final_metadata.st_size != metadata.st_size
+        or sha256_bytes(resolved.read_bytes()) != identity["resolved_sha256"]
+        or any(
+            getattr(path.lstat(), field) != getattr(selector_metadata, field)
+            for field in ("st_dev", "st_ino", "st_uid", "st_mode", "st_size")
+        )
+        or (
+            stat.S_ISLNK(selector_metadata.st_mode)
+            and os.readlink(path) != identity["selector_target"]
+        )
+    ):
+        raise ValueError("the Claude selector or target changed during identity observation")
+    return identity
+
+
+def secure_regular_bytes(path: Path, effective_uid: int, *, modes: set[int]) -> bytes:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != effective_uid
+        or stat.S_IMODE(metadata.st_mode) not in modes
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"state object is not an exact private regular file: {path}")
+    return path.read_bytes()
+
+
+def secure_private_directory(path: Path, effective_uid: int) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != effective_uid
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"state directory is not exact private operator-controlled state: {path}")
+
+
+def load_installed_entry(effective_uid: int) -> tuple[Path, Path, dict[str, object]]:
+    launcher = Path(__file__).resolve(strict=True)
+    launcher_metadata = launcher.lstat()
+    if (
+        launcher.is_symlink()
+        or not stat.S_ISREG(launcher_metadata.st_mode)
+        or launcher_metadata.st_uid != effective_uid
+        or stat.S_IMODE(launcher_metadata.st_mode) != 0o500
+    ):
+        raise ValueError("the installed launcher is not the exact private executable object")
+    secure_private_directory(launcher.parent, effective_uid)
+    manifest_path = launcher.with_name(INSTALLATION_MANIFEST_NAME)
+    try:
+        manifest_bytes = secure_regular_bytes(manifest_path, effective_uid, modes={0o400})
+        manifest = json.loads(manifest_bytes)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError("production auth/review requires the exact schema-v2 installed entry manifest") from error
+    if manifest.get("schema_version") != INSTALLATION_SCHEMA_VERSION:
+        raise ValueError("installed launcher schema is not supported; schema-v1 is not reinterpreted")
+    if manifest.get("installed_launcher_path") != str(launcher):
+        raise ValueError("the installed launcher manifest does not name this exact launcher")
+    launcher_bytes = launcher.read_bytes()
+    if manifest.get("installed_launcher_sha256") != sha256_bytes(launcher_bytes):
+        raise ValueError("the installed launcher bytes do not match the activated reviewed identity")
+    contract = manifest.get("entry_contract")
+    contract_id = manifest.get("entry_contract_id")
+    if (
+        not isinstance(contract, dict)
+        or contract_id != f"sha256:{sha256_bytes(canonical_json_bytes(contract))}"
+        or contract.get("installation_schema_version") != INSTALLATION_SCHEMA_VERSION
+        or contract.get("qualification_schema_version") != QUALIFICATION_SCHEMA_VERSION
+        or contract.get("launcher_sha256") != manifest.get("installed_launcher_sha256")
+    ):
+        raise ValueError("the immutable reviewer entry contract identity is invalid")
+    for field in (
+        "claude_selector",
+        "active_rule_path",
+        "forbidden_roots",
+        "auth_diagnostics_directory",
+    ):
+        if manifest.get(field) != contract.get(field):
+            raise ValueError(f"the entry manifest diverges from its immutable contract at {field}")
+    qualification_root = Path(str(contract.get("qualification_root", "")))
+    expected_qualification_directory = qualification_root / str(contract_id).removeprefix("sha256:")
+    if manifest.get("qualification_directory") != str(expected_qualification_directory):
+        raise ValueError("the qualification directory diverges from the immutable entry contract")
+    expected_state_paths = {
+        "qualification_receipts_directory": expected_qualification_directory / "receipts",
+        "current_selection_path": expected_qualification_directory / "current-selection.json",
+        "qualification_lock_path": expected_qualification_directory / "qualification.lock",
+    }
+    for field, expected_path in expected_state_paths.items():
+        if manifest.get(field) != str(expected_path):
+            raise ValueError(f"the entry manifest declares an invalid {field}")
+    active_rule = Path(str(manifest.get("active_rule_path", "")))
+    if not active_rule.is_absolute():
+        raise ValueError("the active Codex rule path is not exact")
+    active_metadata = active_rule.lstat()
+    if (
+        active_rule.is_symlink()
+        or not stat.S_ISREG(active_metadata.st_mode)
+        or active_metadata.st_uid != effective_uid
+        or stat.S_IMODE(active_metadata.st_mode) & 0o022
+        or active_rule.resolve(strict=True) != active_rule
+        or sha256_bytes(active_rule.read_bytes()) != manifest.get("active_rule_sha256")
+    ):
+        raise ValueError("the active Codex rule does not match the installed launcher manifest")
+    forbidden_roots = manifest.get("forbidden_roots")
+    if not isinstance(forbidden_roots, list) or not all(isinstance(value, str) for value in forbidden_roots):
+        raise ValueError("the installation manifest does not declare exact forbidden writable roots")
+    for field in ("auth_diagnostics_directory", "qualification_directory", "qualification_receipts_directory"):
+        value = manifest.get(field)
+        if not isinstance(value, str) or not Path(value).is_absolute():
+            raise ValueError(f"the installation manifest does not declare an exact {field}")
+        secure_private_directory(Path(value), effective_uid)
+        if any(
+            contained(Path(value), Path(root)) or contained(Path(root), Path(value))
+            for root in forbidden_roots
+        ):
+            raise ValueError(f"{field} overlaps a forbidden writable root")
+    return launcher, manifest_path, manifest
+
+
+def current_qualification(
+    manifest: dict[str, object], effective_uid: int
+) -> tuple[dict[str, object], dict[str, object], bytes]:
+    current_path = Path(str(manifest.get("current_selection_path", "")))
+    receipts_directory = Path(str(manifest.get("qualification_receipts_directory", "")))
+    qualification_directory = Path(str(manifest.get("qualification_directory", "")))
+    if current_path.parent != qualification_directory or current_path.name != "current-selection.json":
+        raise ValueError("the current-selection path escaped its exact qualification directory")
+    current_bytes = secure_regular_bytes(current_path, effective_uid, modes={0o600})
+    try:
+        current = json.loads(current_bytes)
+    except json.JSONDecodeError as error:
+        raise ValueError("the current-selection record is malformed") from error
+    expected = {
+        "kind": "claude_reviewer_current_selection",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest.get("entry_contract_id"),
+        "claude_selector": manifest.get("claude_selector"),
+    }
+    if any(current.get(key) != value for key, value in expected.items()):
+        raise ValueError("the current-selection record does not match the immutable entry contract")
+    receipt_path = Path(str(current.get("receipt_path", "")))
+    receipt_sha256 = current.get("receipt_sha256")
+    if (
+        not isinstance(receipt_sha256, str)
+        or receipt_path.parent != receipts_directory
+        or receipt_path.name != f"{receipt_sha256}.json"
+    ):
+        raise ValueError("the current qualification receipt identity is invalid")
+    receipt_bytes = secure_regular_bytes(receipt_path, effective_uid, modes={0o400})
+    if sha256_bytes(receipt_bytes) != receipt_sha256:
+        raise ValueError("the current qualification receipt digest is invalid")
+    try:
+        receipt = json.loads(receipt_bytes)
+    except json.JSONDecodeError as error:
+        raise ValueError("the current qualification receipt is malformed") from error
+    launcher = Path(__file__).resolve(strict=True)
+    required = {
+        "kind": "claude_reviewer_qualification_receipt",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest.get("entry_contract_id"),
+        "claude_selector": manifest.get("claude_selector"),
+        "producing_launcher_path": str(launcher),
+        "producing_launcher_sha256": manifest.get("installed_launcher_sha256"),
+    }
+    if any(receipt.get(key) != value for key, value in required.items()):
+        raise ValueError("the qualification receipt does not match the immutable entry contract")
+    if not isinstance(receipt.get("observed_identity"), dict):
+        raise ValueError("the qualification receipt lacks an exact executable identity")
+    predecessor_sha256 = receipt.get("predecessor_receipt_sha256")
+    predecessor_path_value = receipt.get("predecessor_receipt_path")
+    if (predecessor_sha256 is None) != (predecessor_path_value is None):
+        raise ValueError("the qualification receipt has ambiguous predecessor lineage")
+    if predecessor_sha256 is not None:
+        predecessor_path = Path(str(predecessor_path_value))
+        if (
+            not isinstance(predecessor_sha256, str)
+            or predecessor_sha256 == receipt_sha256
+            or predecessor_path.parent != receipts_directory
+            or predecessor_path.name != f"{predecessor_sha256}.json"
+        ):
+            raise ValueError("the qualification receipt has stale or invalid predecessor lineage")
+        predecessor_bytes = secure_regular_bytes(predecessor_path, effective_uid, modes={0o400})
+        if sha256_bytes(predecessor_bytes) != predecessor_sha256:
+            raise ValueError("the qualification predecessor receipt digest is invalid")
+        try:
+            predecessor = json.loads(predecessor_bytes)
+        except json.JSONDecodeError as error:
+            raise ValueError("the predecessor qualification receipt is malformed") from error
+        if any(predecessor.get(key) != value for key, value in required.items()):
+            raise ValueError("the predecessor qualification receipt belongs to another entry contract")
+    return current, receipt, current_bytes
+
+
+def observed_identity_digest(identity: dict[str, object]) -> str:
+    return sha256_bytes(canonical_json_bytes(identity))
 
 
 def qualified_execution(
@@ -356,7 +568,7 @@ def qualified_execution(
     *,
     explicit_test_fixture: bool = False,
 ) -> tuple[str, dict[str, object]]:
-    """Bind production execution to the installed launcher, rule, and Claude identity."""
+    """Bind production execution to one immutable entry and current qualification."""
     launcher = Path(__file__).resolve(strict=True)
     if explicit_test_fixture:
         if selector is None:
@@ -366,25 +578,12 @@ def qualified_execution(
         identity = executable_identity(Path(selector), effective_uid)
         identity["qualification"] = "explicit_test_fixture"
         return str(Path(identity["resolved_path"])), identity
-    manifest_path = launcher.with_name(INSTALLATION_MANIFEST_NAME)
-    try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        raise ValueError("production auth/review requires the exact installed launcher manifest") from error
-    if manifest.get("schema_version") != 1 or manifest.get("installed_launcher_path") != str(launcher):
-        raise ValueError("the installed launcher manifest does not name this exact launcher")
-    if manifest.get("installed_launcher_sha256") != sha256_bytes(launcher.read_bytes()):
-        raise ValueError("the installed launcher bytes do not match the activated reviewed identity")
-    active_rule = Path(str(manifest.get("active_rule_path", "")))
-    if not active_rule.is_absolute() or sha256_bytes(active_rule.read_bytes()) != manifest.get("active_rule_sha256"):
-        raise ValueError("the active Codex rule does not match the installed launcher manifest")
+    launcher, manifest_path, manifest = load_installed_entry(effective_uid)
     approved_selector = manifest.get("claude_selector")
     if not isinstance(approved_selector, str) or selector not in {None, approved_selector}:
         raise ValueError("--claude-bin does not match the exact activated Claude selector")
     identity = executable_identity(Path(approved_selector), effective_uid)
-    forbidden_roots = manifest.get("forbidden_roots")
-    if not isinstance(forbidden_roots, list) or not all(isinstance(value, str) for value in forbidden_roots):
-        raise ValueError("the installation manifest does not declare exact forbidden writable roots")
+    forbidden_roots = list(manifest["forbidden_roots"])
     selector_location = Path(approved_selector).parent.resolve(strict=True) / Path(approved_selector).name
     if any(
         contained(Path(identity["resolved_path"]), Path(value))
@@ -392,55 +591,142 @@ def qualified_execution(
         for value in forbidden_roots
     ):
         raise ValueError("the resolved Claude executable is inside a forbidden writable root")
-    auth_diagnostics_value = manifest.get("auth_diagnostics_directory")
-    if not isinstance(auth_diagnostics_value, str) or not Path(auth_diagnostics_value).is_absolute():
-        raise ValueError("the installation manifest does not declare an exact auth diagnostics directory")
-    auth_diagnostics_directory = Path(auth_diagnostics_value)
-    auth_diagnostics_metadata = auth_diagnostics_directory.lstat()
-    if (
-        auth_diagnostics_directory.is_symlink()
-        or not stat.S_ISDIR(auth_diagnostics_metadata.st_mode)
-        or auth_diagnostics_metadata.st_uid != effective_uid
-        or stat.S_IMODE(auth_diagnostics_metadata.st_mode) & 0o022
-        or auth_diagnostics_directory.resolve(strict=True) != auth_diagnostics_directory
-    ):
-        raise ValueError("the auth diagnostics directory is not exact operator-controlled state")
-    if any(
-        contained(auth_diagnostics_directory, Path(value))
-        or contained(Path(value), auth_diagnostics_directory)
-        for value in forbidden_roots
-    ):
-        raise ValueError("the auth diagnostics directory overlaps a forbidden writable root")
-    recorded = manifest.get("claude_identity")
-    for key in (
-        "requested_selector",
-        "selector_kind",
-        "selector_target",
-        "selector_uid",
-        "selector_mode",
-        "resolved_path",
-        "resolved_uid",
-        "resolved_mode",
-        "resolved_device",
-        "resolved_inode",
-        "resolved_size",
-        "resolved_sha256",
-        "version",
-    ):
-        if not isinstance(recorded, dict) or recorded.get(key) != identity.get(key):
-            raise ValueError(f"the Claude executable identity drifted at {key}")
+    current, receipt, _ = current_qualification(manifest, effective_uid)
+    recorded = receipt["observed_identity"]
+    if recorded != identity:
+        observed_digest = observed_identity_digest(identity)
+        action = (
+            f"{launcher} --qualify-claude-identity "
+            f"--expected-current-receipt-sha256 {current['receipt_sha256']} "
+            f"--expected-observed-identity-sha256 {observed_digest}"
+        )
+        raise QualificationRequiredError(
+            "the configured Claude selector resolved to a new exact identity",
+            {
+                "entry_contract_id": manifest.get("entry_contract_id"),
+                "installed_launcher_sha256": manifest.get("installed_launcher_sha256"),
+                "current_qualification_receipt_sha256": current["receipt_sha256"],
+                "observed_identity_sha256": observed_digest,
+                "observed_resolved_path": identity["resolved_path"],
+                "observed_resolved_sha256": identity["resolved_sha256"],
+                "observed_version": identity["version"],
+                "next_qualification_action": action,
+            },
+        )
     identity.update(
         {
-            "qualification": "installed_exact_identity",
+            "qualification": "current_qualification_receipt",
+            "qualification_receipt_path": current["receipt_path"],
+            "qualification_receipt_sha256": current["receipt_sha256"],
+            "entry_contract_id": manifest.get("entry_contract_id"),
             "installation_manifest_path": str(manifest_path),
-            "source_commit": manifest.get("source_commit"),
-            "source_launcher_sha256": manifest.get("source_launcher_sha256"),
+            "installation_manifest_sha256": sha256_bytes(manifest_path.read_bytes()),
             "installed_launcher_sha256": manifest.get("installed_launcher_sha256"),
             "active_rule_sha256": manifest.get("active_rule_sha256"),
-            "auth_diagnostics_directory": str(auth_diagnostics_directory),
+            "auth_diagnostics_directory": manifest.get("auth_diagnostics_directory"),
         }
     )
     return str(Path(identity["resolved_path"])), identity
+
+
+def revalidate_execution_identity(
+    executable: str, execution_identity: dict[str, object], effective_uid: int
+) -> None:
+    """Recheck the selected bytes immediately before provider process creation."""
+    if execution_identity.get("qualification") == "explicit_test_fixture":
+        observed = executable_identity(Path(str(execution_identity["requested_selector"])), effective_uid)
+        for key, value in observed.items():
+            if execution_identity.get(key) != value:
+                raise ValueError(f"the fixture Claude identity changed before execution at {key}")
+        if observed["resolved_path"] != executable:
+            raise ValueError("the fixture Claude canonical path changed before execution")
+        return
+    observed_executable, observed_identity = qualified_execution(None, effective_uid)
+    if observed_executable != executable:
+        raise ValueError("the qualified Claude canonical path changed before execution")
+    for key in (
+        "resolved_path",
+        "resolved_sha256",
+        "resolved_device",
+        "resolved_inode",
+        "resolved_size",
+        "version",
+        "qualification_receipt_sha256",
+        "entry_contract_id",
+    ):
+        if observed_identity.get(key) != execution_identity.get(key):
+            raise ValueError(f"the qualified Claude identity changed before execution at {key}")
+
+
+def qualify_claude_identity(
+    effective_uid: int,
+    *,
+    expected_current_receipt_sha256: str,
+    expected_observed_identity_sha256: str,
+) -> int:
+    launcher, _, manifest = load_installed_entry(effective_uid)
+    lock_path = Path(str(manifest.get("qualification_lock_path", "")))
+    qualification_directory = Path(str(manifest.get("qualification_directory", "")))
+    if lock_path.parent != qualification_directory or lock_path.name != "qualification.lock":
+        raise ValueError("the qualification lock escaped its exact state directory")
+    secure_regular_bytes(lock_path, effective_uid, modes={0o600})
+    with lock_path.open("r+b") as lock_stream:
+        fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
+        current, _, predecessor_current_bytes = current_qualification(manifest, effective_uid)
+        if current["receipt_sha256"] != expected_current_receipt_sha256:
+            raise ValueError("the qualification request names a stale predecessor receipt")
+        selector = Path(str(manifest["claude_selector"]))
+        observed = executable_identity(selector, effective_uid)
+        observed_digest = observed_identity_digest(observed)
+        if observed_digest != expected_observed_identity_sha256:
+            raise ValueError("the qualification request names a stale observed Claude identity")
+        forbidden_roots = list(manifest["forbidden_roots"])
+        selector_location = selector.parent.resolve(strict=True) / selector.name
+        if any(
+            contained(Path(observed["resolved_path"]), Path(value))
+            or contained(selector_location, Path(value))
+            for value in forbidden_roots
+        ):
+            raise ValueError("the resolved Claude executable is inside a forbidden writable root")
+        if executable_identity(selector, effective_uid) != observed:
+            raise ValueError("the Claude selector changed during qualification")
+        receipt = {
+            "kind": "claude_reviewer_qualification_receipt",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "entry_contract_id": manifest["entry_contract_id"],
+            "claude_selector": str(selector),
+            "observed_identity": observed,
+            "predecessor_receipt_sha256": current["receipt_sha256"],
+            "predecessor_receipt_path": current["receipt_path"],
+            "producing_launcher_path": str(launcher),
+            "producing_launcher_sha256": manifest["installed_launcher_sha256"],
+            "qualified_at_epoch": int(time.time()),
+            "authority_semantics": "capability qualification only; grants zero task or review authority",
+        }
+        receipt_bytes = canonical_json_bytes(receipt)
+        receipt_sha256 = sha256_bytes(receipt_bytes)
+        receipt_path = Path(str(manifest["qualification_receipts_directory"])) / f"{receipt_sha256}.json"
+        exclusive_write(receipt_path, receipt_bytes)
+        os.chmod(receipt_path, 0o400)
+        current_path = Path(str(manifest["current_selection_path"]))
+        if secure_regular_bytes(current_path, effective_uid, modes={0o600}) != predecessor_current_bytes:
+            raise ValueError("the current qualification changed before compare-and-swap")
+        new_current = {
+            "kind": "claude_reviewer_current_selection",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "entry_contract_id": manifest["entry_contract_id"],
+            "claude_selector": str(selector),
+            "receipt_path": str(receipt_path),
+            "receipt_sha256": receipt_sha256,
+        }
+        temporary = current_path.with_name(f".{current_path.name}.{uuid.uuid4().hex}.tmp")
+        exclusive_write(temporary, canonical_json_bytes(new_current))
+        os.replace(temporary, current_path)
+        validated_current, validated_receipt, _ = current_qualification(manifest, effective_uid)
+        if validated_current != new_current or validated_receipt != receipt:
+            raise ValueError("the qualification compare-and-swap did not verify")
+    print(json.dumps({"qualification_receipt_path": str(receipt_path), "qualification_receipt_sha256": receipt_sha256, "observed_identity": observed, "entry_contract_id": manifest["entry_contract_id"]}, sort_keys=True))
+    return 0
 
 
 def classify_failure(stderr: str, stdout: str, exit_code: int, *, preflight: bool = False) -> str | None:
@@ -1684,6 +1970,34 @@ def run_governed_review(
             if not contained(live_state_path, scratch):
                 raise RuntimeError("live-state path escaped controller scratch")
             started = time.time()
+            try:
+                revalidate_execution_identity(
+                    executable,
+                    execution_identity,
+                    int(execution_identity["resolved_uid"]),
+                )
+            except (OSError, ValueError) as error:
+                post_snapshot = source_snapshot(list(config.guard_roots), config.candidate, environment)
+                changes = snapshot_delta(attempt_snapshot, post_snapshot)
+                scratch_record = attempt_scratch.record()
+                attempt_scratch.cleanup()
+                emit_diagnostics(
+                    {
+                        "kind": "claude_governed_review",
+                        "review_id": config.body["review_id"],
+                        "contract_id": config.body["contract_id"],
+                        "controller_id": controller_id,
+                        "contract_identity": contract_identity,
+                        "failure_classification": "reviewer_identity_changed_before_execution",
+                        "candidate_verdict": "not_produced",
+                        "substantive_review_started": False,
+                        "no_delta_postflight": {"passed": not changes, "changed_paths": changes},
+                        "attempt_scratch": {**scratch_record, "cleanup": {"passed": True}},
+                        "error": bounded_redacted(str(error)),
+                    },
+                    diagnostics_destination,
+                )
+                return REVIEWER_FAILURE_EXIT
             process = subprocess.Popen(
                 command,
                 cwd=attempt_scratch.path,
@@ -2076,6 +2390,9 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     operation = parser.add_mutually_exclusive_group()
     operation.add_argument("--auth-preflight", action="store_true")
     operation.add_argument("--review-config", type=Path)
+    operation.add_argument("--qualify-claude-identity", action="store_true")
+    parser.add_argument("--expected-current-receipt-sha256")
+    parser.add_argument("--expected-observed-identity-sha256")
     operation.add_argument("--auth-preflight-fixture", action="store_true", help=argparse.SUPPRESS)
     operation.add_argument("--review-config-fixture", type=Path, help=argparse.SUPPRESS)
     operation.add_argument("--permission-hook", type=Path)
@@ -2103,6 +2420,16 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
         parser.error("termination authority and grace options require --terminate")
     if args.terminate is None and args.force_authorized:
         parser.error("--force-authorized requires --terminate")
+    qualification_modifiers = (
+        args.expected_current_receipt_sha256,
+        args.expected_observed_identity_sha256,
+    )
+    if args.qualify_claude_identity and not all(qualification_modifiers):
+        parser.error("--qualify-claude-identity requires both exact expected identity digests")
+    if not args.qualify_claude_identity and any(qualification_modifiers):
+        parser.error("qualification identity digests require --qualify-claude-identity")
+    if args.qualify_claude_identity and (args.claude_bin or args.diagnostics_file or args.claude_args):
+        parser.error("qualification derives the selector from the immutable entry contract")
     return args
 
 
@@ -2131,6 +2458,26 @@ def main(argv: list[str] | None = None) -> int:
             force_authorized=args.force_authorized,
             grace_seconds=args.grace_seconds,
         )
+    if args.qualify_claude_identity:
+        try:
+            uid, _, _ = effective_identity()
+            return qualify_claude_identity(
+                uid,
+                expected_current_receipt_sha256=args.expected_current_receipt_sha256,
+                expected_observed_identity_sha256=args.expected_observed_identity_sha256,
+            )
+        except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
+            emit_diagnostics(
+                {
+                    "kind": "claude_reviewer_qualification",
+                    "failure_classification": "qualification_transition_rejected",
+                    "candidate_verdict": "not_applicable",
+                    "substantive_review_output": False,
+                    "error": bounded_redacted(str(error)),
+                },
+                None,
+            )
+            return REVIEWER_FAILURE_EXIT
     classification_fixture = args.classification_fixture and fixture_environment
     execution_fixture = classification_fixture or requested_execution_fixture
     diagnostics_destination: Path | None = None
@@ -2160,6 +2507,24 @@ def main(argv: list[str] | None = None) -> int:
             uid,
             explicit_test_fixture=execution_fixture,
         )
+    except QualificationRequiredError as error:
+        emit_diagnostics(
+            {
+                "kind": "claude_reviewer_attempt",
+                "attempt_kind": "auth_preflight" if args.auth_preflight else "substantive_review",
+                "runtime": {"effective_uid": uid, "effective_user": user, "cwd": os.getcwd()},
+                "failure_classification": "reviewer_identity_qualification_required",
+                "candidate_verdict": "not_applicable" if args.auth_preflight else "not_produced",
+                "substantive_review_output": False,
+                "claude_exit_code": None,
+                "launcher_exit_code": REVIEWER_FAILURE_EXIT,
+                "qualification_transition": error.details,
+                "stderr": bounded_redacted(str(error)),
+                **failure_fields("reviewer_identity_qualification_required"),
+            },
+            None,
+        )
+        return REVIEWER_FAILURE_EXIT
     except (OSError, ValueError) as error:
         emit_diagnostics(
             {
@@ -2290,6 +2655,8 @@ def main(argv: list[str] | None = None) -> int:
 
     prompt = AUTH_PREFLIGHT_PROMPT if args.auth_preflight else sys.stdin.buffer.read()
     try:
+        if executable is not None:
+            revalidate_execution_identity(executable, execution_identity, uid)
         result = subprocess.run(
             command,
             check=False,
@@ -2299,18 +2666,23 @@ def main(argv: list[str] | None = None) -> int:
             stderr=subprocess.PIPE,
             cwd=execution_cwd,
         )
-    except OSError as error:
+    except (OSError, ValueError) as error:
+        spawn_failure = (
+            "reviewer_identity_changed_before_execution"
+            if isinstance(error, ValueError)
+            else "reviewer_execution_failure"
+        )
         emit_diagnostics(
             {
                 "kind": "claude_reviewer_attempt",
                 "runtime": runtime,
-                "failure_classification": "reviewer_execution_failure",
+                "failure_classification": spawn_failure,
                 "candidate_verdict": "not_produced",
                 "substantive_review_output": False,
                 "claude_exit_code": None,
                 "launcher_exit_code": REVIEWER_FAILURE_EXIT,
                 "stderr": bounded_redacted(str(error)),
-                **failure_fields("reviewer_execution_failure"),
+                **failure_fields(spawn_failure),
             },
             diagnostics_destination,
         )

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -39,7 +39,7 @@ TRANSIENT_OUTER_RETRY_ERRORS = {"overloaded", "server_error"}
 SAFE_EXECUTABLES = {"git", "shasum"}
 INSTALLATION_MANIFEST_NAME = "claude-review-installation.json"
 INSTALLATION_SCHEMA_VERSION = 2
-QUALIFICATION_SCHEMA_VERSION = 1
+QUALIFICATION_SCHEMA_VERSION = 2
 REVISION_ATOM = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64}|HEAD|origin/main)")
 REQUIRED_TOOLS = {"Bash", "Glob", "Grep", "Read"}
 OAUTH_REAUTHENTICATION_DISPOSITION = (
@@ -326,8 +326,12 @@ def accepted_auth_preflight_notices(output: str) -> list[str] | None:
     return notices
 
 
-def executable_identity(path: Path, effective_uid: int) -> dict[str, object]:
-    """Return the exact admitted selector and resolved executable identity."""
+def executable_file_identity(
+    path: Path,
+    effective_uid: int,
+    forbidden_roots: list[Path] | None = None,
+) -> dict[str, object]:
+    """Observe exact selector and target bytes without executing the target."""
     if not path.is_absolute():
         raise ValueError("the Claude selector must be an exact absolute path")
     selector_metadata = path.lstat()
@@ -339,23 +343,37 @@ def executable_identity(path: Path, effective_uid: int) -> dict[str, object]:
         raise ValueError("the resolved Claude executable must be a user-owned regular file")
     if stat.S_IMODE(metadata.st_mode) & 0o022 or not stat.S_IMODE(metadata.st_mode) & 0o100:
         raise ValueError("the resolved Claude executable must be owner-executable and not group/world-writable")
-    version = version_of(str(resolved), os.environ.copy(), cwd=str(resolved.parent))
-    if version is None:
-        raise ValueError("the resolved Claude executable did not provide an exact version identity")
+    roots = forbidden_roots or []
+    selector_location = path.parent.resolve(strict=True) / path.name
+    containment = [
+        {
+            "root": str(root),
+            "selector_contained": contained(selector_location, root),
+            "resolved_contained": contained(resolved, root),
+        }
+        for root in roots
+    ]
+    if any(item["selector_contained"] or item["resolved_contained"] for item in containment):
+        raise ValueError("the resolved Claude executable is inside a forbidden writable root")
     identity = {
         "requested_selector": str(path),
         "selector_kind": "symlink" if stat.S_ISLNK(selector_metadata.st_mode) else "file",
         "selector_target": os.readlink(path) if stat.S_ISLNK(selector_metadata.st_mode) else None,
         "selector_uid": selector_metadata.st_uid,
         "selector_mode": oct(stat.S_IMODE(selector_metadata.st_mode)),
+        "selector_device": selector_metadata.st_dev,
+        "selector_inode": selector_metadata.st_ino,
+        "selector_size": selector_metadata.st_size,
         "resolved_path": str(resolved),
         "resolved_uid": metadata.st_uid,
         "resolved_mode": oct(stat.S_IMODE(metadata.st_mode)),
+        "resolved_regular_file": stat.S_ISREG(metadata.st_mode),
+        "resolved_owner_executable": bool(stat.S_IMODE(metadata.st_mode) & 0o100),
         "resolved_device": metadata.st_dev,
         "resolved_inode": metadata.st_ino,
         "resolved_size": metadata.st_size,
         "resolved_sha256": sha256_bytes(resolved.read_bytes()),
-        "version": version,
+        "forbidden_root_containment": containment,
     }
     final_metadata = resolved.stat()
     if (
@@ -374,6 +392,98 @@ def executable_identity(path: Path, effective_uid: int) -> dict[str, object]:
     ):
         raise ValueError("the Claude selector or target changed during identity observation")
     return identity
+
+
+def qualified_executable_identity(
+    path: Path,
+    effective_uid: int,
+    forbidden_roots: list[Path] | None = None,
+) -> dict[str, object]:
+    """Query version only for bytes whose non-executing identity is already admitted."""
+    before = executable_file_identity(path, effective_uid, forbidden_roots)
+    version = version_of(
+        str(before["resolved_path"]),
+        os.environ.copy(),
+        cwd=str(Path(str(before["resolved_path"])).parent),
+    )
+    if version is None:
+        raise ValueError("the resolved Claude executable did not provide an exact version identity")
+    after = executable_file_identity(path, effective_uid, forbidden_roots)
+    if after != before:
+        raise ValueError("the Claude selector or target changed during version observation")
+    return {"file_identity": before, "version": version}
+
+
+def validate_recorded_file_identity(
+    identity: object,
+    selector: str,
+    forbidden_roots: list[str],
+    effective_uid: int,
+) -> None:
+    required_keys = {
+        "requested_selector",
+        "selector_kind",
+        "selector_target",
+        "selector_uid",
+        "selector_mode",
+        "selector_device",
+        "selector_inode",
+        "selector_size",
+        "resolved_path",
+        "resolved_uid",
+        "resolved_mode",
+        "resolved_regular_file",
+        "resolved_owner_executable",
+        "resolved_device",
+        "resolved_inode",
+        "resolved_size",
+        "resolved_sha256",
+        "forbidden_root_containment",
+    }
+    if not isinstance(identity, dict) or set(identity) != required_keys:
+        raise ValueError("the qualification receipt file identity shape is invalid")
+    try:
+        selector_mode = int(str(identity["selector_mode"]), 8)
+        resolved_mode = int(str(identity["resolved_mode"]), 8)
+    except (KeyError, ValueError) as error:
+        raise ValueError("the qualification receipt file identity modes are invalid") from error
+    if (
+        identity["requested_selector"] != selector
+        or identity["selector_kind"] not in {"file", "symlink"}
+        or identity["selector_uid"] != effective_uid
+        or not isinstance(identity["selector_mode"], str)
+        or selector_mode < 0
+        or not all(
+            isinstance(identity[field], int)
+            for field in ("selector_device", "selector_inode", "selector_size")
+        )
+        or not isinstance(identity["resolved_path"], str)
+        or not Path(identity["resolved_path"]).is_absolute()
+        or identity["resolved_uid"] != effective_uid
+        or not isinstance(identity["resolved_mode"], str)
+        or resolved_mode & 0o022
+        or not resolved_mode & 0o100
+        or identity["resolved_regular_file"] is not True
+        or identity["resolved_owner_executable"] is not True
+        or not all(
+            isinstance(identity[field], int)
+            for field in ("resolved_device", "resolved_inode", "resolved_size")
+        )
+        or not isinstance(identity["resolved_sha256"], str)
+        or re.fullmatch(r"[0-9a-f]{64}", identity["resolved_sha256"]) is None
+    ):
+        raise ValueError("the qualification receipt file identity values are invalid")
+    if identity["selector_kind"] == "symlink":
+        if not isinstance(identity["selector_target"], str):
+            raise ValueError("the qualification receipt selector link target is invalid")
+    elif identity["selector_target"] is not None:
+        raise ValueError("the qualification receipt file selector has an impossible link target")
+    expected_containment = [
+        {"root": root, "selector_contained": False, "resolved_contained": False}
+        for root in forbidden_roots
+    ]
+    if identity["forbidden_root_containment"] != expected_containment:
+        raise ValueError("the qualification receipt forbidden-root evidence is invalid")
 
 
 def secure_regular_bytes(path: Path, effective_uid: int, *, modes: set[int]) -> bytes:
@@ -497,6 +607,8 @@ def current_qualification(
         current = json.loads(current_bytes)
     except json.JSONDecodeError as error:
         raise ValueError("the current-selection record is malformed") from error
+    if not isinstance(current, dict):
+        raise ValueError("the current-selection record is malformed")
     expected = {
         "kind": "claude_reviewer_current_selection",
         "schema_version": QUALIFICATION_SCHEMA_VERSION,
@@ -520,6 +632,8 @@ def current_qualification(
         receipt = json.loads(receipt_bytes)
     except json.JSONDecodeError as error:
         raise ValueError("the current qualification receipt is malformed") from error
+    if not isinstance(receipt, dict):
+        raise ValueError("the current qualification receipt is malformed")
     launcher = Path(__file__).resolve(strict=True)
     required = {
         "kind": "claude_reviewer_qualification_receipt",
@@ -531,8 +645,23 @@ def current_qualification(
     }
     if any(receipt.get(key) != value for key, value in required.items()):
         raise ValueError("the qualification receipt does not match the immutable entry contract")
-    if not isinstance(receipt.get("observed_identity"), dict):
-        raise ValueError("the qualification receipt lacks an exact executable identity")
+    forbidden_roots = manifest.get("forbidden_roots")
+    if not isinstance(forbidden_roots, list) or not all(isinstance(root, str) for root in forbidden_roots):
+        raise ValueError("the qualification manifest forbidden roots are invalid")
+    validate_recorded_file_identity(
+        receipt.get("file_identity"),
+        str(manifest.get("claude_selector")),
+        forbidden_roots,
+        effective_uid,
+    )
+    if (
+        not isinstance(receipt.get("version"), str)
+        or not receipt["version"]
+        or len(receipt["version"]) > 1000
+        or receipt.get("authority_semantics")
+        != "capability qualification only; grants zero task or review authority"
+    ):
+        raise ValueError("the qualification receipt lacks an exact qualified executable identity")
     predecessor_sha256 = receipt.get("predecessor_receipt_sha256")
     predecessor_path_value = receipt.get("predecessor_receipt_path")
     if (predecessor_sha256 is None) != (predecessor_path_value is None):
@@ -553,12 +682,26 @@ def current_qualification(
             predecessor = json.loads(predecessor_bytes)
         except json.JSONDecodeError as error:
             raise ValueError("the predecessor qualification receipt is malformed") from error
-        if any(predecessor.get(key) != value for key, value in required.items()):
+        if not isinstance(predecessor, dict):
+            raise ValueError("the predecessor qualification receipt is malformed")
+        validate_recorded_file_identity(
+            predecessor.get("file_identity"),
+            str(manifest.get("claude_selector")),
+            forbidden_roots,
+            effective_uid,
+        )
+        if (
+            any(predecessor.get(key) != value for key, value in required.items())
+            or not isinstance(predecessor.get("version"), str)
+            or not predecessor["version"]
+            or predecessor.get("authority_semantics")
+            != "capability qualification only; grants zero task or review authority"
+        ):
             raise ValueError("the predecessor qualification receipt belongs to another entry contract")
     return current, receipt, current_bytes
 
 
-def observed_identity_digest(identity: dict[str, object]) -> str:
+def file_identity_digest(identity: dict[str, object]) -> str:
     return sha256_bytes(canonical_json_bytes(identity))
 
 
@@ -575,30 +718,26 @@ def qualified_execution(
             raise ValueError("test fixtures require an explicit absolute --claude-bin")
         if launcher.with_name(INSTALLATION_MANIFEST_NAME).exists():
             raise ValueError("an installed production launcher cannot use test executable qualification")
-        identity = executable_identity(Path(selector), effective_uid)
+        qualified = qualified_executable_identity(Path(selector), effective_uid)
+        identity = {**qualified["file_identity"], "version": qualified["version"]}
         identity["qualification"] = "explicit_test_fixture"
         return str(Path(identity["resolved_path"])), identity
     launcher, manifest_path, manifest = load_installed_entry(effective_uid)
     approved_selector = manifest.get("claude_selector")
     if not isinstance(approved_selector, str) or selector not in {None, approved_selector}:
         raise ValueError("--claude-bin does not match the exact activated Claude selector")
-    identity = executable_identity(Path(approved_selector), effective_uid)
     forbidden_roots = list(manifest["forbidden_roots"])
-    selector_location = Path(approved_selector).parent.resolve(strict=True) / Path(approved_selector).name
-    if any(
-        contained(Path(identity["resolved_path"]), Path(value))
-        or contained(selector_location, Path(value))
-        for value in forbidden_roots
-    ):
-        raise ValueError("the resolved Claude executable is inside a forbidden writable root")
     current, receipt, _ = current_qualification(manifest, effective_uid)
-    recorded = receipt["observed_identity"]
-    if recorded != identity:
-        observed_digest = observed_identity_digest(identity)
+    file_identity = executable_file_identity(
+        Path(approved_selector), effective_uid, [Path(value) for value in forbidden_roots]
+    )
+    recorded = receipt["file_identity"]
+    if recorded != file_identity:
+        observed_digest = file_identity_digest(file_identity)
         action = (
             f"{launcher} --qualify-claude-identity "
             f"--expected-current-receipt-sha256 {current['receipt_sha256']} "
-            f"--expected-observed-identity-sha256 {observed_digest}"
+            f"--expected-observed-file-identity-sha256 {observed_digest}"
         )
         raise QualificationRequiredError(
             "the configured Claude selector resolved to a new exact identity",
@@ -606,13 +745,28 @@ def qualified_execution(
                 "entry_contract_id": manifest.get("entry_contract_id"),
                 "installed_launcher_sha256": manifest.get("installed_launcher_sha256"),
                 "current_qualification_receipt_sha256": current["receipt_sha256"],
-                "observed_identity_sha256": observed_digest,
-                "observed_resolved_path": identity["resolved_path"],
-                "observed_resolved_sha256": identity["resolved_sha256"],
-                "observed_version": identity["version"],
+                "observed_file_identity": file_identity,
+                "observed_file_identity_sha256": observed_digest,
+                "observed_resolved_path": file_identity["resolved_path"],
+                "observed_resolved_sha256": file_identity["resolved_sha256"],
                 "next_qualification_action": action,
             },
         )
+    version = version_of(
+        str(file_identity["resolved_path"]),
+        os.environ.copy(),
+        cwd=str(Path(str(file_identity["resolved_path"])).parent),
+    )
+    if version is None:
+        raise ValueError("the qualified Claude executable did not provide its recorded version identity")
+    final_file_identity = executable_file_identity(
+        Path(approved_selector), effective_uid, [Path(value) for value in forbidden_roots]
+    )
+    if final_file_identity != file_identity:
+        raise ValueError("the qualified Claude selector or target changed during version observation")
+    if version != receipt["version"]:
+        raise ValueError("the qualified Claude executable version does not match its receipt")
+    identity = {**file_identity, "version": version}
     identity.update(
         {
             "qualification": "current_qualification_receipt",
@@ -634,7 +788,10 @@ def revalidate_execution_identity(
 ) -> None:
     """Recheck the selected bytes immediately before provider process creation."""
     if execution_identity.get("qualification") == "explicit_test_fixture":
-        observed = executable_identity(Path(str(execution_identity["requested_selector"])), effective_uid)
+        qualified = qualified_executable_identity(
+            Path(str(execution_identity["requested_selector"])), effective_uid
+        )
+        observed = {**qualified["file_identity"], "version": qualified["version"]}
         for key, value in observed.items():
             if execution_identity.get(key) != value:
                 raise ValueError(f"the fixture Claude identity changed before execution at {key}")
@@ -662,7 +819,7 @@ def qualify_claude_identity(
     effective_uid: int,
     *,
     expected_current_receipt_sha256: str,
-    expected_observed_identity_sha256: str,
+    expected_observed_file_identity_sha256: str,
 ) -> int:
     launcher, _, manifest = load_installed_entry(effective_uid)
     lock_path = Path(str(manifest.get("qualification_lock_path", "")))
@@ -672,30 +829,35 @@ def qualify_claude_identity(
     secure_regular_bytes(lock_path, effective_uid, modes={0o600})
     with lock_path.open("r+b") as lock_stream:
         fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
-        current, _, predecessor_current_bytes = current_qualification(manifest, effective_uid)
+        current, current_receipt, predecessor_current_bytes = current_qualification(manifest, effective_uid)
         if current["receipt_sha256"] != expected_current_receipt_sha256:
             raise ValueError("the qualification request names a stale predecessor receipt")
         selector = Path(str(manifest["claude_selector"]))
-        observed = executable_identity(selector, effective_uid)
-        observed_digest = observed_identity_digest(observed)
-        if observed_digest != expected_observed_identity_sha256:
+        forbidden_roots = [Path(value) for value in manifest["forbidden_roots"]]
+        observed = executable_file_identity(selector, effective_uid, forbidden_roots)
+        observed_digest = file_identity_digest(observed)
+        if observed_digest != expected_observed_file_identity_sha256:
             raise ValueError("the qualification request names a stale observed Claude identity")
-        forbidden_roots = list(manifest["forbidden_roots"])
-        selector_location = selector.parent.resolve(strict=True) / selector.name
-        if any(
-            contained(Path(observed["resolved_path"]), Path(value))
-            or contained(selector_location, Path(value))
-            for value in forbidden_roots
-        ):
-            raise ValueError("the resolved Claude executable is inside a forbidden writable root")
-        if executable_identity(selector, effective_uid) != observed:
+        if current_receipt["file_identity"] == observed:
+            raise ValueError("the qualification request is a no-op for the current qualified identity")
+        version = version_of(
+            str(observed["resolved_path"]),
+            os.environ.copy(),
+            cwd=str(Path(str(observed["resolved_path"])).parent),
+        )
+        if version is None:
+            raise ValueError("the resolved Claude executable did not provide an exact version identity")
+        if executable_file_identity(selector, effective_uid, forbidden_roots) != observed:
             raise ValueError("the Claude selector changed during qualification")
+        if executable_file_identity(selector, effective_uid, forbidden_roots) != observed:
+            raise ValueError("the Claude selector changed before qualification receipt creation")
         receipt = {
             "kind": "claude_reviewer_qualification_receipt",
             "schema_version": QUALIFICATION_SCHEMA_VERSION,
             "entry_contract_id": manifest["entry_contract_id"],
             "claude_selector": str(selector),
-            "observed_identity": observed,
+            "file_identity": observed,
+            "version": version,
             "predecessor_receipt_sha256": current["receipt_sha256"],
             "predecessor_receipt_path": current["receipt_path"],
             "producing_launcher_path": str(launcher),
@@ -719,13 +881,16 @@ def qualify_claude_identity(
             "receipt_path": str(receipt_path),
             "receipt_sha256": receipt_sha256,
         }
-        temporary = current_path.with_name(f".{current_path.name}.{uuid.uuid4().hex}.tmp")
-        exclusive_write(temporary, canonical_json_bytes(new_current))
-        os.replace(temporary, current_path)
+        atomic_replace_current_selection(
+            current_path,
+            new_current,
+            predecessor_current_bytes,
+            effective_uid,
+        )
         validated_current, validated_receipt, _ = current_qualification(manifest, effective_uid)
         if validated_current != new_current or validated_receipt != receipt:
             raise ValueError("the qualification compare-and-swap did not verify")
-    print(json.dumps({"qualification_receipt_path": str(receipt_path), "qualification_receipt_sha256": receipt_sha256, "observed_identity": observed, "entry_contract_id": manifest["entry_contract_id"]}, sort_keys=True))
+    print(json.dumps({"qualification_receipt_path": str(receipt_path), "qualification_receipt_sha256": receipt_sha256, "file_identity": observed, "version": version, "entry_contract_id": manifest["entry_contract_id"]}, sort_keys=True))
     return 0
 
 
@@ -928,6 +1093,50 @@ def exclusive_write(path: Path, payload: bytes) -> None:
         except OSError:
             pass
         raise
+
+
+def atomic_replace_current_selection(
+    path: Path,
+    record: dict[str, Any],
+    expected_bytes: bytes,
+    effective_uid: int,
+) -> None:
+    """Replace singular current state using an exact private compare-and-swap file."""
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    created = False
+    try:
+        exclusive_write(temporary, canonical_json_bytes(record))
+        created = True
+        temporary_bytes = secure_regular_bytes(temporary, effective_uid, modes={0o600})
+        if temporary_bytes != canonical_json_bytes(record):
+            raise ValueError(f"the qualification temporary state did not verify: {temporary}")
+        if secure_regular_bytes(path, effective_uid, modes={0o600}) != expected_bytes:
+            raise ValueError("the current qualification changed before compare-and-swap")
+        os.replace(temporary, path)
+        created = False
+        directory_descriptor = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        if created:
+            try:
+                metadata = temporary.lstat()
+                if (
+                    temporary.parent == path.parent
+                    and not temporary.is_symlink()
+                    and stat.S_ISREG(metadata.st_mode)
+                    and metadata.st_uid == effective_uid
+                    and stat.S_IMODE(metadata.st_mode) == 0o600
+                ):
+                    temporary.unlink()
+                else:
+                    raise RuntimeError(
+                        f"qualification temporary cleanup identity is ambiguous; residue preserved: {temporary}"
+                    )
+            except FileNotFoundError:
+                pass
 
 
 def replace_live_state(path: Path, record: dict[str, Any]) -> None:
@@ -2392,7 +2601,7 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     operation.add_argument("--review-config", type=Path)
     operation.add_argument("--qualify-claude-identity", action="store_true")
     parser.add_argument("--expected-current-receipt-sha256")
-    parser.add_argument("--expected-observed-identity-sha256")
+    parser.add_argument("--expected-observed-file-identity-sha256")
     operation.add_argument("--auth-preflight-fixture", action="store_true", help=argparse.SUPPRESS)
     operation.add_argument("--review-config-fixture", type=Path, help=argparse.SUPPRESS)
     operation.add_argument("--permission-hook", type=Path)
@@ -2422,7 +2631,7 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
         parser.error("--force-authorized requires --terminate")
     qualification_modifiers = (
         args.expected_current_receipt_sha256,
-        args.expected_observed_identity_sha256,
+        args.expected_observed_file_identity_sha256,
     )
     if args.qualify_claude_identity and not all(qualification_modifiers):
         parser.error("--qualify-claude-identity requires both exact expected identity digests")
@@ -2464,7 +2673,7 @@ def main(argv: list[str] | None = None) -> int:
             return qualify_claude_identity(
                 uid,
                 expected_current_receipt_sha256=args.expected_current_receipt_sha256,
-                expected_observed_identity_sha256=args.expected_observed_identity_sha256,
+                expected_observed_file_identity_sha256=args.expected_observed_file_identity_sha256,
             )
         except (OSError, RuntimeError, ValueError, json.JSONDecodeError) as error:
             emit_diagnostics(

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -793,15 +793,18 @@ def revalidate_execution_identity(
 ) -> None:
     """Recheck the selected bytes immediately before provider process creation."""
     if execution_identity.get("qualification") == "explicit_test_fixture":
-        qualified = qualified_executable_identity(
-            Path(str(execution_identity["requested_selector"])), effective_uid
-        )
-        observed = {**qualified["file_identity"], "version": qualified["version"]}
+        selector = Path(str(execution_identity["requested_selector"]))
+        observed = executable_file_identity(selector, effective_uid)
         for key, value in observed.items():
             if execution_identity.get(key) != value:
                 raise ValueError(f"the fixture Claude identity changed before execution at {key}")
         if observed["resolved_path"] != executable:
             raise ValueError("the fixture Claude canonical path changed before execution")
+        version = version_of(executable, os.environ.copy(), cwd=str(Path(executable).parent))
+        if version != execution_identity.get("version"):
+            raise ValueError("the fixture Claude version changed before execution")
+        if executable_file_identity(selector, effective_uid) != observed:
+            raise ValueError("the fixture Claude identity changed during version observation")
         return
     observed_executable, observed_identity = qualified_execution(None, effective_uid)
     if observed_executable != executable:
@@ -2450,7 +2453,7 @@ def run_governed_review(
             elif changes:
                 classification = "reviewer_side_effect_failure"
                 retryable = False
-            claude_version = version_of(executable, environment, cwd=str(attempt_scratch.path))
+            claude_version = execution_identity.get("version")
             scratch_record = attempt_scratch.record()
             try:
                 attempt_scratch.cleanup()

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -734,10 +734,15 @@ def qualified_execution(
     recorded = receipt["file_identity"]
     if recorded != file_identity:
         observed_digest = file_identity_digest(file_identity)
-        action = (
-            f"{launcher} --qualify-claude-identity "
-            f"--expected-current-receipt-sha256 {current['receipt_sha256']} "
-            f"--expected-observed-file-identity-sha256 {observed_digest}"
+        action = shlex.join(
+            [
+                str(launcher),
+                "--qualify-claude-identity",
+                "--expected-current-receipt-sha256",
+                current["receipt_sha256"],
+                "--expected-observed-file-identity-sha256",
+                observed_digest,
+            ]
         )
         raise QualificationRequiredError(
             "the configured Claude selector resolved to a new exact identity",
@@ -1120,6 +1125,7 @@ def atomic_replace_current_selection(
         finally:
             os.close(directory_descriptor)
     finally:
+        original_error = sys.exc_info()[1]
         if created:
             try:
                 metadata = temporary.lstat()
@@ -1132,9 +1138,12 @@ def atomic_replace_current_selection(
                 ):
                     temporary.unlink()
                 else:
-                    raise RuntimeError(
+                    cleanup_error = RuntimeError(
                         f"qualification temporary cleanup identity is ambiguous; residue preserved: {temporary}"
                     )
+                    if original_error is not None:
+                        raise cleanup_error from original_error
+                    raise cleanup_error
             except FileNotFoundError:
                 pass
 
@@ -2811,7 +2820,7 @@ def main(argv: list[str] | None = None) -> int:
     runtime = {
         "claude_executable": executable,
         "reviewer_execution_identity": execution_identity,
-        "claude_version": version_of(executable, child_environment, cwd=execution_cwd) if executable else None,
+        "claude_version": execution_identity.get("version") if executable else None,
         "argv": redacted_argv(command) if command else None,
         "requested_argv": redacted_argv([executable, "-p", *args.claude_args]) if executable else None,
         "effective_uid": uid,

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -875,6 +875,7 @@ def qualify_claude_identity(
         receipt_path = Path(str(manifest["qualification_receipts_directory"])) / f"{receipt_sha256}.json"
         exclusive_write(receipt_path, receipt_bytes)
         os.chmod(receipt_path, 0o400)
+        fsync_directory(receipt_path.parent)
         current_path = Path(str(manifest["current_selection_path"]))
         if secure_regular_bytes(current_path, effective_uid, modes={0o600}) != predecessor_current_bytes:
             raise ValueError("the current qualification changed before compare-and-swap")
@@ -1098,6 +1099,14 @@ def exclusive_write(path: Path, payload: bytes) -> None:
         except OSError:
             pass
         raise
+
+
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
 
 
 def atomic_replace_current_selection(
@@ -2208,7 +2217,10 @@ def run_governed_review(
                         "contract_identity": contract_identity,
                         "failure_classification": "reviewer_identity_changed_before_execution",
                         "candidate_verdict": "not_produced",
-                        "substantive_review_started": False,
+                        "attempts": attempt_summaries,
+                        "attempt_number": attempt_number,
+                        "substantive_review_started": bool(attempt_summaries),
+                        "automated_retry_attempted": attempt_number > 1,
                         "no_delta_postflight": {"passed": not changes, "changed_paths": changes},
                         "attempt_scratch": {**scratch_record, "cleanup": {"passed": True}},
                         "error": bounded_redacted(str(error)),

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -10,6 +10,7 @@ import os
 from pathlib import Path
 import stat
 import subprocess
+import sys
 import tempfile
 
 
@@ -17,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SOURCE_LAUNCHER = ROOT / "scripts" / "claude-review"
 RULE_TEMPLATE = ROOT / ".codex" / "rule-templates" / "claude-review.rules"
 INSTALLATION_SCHEMA_VERSION = 2
-QUALIFICATION_SCHEMA_VERSION = 1
+QUALIFICATION_SCHEMA_VERSION = 2
 ENTRY_CONTRACT_SCHEMA_VERSION = 1
 
 
@@ -48,7 +49,14 @@ def git(*arguments: str) -> str:
     return result.stdout.strip()
 
 
-def exact_executable_identity(selector: Path) -> dict[str, object]:
+class QualificationRequiredError(ValueError):
+    """Signal selector drift without mutating valid qualification state."""
+
+
+def exact_executable_file_identity(
+    selector: Path, forbidden_roots: list[Path] | None = None
+) -> dict[str, object]:
+    """Observe exact selector and target bytes without executing the target."""
     if not selector.is_absolute():
         raise ValueError("--claude-bin must be an exact absolute path")
     selector_metadata = selector.lstat()
@@ -59,31 +67,37 @@ def exact_executable_identity(selector: Path) -> dict[str, object]:
     mode = stat.S_IMODE(metadata.st_mode)
     if not stat.S_ISREG(metadata.st_mode) or mode & 0o022 or not mode & 0o100:
         raise ValueError("Claude target must be owner-executable and not group/world-writable")
-    version = subprocess.run(
-        [str(resolved), "--version"],
-        check=False,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        timeout=5,
-    )
-    if version.returncode != 0 or not (version.stdout or version.stderr).strip():
-        raise ValueError("Claude target did not provide an exact version identity")
+    roots = forbidden_roots or []
+    selector_location = selector.parent.resolve(strict=True) / selector.name
+    containment = [
+        {
+            "root": str(root),
+            "selector_contained": contained(selector_location, root),
+            "resolved_contained": contained(resolved, root),
+        }
+        for root in roots
+    ]
+    if any(item["selector_contained"] or item["resolved_contained"] for item in containment):
+        raise ValueError("Claude selector and target must be outside every forbidden writable root")
     identity = {
         "requested_selector": str(selector),
         "selector_kind": "symlink" if stat.S_ISLNK(selector_metadata.st_mode) else "file",
         "selector_target": os.readlink(selector) if stat.S_ISLNK(selector_metadata.st_mode) else None,
         "selector_uid": selector_metadata.st_uid,
         "selector_mode": oct(stat.S_IMODE(selector_metadata.st_mode)),
+        "selector_device": selector_metadata.st_dev,
+        "selector_inode": selector_metadata.st_ino,
+        "selector_size": selector_metadata.st_size,
         "resolved_path": str(resolved),
         "resolved_uid": metadata.st_uid,
         "resolved_mode": oct(mode),
+        "resolved_regular_file": stat.S_ISREG(metadata.st_mode),
+        "resolved_owner_executable": bool(mode & 0o100),
         "resolved_device": metadata.st_dev,
         "resolved_inode": metadata.st_ino,
         "resolved_size": metadata.st_size,
         "resolved_sha256": digest(resolved.read_bytes()),
-        "version": (version.stdout or version.stderr).strip()[:1000],
+        "forbidden_root_containment": containment,
     }
     final_metadata = resolved.stat()
     if (
@@ -102,6 +116,85 @@ def exact_executable_identity(selector: Path) -> dict[str, object]:
     ):
         raise ValueError("Claude selector or target changed during identity observation")
     return identity
+
+
+def qualified_executable_identity(
+    selector: Path, forbidden_roots: list[Path] | None = None
+) -> dict[str, object]:
+    before = exact_executable_file_identity(selector, forbidden_roots)
+    version = subprocess.run(
+        [str(before["resolved_path"]), "--version"],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=5,
+    )
+    exact_version = (version.stdout or version.stderr).strip()[:1000]
+    if version.returncode != 0 or not exact_version:
+        raise ValueError("Claude target did not provide an exact version identity")
+    after = exact_executable_file_identity(selector, forbidden_roots)
+    if after != before:
+        raise ValueError("Claude selector or target changed during version observation")
+    return {"file_identity": before, "version": exact_version}
+
+
+def validate_recorded_file_identity(
+    identity: object, selector: str, forbidden_roots: list[str]
+) -> None:
+    required_keys = {
+        "requested_selector", "selector_kind", "selector_target", "selector_uid",
+        "selector_mode", "selector_device", "selector_inode", "selector_size",
+        "resolved_path", "resolved_uid", "resolved_mode", "resolved_regular_file",
+        "resolved_owner_executable", "resolved_device", "resolved_inode",
+        "resolved_size", "resolved_sha256", "forbidden_root_containment",
+    }
+    if not isinstance(identity, dict) or set(identity) != required_keys:
+        raise ValueError("existing qualification receipt file identity shape is invalid")
+    try:
+        selector_mode = int(str(identity["selector_mode"]), 8)
+        resolved_mode = int(str(identity["resolved_mode"]), 8)
+    except (KeyError, ValueError) as error:
+        raise ValueError("existing qualification receipt file identity modes are invalid") from error
+    if (
+        identity["requested_selector"] != selector
+        or identity["selector_kind"] not in {"file", "symlink"}
+        or identity["selector_uid"] != os.geteuid()
+        or not isinstance(identity["selector_mode"], str)
+        or selector_mode < 0
+        or not all(
+            isinstance(identity[field], int)
+            for field in ("selector_device", "selector_inode", "selector_size")
+        )
+        or not isinstance(identity["resolved_path"], str)
+        or not Path(identity["resolved_path"]).is_absolute()
+        or identity["resolved_uid"] != os.geteuid()
+        or not isinstance(identity["resolved_mode"], str)
+        or resolved_mode & 0o022
+        or not resolved_mode & 0o100
+        or identity["resolved_regular_file"] is not True
+        or identity["resolved_owner_executable"] is not True
+        or not all(
+            isinstance(identity[field], int)
+            for field in ("resolved_device", "resolved_inode", "resolved_size")
+        )
+        or not isinstance(identity["resolved_sha256"], str)
+        or len(identity["resolved_sha256"]) != 64
+        or any(character not in "0123456789abcdef" for character in identity["resolved_sha256"])
+    ):
+        raise ValueError("existing qualification receipt file identity values are invalid")
+    if identity["selector_kind"] == "symlink":
+        if not isinstance(identity["selector_target"], str):
+            raise ValueError("existing qualification receipt selector link target is invalid")
+    elif identity["selector_target"] is not None:
+        raise ValueError("existing qualification receipt file selector has an impossible link target")
+    expected_containment = [
+        {"root": root, "selector_contained": False, "resolved_contained": False}
+        for root in forbidden_roots
+    ]
+    if identity["forbidden_root_containment"] != expected_containment:
+        raise ValueError("existing qualification receipt forbidden-root evidence is invalid")
 
 
 def contained(path: Path, root: Path) -> bool:
@@ -129,7 +222,15 @@ def exclusive_or_identical(path: Path, payload: bytes, mode: int) -> str:
     try:
         descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
     except FileExistsError:
-        if path.is_symlink() or path.read_bytes() != payload:
+        metadata = path.lstat()
+        if (
+            path.is_symlink()
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) != mode
+            or path.resolve(strict=True) != path
+            or path.read_bytes() != payload
+        ):
             raise ValueError(f"existing installed object is not byte-identical: {path}")
         return "existing_identical"
     with os.fdopen(descriptor, "wb") as stream:
@@ -138,6 +239,136 @@ def exclusive_or_identical(path: Path, payload: bytes, mode: int) -> str:
         os.fsync(stream.fileno())
     os.chmod(path, mode)
     return "created"
+
+
+def secure_private_directory(path: Path) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"state directory is not exact private operator-controlled state: {path}")
+
+
+def secure_regular_bytes(path: Path, *, mode: int) -> bytes:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) != mode
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"state object is not an exact private regular file: {path}")
+    return path.read_bytes()
+
+
+def validated_existing_qualification(
+    manifest: dict[str, object],
+) -> tuple[dict[str, object], dict[str, object], bytes]:
+    """Apply the launcher's security invariants to existing singular state."""
+    qualification_directory = Path(str(manifest["qualification_directory"]))
+    receipts_directory = Path(str(manifest["qualification_receipts_directory"]))
+    current_path = Path(str(manifest["current_selection_path"]))
+    secure_private_directory(qualification_directory)
+    secure_private_directory(receipts_directory)
+    if receipts_directory.parent != qualification_directory or receipts_directory.name != "receipts":
+        raise ValueError("qualification receipts escaped the exact state directory")
+    if current_path.parent != qualification_directory or current_path.name != "current-selection.json":
+        raise ValueError("current selection escaped the exact state directory")
+    current_bytes = secure_regular_bytes(current_path, mode=0o600)
+    try:
+        current = json.loads(current_bytes)
+    except json.JSONDecodeError as error:
+        raise ValueError("existing current-selection record is malformed") from error
+    expected_current = {
+        "kind": "claude_reviewer_current_selection",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest["entry_contract_id"],
+        "claude_selector": manifest["claude_selector"],
+    }
+    if not isinstance(current, dict) or any(
+        current.get(key) != value for key, value in expected_current.items()
+    ):
+        raise ValueError("existing current-selection record does not match the entry contract")
+    receipt_sha256 = current.get("receipt_sha256")
+    receipt_path = Path(str(current.get("receipt_path", "")))
+    if (
+        not isinstance(receipt_sha256, str)
+        or len(receipt_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in receipt_sha256)
+        or receipt_path.parent != receipts_directory
+        or receipt_path.name != f"{receipt_sha256}.json"
+    ):
+        raise ValueError("existing current qualification receipt identity is invalid")
+    receipt_bytes = secure_regular_bytes(receipt_path, mode=0o400)
+    if digest(receipt_bytes) != receipt_sha256:
+        raise ValueError("existing current qualification receipt digest is invalid")
+    try:
+        receipt = json.loads(receipt_bytes)
+    except json.JSONDecodeError as error:
+        raise ValueError("existing current qualification receipt is malformed") from error
+    if not isinstance(receipt, dict):
+        raise ValueError("existing current qualification receipt is malformed")
+    required_receipt = {
+        "kind": "claude_reviewer_qualification_receipt",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest["entry_contract_id"],
+        "claude_selector": manifest["claude_selector"],
+        "producing_launcher_path": manifest["installed_launcher_path"],
+        "producing_launcher_sha256": manifest["installed_launcher_sha256"],
+        "authority_semantics": "capability qualification only; grants zero task or review authority",
+    }
+    forbidden_roots = manifest.get("forbidden_roots")
+    if not isinstance(forbidden_roots, list) or not all(isinstance(root, str) for root in forbidden_roots):
+        raise ValueError("existing qualification manifest forbidden roots are invalid")
+    validate_recorded_file_identity(
+        receipt.get("file_identity"), str(manifest["claude_selector"]), forbidden_roots
+    )
+    if (
+        any(receipt.get(key) != value for key, value in required_receipt.items())
+        or not isinstance(receipt.get("version"), str)
+        or not receipt["version"]
+        or len(receipt["version"]) > 1000
+    ):
+        raise ValueError("existing qualification receipt does not match the entry contract")
+    predecessor_sha256 = receipt.get("predecessor_receipt_sha256")
+    predecessor_path_value = receipt.get("predecessor_receipt_path")
+    if (predecessor_sha256 is None) != (predecessor_path_value is None):
+        raise ValueError("existing qualification receipt has ambiguous predecessor lineage")
+    if predecessor_sha256 is not None:
+        predecessor_path = Path(str(predecessor_path_value))
+        if (
+            not isinstance(predecessor_sha256, str)
+            or len(predecessor_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in predecessor_sha256)
+            or predecessor_sha256 == receipt_sha256
+            or predecessor_path.parent != receipts_directory
+            or predecessor_path.name != f"{predecessor_sha256}.json"
+        ):
+            raise ValueError("existing qualification receipt has invalid predecessor lineage")
+        predecessor_bytes = secure_regular_bytes(predecessor_path, mode=0o400)
+        if digest(predecessor_bytes) != predecessor_sha256:
+            raise ValueError("existing qualification predecessor digest is invalid")
+        try:
+            predecessor = json.loads(predecessor_bytes)
+        except json.JSONDecodeError as error:
+            raise ValueError("existing qualification predecessor is malformed") from error
+        if not isinstance(predecessor, dict):
+            raise ValueError("existing qualification predecessor is malformed")
+        validate_recorded_file_identity(
+            predecessor.get("file_identity"), str(manifest["claude_selector"]), forbidden_roots
+        )
+        if (
+            any(predecessor.get(key) != value for key, value in required_receipt.items())
+            or not isinstance(predecessor.get("version"), str)
+            or not predecessor["version"]
+        ):
+            raise ValueError("existing qualification predecessor does not match the entry contract")
+    return current, receipt, current_bytes
 
 
 def replace_expected(path: Path, payload: bytes, expected_sha256: str | None) -> dict[str, object]:
@@ -227,11 +458,7 @@ def main() -> int:
         or auth_diagnostics_directory.resolve(strict=True) != auth_diagnostics_directory
     ):
         raise ValueError("auth diagnostics directory is not exact operator-controlled state")
-    claude_identity = exact_executable_identity(args.claude_bin)
-    selector_location = args.claude_bin.parent.resolve(strict=True) / args.claude_bin.name
-    for root in forbidden:
-        if contained(Path(claude_identity["resolved_path"]), root) or contained(selector_location, root):
-            raise ValueError("Claude selector and target must be outside every forbidden writable root")
+    initial_file_identity = exact_executable_file_identity(args.claude_bin, forbidden)
     immutable_contract = {
         "entry_contract_schema_version": ENTRY_CONTRACT_SCHEMA_VERSION,
         "installation_schema_version": INSTALLATION_SCHEMA_VERSION,
@@ -297,6 +524,47 @@ def main() -> int:
     manifest_path = version_directory / "claude-review-installation.json"
     manifest_bytes = canonical(manifest)
     manifest_result = exclusive_or_identical(manifest_path, manifest_bytes, 0o400)
+    exclusive_or_identical(qualification_lock, b"claude-review qualification lock\n", 0o600)
+    if current_selection.exists() or current_selection.is_symlink():
+        current_record, current_receipt, _ = validated_existing_qualification(manifest)
+        observed_file_identity = exact_executable_file_identity(args.claude_bin, forbidden)
+        if current_receipt["file_identity"] != observed_file_identity:
+            raise QualificationRequiredError(
+                "qualification required: the configured Claude selector no longer matches the valid current receipt"
+            )
+    else:
+        if any(receipts_directory.iterdir()):
+            raise ValueError("qualification receipts exist without singular current-selection state")
+        qualified_identity = qualified_executable_identity(args.claude_bin, forbidden)
+        if qualified_identity["file_identity"] != initial_file_identity:
+            raise ValueError("Claude selector changed before initial qualification state creation")
+        initial_receipt = {
+            "kind": "claude_reviewer_qualification_receipt",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "entry_contract_id": contract_id,
+            "claude_selector": str(args.claude_bin),
+            "file_identity": qualified_identity["file_identity"],
+            "version": qualified_identity["version"],
+            "predecessor_receipt_sha256": None,
+            "predecessor_receipt_path": None,
+            "producing_launcher_path": str(installed_launcher),
+            "producing_launcher_sha256": launcher_sha256,
+            "qualification_event": "initial_installation",
+            "authority_semantics": "capability qualification only; grants zero task or review authority",
+        }
+        initial_receipt_bytes = canonical(initial_receipt)
+        initial_receipt_sha256 = digest(initial_receipt_bytes)
+        initial_receipt_path = receipts_directory / f"{initial_receipt_sha256}.json"
+        exclusive_or_identical(initial_receipt_path, initial_receipt_bytes, 0o400)
+        current_record = {
+            "kind": "claude_reviewer_current_selection",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "entry_contract_id": contract_id,
+            "claude_selector": str(args.claude_bin),
+            "receipt_path": str(initial_receipt_path),
+            "receipt_sha256": initial_receipt_sha256,
+        }
+        exclusive_or_identical(current_selection, canonical(current_record), 0o600)
     source_provenance = {
         "kind": "claude_review_source_provenance",
         "schema_version": 1,
@@ -311,38 +579,6 @@ def main() -> int:
     }
     provenance_path = version_directory / f"source-provenance-{commit}.json"
     provenance_result = exclusive_or_identical(provenance_path, canonical(source_provenance), 0o400)
-    exclusive_or_identical(qualification_lock, b"claude-review qualification lock\n", 0o600)
-    initial_receipt = {
-        "kind": "claude_reviewer_qualification_receipt",
-        "schema_version": QUALIFICATION_SCHEMA_VERSION,
-        "entry_contract_id": contract_id,
-        "claude_selector": str(args.claude_bin),
-        "observed_identity": claude_identity,
-        "predecessor_receipt_sha256": None,
-        "predecessor_receipt_path": None,
-        "producing_launcher_path": str(installed_launcher),
-        "producing_launcher_sha256": launcher_sha256,
-        "qualification_event": "initial_installation",
-        "authority_semantics": "capability qualification only; grants zero task or review authority",
-    }
-    initial_receipt_bytes = canonical(initial_receipt)
-    initial_receipt_sha256 = digest(initial_receipt_bytes)
-    initial_receipt_path = receipts_directory / f"{initial_receipt_sha256}.json"
-    if current_selection.exists() or current_selection.is_symlink():
-        current_record = json.loads(current_selection.read_text(encoding="utf-8"))
-        if current_record.get("receipt_sha256") != initial_receipt_sha256:
-            raise ValueError("existing current qualification does not match the installation identity")
-    else:
-        exclusive_or_identical(initial_receipt_path, initial_receipt_bytes, 0o400)
-        current_record = {
-            "kind": "claude_reviewer_current_selection",
-            "schema_version": QUALIFICATION_SCHEMA_VERSION,
-            "entry_contract_id": contract_id,
-            "claude_selector": str(args.claude_bin),
-            "receipt_path": str(initial_receipt_path),
-            "receipt_sha256": initial_receipt_sha256,
-        }
-        exclusive_or_identical(current_selection, canonical(current_record), 0o600)
     rule_result = replace_expected(args.active_rule, rendered_rule, args.expected_existing_rule_sha256)
     receipt = {
         "kind": "claude_review_activation_receipt",
@@ -366,4 +602,18 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except QualificationRequiredError as error:
+        print(
+            json.dumps(
+                {
+                    "kind": "claude_review_installation",
+                    "failure_classification": "reviewer_identity_qualification_required",
+                    "error": str(error),
+                },
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(70) from None

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -590,6 +590,7 @@ def main() -> int:
             "receipt_sha256": initial_receipt_sha256,
         }
         exclusive_or_identical(current_selection, canonical(current_record), 0o600)
+        fsync_directory(qualification_directory)
     source_provenance = {
         "kind": "claude_review_source_provenance",
         "schema_version": 1,

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -265,6 +265,14 @@ def exclusive_or_identical(path: Path, payload: bytes, mode: int) -> str:
     return "created"
 
 
+def fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def secure_private_directory(path: Path) -> None:
     metadata = path.lstat()
     if (
@@ -398,11 +406,18 @@ def validated_existing_qualification(
 def replace_expected(path: Path, payload: bytes, expected_sha256: str | None) -> dict[str, object]:
     prior = None
     if path.exists() or path.is_symlink():
-        if path.is_symlink():
-            raise ValueError("active rule must not be a symbolic link")
+        metadata = path.lstat()
+        if path.is_symlink() or not stat.S_ISREG(metadata.st_mode):
+            raise ValueError("active rule must be a non-symlink regular file")
         prior_bytes = path.read_bytes()
         prior = {"size": len(prior_bytes), "sha256": digest(prior_bytes)}
         if prior_bytes == payload:
+            if (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) & 0o022
+                or path.resolve(strict=True) != path
+            ):
+                raise ValueError("existing identical active rule is not a safe operator-owned file")
             return {"result": "existing_identical", "prior": prior}
         if expected_sha256 is None or prior["sha256"] != expected_sha256:
             raise ValueError("existing active rule does not match --expected-existing-rule-sha256")
@@ -565,6 +580,7 @@ def main() -> int:
         initial_receipt_sha256 = digest(initial_receipt_bytes)
         initial_receipt_path = receipts_directory / f"{initial_receipt_sha256}.json"
         exclusive_or_identical(initial_receipt_path, initial_receipt_bytes, 0o400)
+        fsync_directory(receipts_directory)
         current_record = {
             "kind": "claude_reviewer_current_selection",
             "schema_version": QUALIFICATION_SCHEMA_VERSION,

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -16,6 +16,9 @@ import tempfile
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_LAUNCHER = ROOT / "scripts" / "claude-review"
 RULE_TEMPLATE = ROOT / ".codex" / "rule-templates" / "claude-review.rules"
+INSTALLATION_SCHEMA_VERSION = 2
+QUALIFICATION_SCHEMA_VERSION = 1
+ENTRY_CONTRACT_SCHEMA_VERSION = 1
 
 
 def digest(payload: bytes) -> str:
@@ -24,6 +27,11 @@ def digest(payload: bytes) -> str:
 
 def canonical(value: object) -> bytes:
     return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def entry_contract_identity(contract: dict[str, object]) -> str:
+    """Return the content identity of execution-relevant immutable inputs."""
+    return f"sha256:{digest(canonical(contract))}"
 
 
 def git(*arguments: str) -> str:
@@ -62,7 +70,7 @@ def exact_executable_identity(selector: Path) -> dict[str, object]:
     )
     if version.returncode != 0 or not (version.stdout or version.stderr).strip():
         raise ValueError("Claude target did not provide an exact version identity")
-    return {
+    identity = {
         "requested_selector": str(selector),
         "selector_kind": "symlink" if stat.S_ISLNK(selector_metadata.st_mode) else "file",
         "selector_target": os.readlink(selector) if stat.S_ISLNK(selector_metadata.st_mode) else None,
@@ -77,6 +85,23 @@ def exact_executable_identity(selector: Path) -> dict[str, object]:
         "resolved_sha256": digest(resolved.read_bytes()),
         "version": (version.stdout or version.stderr).strip()[:1000],
     }
+    final_metadata = resolved.stat()
+    if (
+        final_metadata.st_dev != metadata.st_dev
+        or final_metadata.st_ino != metadata.st_ino
+        or final_metadata.st_size != metadata.st_size
+        or digest(resolved.read_bytes()) != identity["resolved_sha256"]
+        or any(
+            getattr(selector.lstat(), field) != getattr(selector_metadata, field)
+            for field in ("st_dev", "st_ino", "st_uid", "st_mode", "st_size")
+        )
+        or (
+            stat.S_ISLNK(selector_metadata.st_mode)
+            and os.readlink(selector) != identity["selector_target"]
+        )
+    ):
+        raise ValueError("Claude selector or target changed during identity observation")
+    return identity
 
 
 def contained(path: Path, root: Path) -> bool:
@@ -158,6 +183,11 @@ def parse_arguments() -> argparse.Namespace:
         default=Path.home() / ".codex" / "rules" / "claude-review.rules",
     )
     parser.add_argument("--activation-receipt", required=True, type=Path)
+    parser.add_argument(
+        "--qualification-root",
+        type=Path,
+        default=Path.home() / ".local" / "state" / "ai-workflow-playbook" / "claude-review",
+    )
     parser.add_argument("--expected-existing-rule-sha256")
     parser.add_argument("--forbidden-root", action="append", default=[], type=Path)
     return parser.parse_args()
@@ -170,6 +200,7 @@ def main() -> int:
     args.activation_receipt = (
         args.activation_receipt.parent.resolve(strict=False) / args.activation_receipt.name
     )
+    args.qualification_root = args.qualification_root.resolve(strict=False)
     if args.activation_receipt.exists() or args.activation_receipt.is_symlink():
         raise ValueError("activation receipt destination must be absent")
     status = git("status", "--porcelain=v1", "--untracked-files=all")
@@ -184,6 +215,7 @@ def main() -> int:
     validate_destination(args.install_root, forbidden)
     validate_destination(args.active_rule, forbidden)
     validate_destination(args.activation_receipt, forbidden)
+    validate_destination(args.qualification_root, forbidden)
     auth_diagnostics_directory = args.activation_receipt.parent
     auth_diagnostics_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     auth_diagnostics_metadata = auth_diagnostics_directory.lstat()
@@ -200,7 +232,20 @@ def main() -> int:
     for root in forbidden:
         if contained(Path(claude_identity["resolved_path"]), root) or contained(selector_location, root):
             raise ValueError("Claude selector and target must be outside every forbidden writable root")
-    version_directory = args.install_root / f"{commit}-{launcher_sha256[:16]}"
+    immutable_contract = {
+        "entry_contract_schema_version": ENTRY_CONTRACT_SCHEMA_VERSION,
+        "installation_schema_version": INSTALLATION_SCHEMA_VERSION,
+        "qualification_schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "launcher_sha256": launcher_sha256,
+        "rule_template_sha256": source_rule_sha256,
+        "claude_selector": str(args.claude_bin),
+        "active_rule_path": str(args.active_rule),
+        "forbidden_roots": [str(root) for root in forbidden],
+        "auth_diagnostics_directory": str(auth_diagnostics_directory),
+        "qualification_root": str(args.qualification_root),
+    }
+    contract_id = entry_contract_identity(immutable_contract)
+    version_directory = args.install_root / f"entry-{contract_id.removeprefix('sha256:')}"
     version_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
     version_metadata = version_directory.lstat()
     if (
@@ -209,14 +254,53 @@ def main() -> int:
         or version_metadata.st_uid != os.geteuid()
         or stat.S_IMODE(version_metadata.st_mode) & 0o022
     ):
-        raise ValueError("versioned installation directory is not operator-controlled")
+        raise ValueError("content-addressed entry directory is not operator-controlled")
     installed_launcher = version_directory / "claude-review"
     rendered_rule = RULE_TEMPLATE.read_text(encoding="utf-8").replace(
         "__CLAUDE_REVIEW_LAUNCHER__", str(installed_launcher)
     ).encode("utf-8")
     active_rule_sha256 = digest(rendered_rule)
+    qualification_directory = args.qualification_root / contract_id.removeprefix("sha256:")
+    receipts_directory = qualification_directory / "receipts"
+    qualification_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    receipts_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    for directory in (qualification_directory, receipts_directory):
+        metadata = directory.lstat()
+        if (
+            directory.is_symlink()
+            or not stat.S_ISDIR(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+            or directory.resolve(strict=True) != directory
+        ):
+            raise ValueError("qualification state directory is not exact private operator-controlled state")
+    current_selection = qualification_directory / "current-selection.json"
+    qualification_lock = qualification_directory / "qualification.lock"
     manifest = {
+        "schema_version": INSTALLATION_SCHEMA_VERSION,
+        "entry_contract_id": contract_id,
+        "entry_contract": immutable_contract,
+        "installed_launcher_path": str(installed_launcher),
+        "installed_launcher_sha256": launcher_sha256,
+        "active_rule_path": str(args.active_rule),
+        "active_rule_sha256": active_rule_sha256,
+        "claude_selector": str(args.claude_bin),
+        "forbidden_roots": [str(root) for root in forbidden],
+        "auth_diagnostics_directory": str(auth_diagnostics_directory),
+        "qualification_schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "qualification_directory": str(qualification_directory),
+        "qualification_receipts_directory": str(receipts_directory),
+        "current_selection_path": str(current_selection),
+        "qualification_lock_path": str(qualification_lock),
+    }
+    launcher_result = exclusive_or_identical(installed_launcher, launcher_bytes, 0o500)
+    manifest_path = version_directory / "claude-review-installation.json"
+    manifest_bytes = canonical(manifest)
+    manifest_result = exclusive_or_identical(manifest_path, manifest_bytes, 0o400)
+    source_provenance = {
+        "kind": "claude_review_source_provenance",
         "schema_version": 1,
+        "entry_contract_id": contract_id,
         "source_repository": str(ROOT),
         "source_remote": source_remote,
         "source_commit": commit,
@@ -224,28 +308,56 @@ def main() -> int:
         "source_launcher_sha256": launcher_sha256,
         "source_rule_template_path": str(RULE_TEMPLATE),
         "source_rule_template_sha256": source_rule_sha256,
-        "installed_launcher_path": str(installed_launcher),
-        "installed_launcher_sha256": launcher_sha256,
-        "active_rule_path": str(args.active_rule),
-        "active_rule_sha256": active_rule_sha256,
-        "claude_selector": str(args.claude_bin),
-        "claude_identity": claude_identity,
-        "forbidden_roots": [str(root) for root in forbidden],
-        "auth_diagnostics_directory": str(auth_diagnostics_directory),
     }
-    launcher_result = exclusive_or_identical(installed_launcher, launcher_bytes, 0o500)
-    manifest_path = version_directory / "claude-review-installation.json"
-    manifest_bytes = canonical(manifest)
-    manifest_result = exclusive_or_identical(manifest_path, manifest_bytes, 0o400)
+    provenance_path = version_directory / f"source-provenance-{commit}.json"
+    provenance_result = exclusive_or_identical(provenance_path, canonical(source_provenance), 0o400)
+    exclusive_or_identical(qualification_lock, b"claude-review qualification lock\n", 0o600)
+    initial_receipt = {
+        "kind": "claude_reviewer_qualification_receipt",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": contract_id,
+        "claude_selector": str(args.claude_bin),
+        "observed_identity": claude_identity,
+        "predecessor_receipt_sha256": None,
+        "predecessor_receipt_path": None,
+        "producing_launcher_path": str(installed_launcher),
+        "producing_launcher_sha256": launcher_sha256,
+        "qualification_event": "initial_installation",
+        "authority_semantics": "capability qualification only; grants zero task or review authority",
+    }
+    initial_receipt_bytes = canonical(initial_receipt)
+    initial_receipt_sha256 = digest(initial_receipt_bytes)
+    initial_receipt_path = receipts_directory / f"{initial_receipt_sha256}.json"
+    if current_selection.exists() or current_selection.is_symlink():
+        current_record = json.loads(current_selection.read_text(encoding="utf-8"))
+        if current_record.get("receipt_sha256") != initial_receipt_sha256:
+            raise ValueError("existing current qualification does not match the installation identity")
+    else:
+        exclusive_or_identical(initial_receipt_path, initial_receipt_bytes, 0o400)
+        current_record = {
+            "kind": "claude_reviewer_current_selection",
+            "schema_version": QUALIFICATION_SCHEMA_VERSION,
+            "entry_contract_id": contract_id,
+            "claude_selector": str(args.claude_bin),
+            "receipt_path": str(initial_receipt_path),
+            "receipt_sha256": initial_receipt_sha256,
+        }
+        exclusive_or_identical(current_selection, canonical(current_record), 0o600)
     rule_result = replace_expected(args.active_rule, rendered_rule, args.expected_existing_rule_sha256)
     receipt = {
         "kind": "claude_review_activation_receipt",
         **manifest,
+        "source_commit": commit,
+        "source_remote": source_remote,
+        "source_provenance_path": str(provenance_path),
+        "source_provenance_result": provenance_result,
         "installation_manifest_path": str(manifest_path),
         "installation_manifest_sha256": digest(manifest_bytes),
         "launcher_result": launcher_result,
         "manifest_result": manifest_result,
         "active_rule_result": rule_result,
+        "qualification_receipt_path": current_record["receipt_path"],
+        "qualification_receipt_sha256": current_record["receipt_sha256"],
     }
     args.activation_receipt.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     exclusive_or_identical(args.activation_receipt, canonical(receipt), 0o600)

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import sys
@@ -20,6 +21,7 @@ RULE_TEMPLATE = ROOT / ".codex" / "rule-templates" / "claude-review.rules"
 INSTALLATION_SCHEMA_VERSION = 2
 QUALIFICATION_SCHEMA_VERSION = 2
 ENTRY_CONTRACT_SCHEMA_VERSION = 1
+MAX_ERROR_CHARS = 1_000
 
 
 def digest(payload: bytes) -> str:
@@ -33,6 +35,27 @@ def canonical(value: object) -> bytes:
 def entry_contract_identity(contract: dict[str, object]) -> str:
     """Return the content identity of execution-relevant immutable inputs."""
     return f"sha256:{digest(canonical(contract))}"
+
+
+def bounded_redacted(value: str) -> str:
+    """Match the launcher's bounded version-identity rendering."""
+    redacted = re.sub(
+        r"(?i)\bauthorization\b\s*[:=]\s*(?:bearer\s+)?\S+",
+        "authorization=[REDACTED]",
+        value,
+    )
+    redacted = re.sub(
+        r"(?i)\b(bearer|token|api[_ -]?key|cookie)\b\s*[:=]\s*\S+",
+        r"\1=[REDACTED]",
+        redacted,
+    )
+    redacted = re.sub(
+        r'''(?i)[A-Za-z_]*(?:auth|cookie|credential|key|secret|token)[A-Za-z_]*["']?\s*[:=]\s*["']?[^\s,"'}]+''',
+        "[REDACTED]",
+        redacted,
+    )
+    redacted = re.sub(r"\b(?:sk|gho|ghp)[_-][A-Za-z0-9_=-]+", "[REDACTED]", redacted)
+    return redacted[:MAX_ERROR_CHARS]
 
 
 def git(*arguments: str) -> str:
@@ -130,8 +153,9 @@ def qualified_executable_identity(
         stderr=subprocess.PIPE,
         text=True,
         timeout=5,
+        cwd=str(Path(str(before["resolved_path"])).parent),
     )
-    exact_version = (version.stdout or version.stderr).strip()[:1000]
+    exact_version = bounded_redacted((version.stdout or version.stderr).strip())
     if version.returncode != 0 or not exact_version:
         raise ValueError("Claude target did not provide an exact version identity")
     after = exact_executable_file_identity(selector, forbidden_roots)
@@ -449,15 +473,7 @@ def main() -> int:
     validate_destination(args.qualification_root, forbidden)
     auth_diagnostics_directory = args.activation_receipt.parent
     auth_diagnostics_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    auth_diagnostics_metadata = auth_diagnostics_directory.lstat()
-    if (
-        auth_diagnostics_directory.is_symlink()
-        or not stat.S_ISDIR(auth_diagnostics_metadata.st_mode)
-        or auth_diagnostics_metadata.st_uid != os.geteuid()
-        or stat.S_IMODE(auth_diagnostics_metadata.st_mode) & 0o022
-        or auth_diagnostics_directory.resolve(strict=True) != auth_diagnostics_directory
-    ):
-        raise ValueError("auth diagnostics directory is not exact operator-controlled state")
+    secure_private_directory(auth_diagnostics_directory)
     initial_file_identity = exact_executable_file_identity(args.claude_bin, forbidden)
     immutable_contract = {
         "entry_contract_schema_version": ENTRY_CONTRACT_SCHEMA_VERSION,
@@ -474,14 +490,7 @@ def main() -> int:
     contract_id = entry_contract_identity(immutable_contract)
     version_directory = args.install_root / f"entry-{contract_id.removeprefix('sha256:')}"
     version_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    version_metadata = version_directory.lstat()
-    if (
-        version_directory.is_symlink()
-        or not stat.S_ISDIR(version_metadata.st_mode)
-        or version_metadata.st_uid != os.geteuid()
-        or stat.S_IMODE(version_metadata.st_mode) & 0o022
-    ):
-        raise ValueError("content-addressed entry directory is not operator-controlled")
+    secure_private_directory(version_directory)
     installed_launcher = version_directory / "claude-review"
     rendered_rule = RULE_TEMPLATE.read_text(encoding="utf-8").replace(
         "__CLAUDE_REVIEW_LAUNCHER__", str(installed_launcher)

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -937,6 +937,10 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 events.index(("fsync", receipt_directory)),
                 events.index(("current", current_selection)),
             )
+            self.assertLess(
+                events.index(("current", current_selection)),
+                events.index(("fsync", receipt_directory.parent)),
+            )
 
     def test_installer_qualifies_exact_selector_target_and_rejects_writable_target(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -2093,6 +2097,9 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "#!/usr/bin/env python3\n"
             "import json, os, pathlib, signal, subprocess, sys, time\n"
             "if '--version' in sys.argv:\n"
+            "    version_count = pathlib.Path(os.environ['FAKE_VERSION_COUNT'])\n"
+            "    count = int(version_count.read_text()) + 1 if version_count.exists() else 1\n"
+            "    version_count.write_text(str(count))\n"
             "    print('fake-claude 2.1.241')\n"
             "    raise SystemExit(0)\n"
             "prompt = sys.stdin.read()\n"
@@ -2232,6 +2239,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             {
                 "FAKE_SCENARIO": scenario,
                 "FAKE_COUNT": str(self.count),
+                "FAKE_VERSION_COUNT": str(self.root / "version-count"),
                 "FAKE_CANDIDATE": str(self.candidate),
                 "FAKE_PACKAGE": str(self.package),
                 "CLAUDE_REVIEW_TEST_FIXTURE": "1",
@@ -2612,6 +2620,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(diagnostic["attempt_number"], 2)
         self.assertTrue(diagnostic["substantive_review_started"])
         self.assertTrue(diagnostic["automated_retry_attempted"])
+        self.assertEqual((self.root / "version-count").read_text(encoding="utf-8"), "2")
         self.assertEqual(len(diagnostic["attempts"]), 1)
         prior_attempt = diagnostic["attempts"][0]
         self.assertTrue(Path(prior_attempt["receipt"]).exists())

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import json
 import os
 from pathlib import Path
@@ -10,6 +12,7 @@ import textwrap
 import time
 import unittest
 from unittest import mock
+from types import SimpleNamespace
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -59,10 +62,10 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 "#!/usr/bin/env python3\n"
                 "import os, pathlib, sys\n"
                 f"VERSION = 'fixture-claude {number}'\n"
+                "pathlib.Path(os.environ['FIXTURE_PROVIDER_RUNS']).open('a').write(VERSION + (':version\\n' if '--version' in sys.argv else ':run\\n'))\n"
                 "if '--version' in sys.argv:\n"
                 "    print(VERSION)\n"
                 "    raise SystemExit(0)\n"
-                "pathlib.Path(os.environ['FIXTURE_PROVIDER_RUNS']).open('a').write(VERSION + '\\n')\n"
                 "print('CLAUDE_AUTH_OK')\n",
                 encoding="utf-8",
             )
@@ -70,12 +73,16 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             versions.append(version)
         selector = root / "claude"
         selector.symlink_to(versions[0])
-        identity = self.launcher.executable_identity(selector, os.geteuid())
+        with mock.patch.dict(os.environ, {"FIXTURE_PROVIDER_RUNS": str(marker)}):
+            qualified_identity = self.launcher.qualified_executable_identity(
+                selector, os.geteuid(), [candidate]
+            )
+        marker.unlink()
         qualification_root = root / "qualification-root"
         entry_contract = {
             "entry_contract_schema_version": 1,
             "installation_schema_version": 2,
-            "qualification_schema_version": 1,
+            "qualification_schema_version": 2,
             "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
             "rule_template_sha256": "fixture-rule-template",
             "claude_selector": str(selector),
@@ -107,7 +114,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             "claude_selector": str(selector),
             "forbidden_roots": [str(candidate)],
             "auth_diagnostics_directory": str(auth_diagnostics),
-            "qualification_schema_version": 1,
+            "qualification_schema_version": 2,
             "qualification_directory": str(qualification),
             "qualification_receipts_directory": str(receipts),
             "current_selection_path": str(qualification / "current-selection.json"),
@@ -115,10 +122,11 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         }
         receipt = {
             "kind": "claude_reviewer_qualification_receipt",
-            "schema_version": 1,
+            "schema_version": 2,
             "entry_contract_id": entry_contract_id,
             "claude_selector": str(selector),
-            "observed_identity": identity,
+            "file_identity": qualified_identity["file_identity"],
+            "version": qualified_identity["version"],
             "predecessor_receipt_sha256": None,
             "predecessor_receipt_path": None,
             "producing_launcher_path": str(launcher),
@@ -132,7 +140,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         receipt_path.chmod(0o400)
         current = {
             "kind": "claude_reviewer_current_selection",
-            "schema_version": 1,
+            "schema_version": 2,
             "entry_contract_id": entry_contract_id,
             "claude_selector": str(selector),
             "receipt_path": str(receipt_path),
@@ -174,6 +182,49 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         )
         return completed, diagnostics
 
+    def run_installer(self, root: Path, selector: Path, activation_name: str, commit: str):
+        activation_receipt = root / "activation" / activation_name
+        arguments = SimpleNamespace(
+            claude_bin=selector,
+            install_root=root / "install-root",
+            active_rule=root / "active.rules",
+            activation_receipt=activation_receipt,
+            qualification_root=root / "qualification-root",
+            expected_existing_rule_sha256=None,
+            forbidden_root=[],
+        )
+
+        def fake_git(*git_arguments):
+            if git_arguments[0] == "status":
+                return ""
+            if git_arguments == ("rev-parse", "HEAD"):
+                return commit
+            if git_arguments == ("remote", "get-url", "origin"):
+                return "git@github.com:ctrl-alt-keith/ai-workflow-playbook.git"
+            raise AssertionError(git_arguments)
+
+        output = io.StringIO()
+        with mock.patch.object(self.installer, "parse_arguments", return_value=arguments), mock.patch.object(
+            self.installer, "git", side_effect=fake_git
+        ), contextlib.redirect_stdout(output):
+            self.assertEqual(self.installer.main(), 0)
+        return json.loads(output.getvalue()), activation_receipt
+
+    def create_installer_targets(self, root: Path):
+        targets = []
+        for number in (1, 2, 3):
+            target = root / f"installer-claude-{number}"
+            target.write_text(
+                "#!/bin/sh\n"
+                f"printf 'installer-claude {number}\\n'\n",
+                encoding="utf-8",
+            )
+            target.chmod(0o755)
+            targets.append(target)
+        selector = root / "installer-claude"
+        selector.symlink_to(targets[0])
+        return selector, targets
+
     def test_project_rule_never_allows_repository_relative_launcher(self):
         rule = CODEX_RULE.read_text(encoding="utf-8")
         self.assertNotIn('decision="allow"', rule)
@@ -194,7 +245,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             "launcher_sha256": "a" * 64,
             "rule_template_sha256": "b" * 64,
             "installation_schema_version": 2,
-            "qualification_schema_version": 1,
+            "qualification_schema_version": 2,
         }
         first = self.installer.entry_contract_identity(contract)
         second = self.installer.entry_contract_identity({**contract})
@@ -206,7 +257,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         )
         self.assertNotEqual(
             first,
-            self.installer.entry_contract_identity({**contract, "qualification_schema_version": 2}),
+            self.installer.entry_contract_identity({**contract, "qualification_schema_version": 3}),
         )
 
     def test_managed_selector_advance_uses_prompted_qualification_without_entry_or_rule_change(self):
@@ -231,27 +282,33 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertEqual(rejected.returncode, 70)
             self.assertIn('"failure_classification": "reviewer_identity_qualification_required"', rejected.stderr)
             self.assertIn("--qualify-claude-identity", rejected.stderr)
-            self.assertEqual(fixture["marker"].read_text(encoding="utf-8"), "fixture-claude 1\n")
+            self.assertEqual(
+                fixture["marker"].read_text(encoding="utf-8"),
+                "fixture-claude 1:version\n" * 3 + "fixture-claude 1:run\n",
+            )
 
-            observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
-            observed_digest = self.launcher.observed_identity_digest(observed)
+            observed = self.launcher.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            observed_digest = self.launcher.file_identity_digest(observed)
             qualify = subprocess.run(
                 [
                     str(fixture["launcher"]),
                     "--qualify-claude-identity",
                     "--expected-current-receipt-sha256",
                     fixture["current"]["receipt_sha256"],
-                    "--expected-observed-identity-sha256",
+                    "--expected-observed-file-identity-sha256",
                     observed_digest,
                 ],
                 check=False,
                 text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env={**os.environ, "FIXTURE_PROVIDER_RUNS": str(fixture["marker"])},
             )
             self.assertEqual(qualify.returncode, 0, qualify.stderr)
             qualification_result = json.loads(qualify.stdout)
-            self.assertEqual(qualification_result["observed_identity"]["resolved_path"], str(fixture["versions"][1]))
+            self.assertEqual(qualification_result["file_identity"]["resolved_path"], str(fixture["versions"][1]))
             self.assertEqual(self.launcher.sha256_bytes(fixture["launcher"].read_bytes()), launcher_sha256)
             self.assertEqual(fixture["active_rule"].read_bytes(), rule_bytes)
             self.assertEqual(fixture["manifest_path"].read_bytes(), self.launcher.canonical_json_bytes(fixture["manifest"]))
@@ -264,6 +321,173 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertEqual(execution_identity["version"], "fixture-claude 2")
             self.assertEqual(execution_identity["qualification_receipt_sha256"], qualification_result["qualification_receipt_sha256"])
 
+    def test_unqualified_malicious_version_is_never_invoked_by_auth_or_review(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            malicious_marker = Path(temporary_directory) / "malicious-version"
+            malicious = Path(temporary_directory) / "malicious-claude"
+            malicious.write_text(
+                "#!/usr/bin/env python3\n"
+                "import pathlib, sys\n"
+                f"marker = pathlib.Path({str(malicious_marker)!r})\n"
+                "marker.open('a').write('version-side-effect\\n' if '--version' in sys.argv else 'run-side-effect\\n')\n"
+                "print('malicious-claude 2' if '--version' in sys.argv else 'CLAUDE_AUTH_OK')\n",
+                encoding="utf-8",
+            )
+            malicious.chmod(0o755)
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(malicious)
+            current_bytes = fixture["current_path"].read_bytes()
+            receipt_names = {path.name for path in fixture["receipts"].iterdir()}
+
+            for arguments in (
+                ["--auth-preflight", "--diagnostics-file", str(fixture["auth_diagnostics"] / "drift-auth.json")],
+                ["--review-config", str(Path(temporary_directory) / "unread-review-config.json")],
+            ):
+                completed = subprocess.run(
+                    [str(fixture["launcher"]), *arguments],
+                    check=False,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                self.assertEqual(completed.returncode, 70, completed.stderr)
+                self.assertIn("reviewer_identity_qualification_required", completed.stderr)
+                self.assertIn("observed_file_identity_sha256", completed.stderr)
+                self.assertIn("--expected-observed-file-identity-sha256", completed.stderr)
+                self.assertNotIn("observed_version", completed.stderr)
+                self.assertFalse(malicious_marker.exists())
+                self.assertEqual(fixture["current_path"].read_bytes(), current_bytes)
+                self.assertEqual({path.name for path in fixture["receipts"].iterdir()}, receipt_names)
+
+            observed = self.launcher.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            qualified = subprocess.run(
+                [
+                    str(fixture["launcher"]),
+                    "--qualify-claude-identity",
+                    "--expected-current-receipt-sha256",
+                    fixture["current"]["receipt_sha256"],
+                    "--expected-observed-file-identity-sha256",
+                    self.launcher.file_identity_digest(observed),
+                ],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertEqual(qualified.returncode, 0, qualified.stderr)
+            self.assertEqual(malicious_marker.read_text(encoding="utf-8"), "version-side-effect\n")
+            result = json.loads(qualified.stdout)
+            receipt = json.loads(Path(result["qualification_receipt_path"]).read_text(encoding="utf-8"))
+            self.assertEqual(receipt["file_identity"], observed)
+            self.assertEqual(receipt["version"], "malicious-claude 2")
+
+    def test_noop_qualification_is_rejected_without_execution_or_state_change(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            installed_module = load_script("claude_review_noop_qualification", fixture["launcher"])
+            observed = installed_module.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            before_current = fixture["current_path"].read_bytes()
+            before_receipts = {path.name for path in fixture["receipts"].iterdir()}
+            with self.assertRaisesRegex(ValueError, "no-op"):
+                installed_module.qualify_claude_identity(
+                    os.geteuid(),
+                    expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
+                    expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
+                )
+            self.assertFalse(fixture["marker"].exists())
+            self.assertEqual(fixture["current_path"].read_bytes(), before_current)
+            self.assertEqual({path.name for path in fixture["receipts"].iterdir()}, before_receipts)
+
+    def test_qualification_races_never_replace_current_selection(self):
+        scenarios = ("before_lock", "before_version", "during_version", "after_version")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+                installed_module = load_script(f"claude_review_race_{scenario}", fixture["launcher"])
+                fixture["selector"].unlink()
+                fixture["selector"].symlink_to(fixture["versions"][1])
+                observed = installed_module.executable_file_identity(
+                    fixture["selector"], os.geteuid(), [fixture["candidate"]]
+                )
+                before_current = fixture["current_path"].read_bytes()
+                before_receipts = {path.name for path in fixture["receipts"].iterdir()}
+
+                if scenario == "before_lock":
+                    fixture["selector"].unlink()
+                    fixture["selector"].symlink_to(fixture["versions"][2])
+                    patches = contextlib.nullcontext()
+                elif scenario in {"before_version", "during_version"}:
+                    original_version = installed_module.version_of
+
+                    def move_before_version(executable, environment, *, cwd):
+                        if scenario == "before_version":
+                            fixture["selector"].unlink()
+                            fixture["selector"].symlink_to(fixture["versions"][2])
+                        result = original_version(executable, environment, cwd=cwd)
+                        if scenario == "during_version":
+                            fixture["selector"].unlink()
+                            fixture["selector"].symlink_to(fixture["versions"][2])
+                        return result
+
+                    patches = mock.patch.object(installed_module, "version_of", move_before_version)
+                else:
+                    original_observation = installed_module.executable_file_identity
+                    observations = 0
+
+                    def move_on_final_observation(path, effective_uid, forbidden_roots=None):
+                        nonlocal observations
+                        observations += 1
+                        if observations == 3:
+                            fixture["selector"].unlink()
+                            fixture["selector"].symlink_to(fixture["versions"][2])
+                        return original_observation(path, effective_uid, forbidden_roots)
+
+                    patches = mock.patch.object(
+                        installed_module, "executable_file_identity", move_on_final_observation
+                    )
+                with patches, mock.patch.dict(
+                    os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}
+                ), self.assertRaises(ValueError):
+                    installed_module.qualify_claude_identity(
+                        os.geteuid(),
+                        expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
+                        expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
+                    )
+                self.assertEqual(fixture["current_path"].read_bytes(), before_current)
+                self.assertEqual({path.name for path in fixture["receipts"].iterdir()}, before_receipts)
+
+    def test_atomic_current_selection_cleanup_and_ambiguous_residue(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            current = root / "current-selection.json"
+            current.write_bytes(b"prior\n")
+            current.chmod(0o600)
+            with self.assertRaisesRegex(ValueError, "compare-and-swap"):
+                self.launcher.atomic_replace_current_selection(
+                    current, {"next": True}, b"stale\n", os.geteuid()
+                )
+            self.assertEqual(current.read_bytes(), b"prior\n")
+            self.assertEqual(list(root.glob(".current-selection.json.*.tmp")), [])
+
+            def contaminate_then_fail(source, destination):
+                Path(source).chmod(0o644)
+                raise OSError("fixture replacement failure")
+
+            with mock.patch.object(self.launcher.os, "replace", contaminate_then_fail), self.assertRaisesRegex(
+                RuntimeError, "residue preserved"
+            ):
+                self.launcher.atomic_replace_current_selection(
+                    current, {"next": True}, b"prior\n", os.geteuid()
+                )
+            residue = list(root.glob(".current-selection.json.*.tmp"))
+            self.assertEqual(len(residue), 1)
+            self.assertEqual(current.read_bytes(), b"prior\n")
+
     def test_consecutive_upgrades_and_rollback_require_singular_lineage_transitions(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
@@ -274,20 +498,23 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 fixture["selector"].symlink_to(target)
                 rejected, _ = self.run_production_preflight(fixture, f"reject-{target.name}")
                 self.assertEqual(rejected.returncode, 70)
-                observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
+                observed = self.launcher.executable_file_identity(
+                    fixture["selector"], os.geteuid(), [fixture["candidate"]]
+                )
                 qualified = subprocess.run(
                     [
                         str(fixture["launcher"]),
                         "--qualify-claude-identity",
                         "--expected-current-receipt-sha256",
                         predecessor,
-                        "--expected-observed-identity-sha256",
-                        self.launcher.observed_identity_digest(observed),
+                        "--expected-observed-file-identity-sha256",
+                        self.launcher.file_identity_digest(observed),
                     ],
                     check=False,
                     text=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
+                    env={**os.environ, "FIXTURE_PROVIDER_RUNS": str(fixture["marker"])},
                 )
                 self.assertEqual(qualified.returncode, 0, qualified.stderr)
                 result = json.loads(qualified.stdout)
@@ -305,15 +532,17 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
             fixture["selector"].unlink()
             fixture["selector"].symlink_to(fixture["versions"][1])
-            observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
+            observed = self.launcher.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
             base = [str(fixture["launcher"]), "--qualify-claude-identity"]
             stale = subprocess.run(
                 [
                     *base,
                     "--expected-current-receipt-sha256",
                     "0" * 64,
-                    "--expected-observed-identity-sha256",
-                    self.launcher.observed_identity_digest(observed),
+                    "--expected-observed-file-identity-sha256",
+                    self.launcher.file_identity_digest(observed),
                 ],
                 check=False,
                 text=True,
@@ -329,8 +558,8 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     "/bin/echo",
                     "--expected-current-receipt-sha256",
                     fixture["current"]["receipt_sha256"],
-                    "--expected-observed-identity-sha256",
-                    self.launcher.observed_identity_digest(observed),
+                    "--expected-observed-file-identity-sha256",
+                    self.launcher.file_identity_digest(observed),
                 ],
                 check=False,
                 text=True,
@@ -346,26 +575,30 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             fixture["selector"].unlink()
             fixture["selector"].symlink_to(fixture["versions"][1])
             installed_module = load_script("claude_review_qualification_race", fixture["launcher"])
-            expected = installed_module.executable_identity(fixture["selector"], os.geteuid())
-            expected_digest = installed_module.observed_identity_digest(expected)
-            original = installed_module.executable_identity
+            expected = installed_module.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            expected_digest = installed_module.file_identity_digest(expected)
+            original = installed_module.executable_file_identity
             observations = 0
 
-            def move_after_first_observation(path, effective_uid):
+            def move_after_first_observation(path, effective_uid, forbidden_roots=None):
                 nonlocal observations
                 observations += 1
                 if observations == 2:
                     fixture["selector"].unlink()
                     fixture["selector"].symlink_to(fixture["versions"][2])
-                return original(path, effective_uid)
+                return original(path, effective_uid, forbidden_roots)
 
-            installed_module.executable_identity = move_after_first_observation
+            installed_module.executable_file_identity = move_after_first_observation
             current_bytes = fixture["current_path"].read_bytes()
-            with self.assertRaisesRegex(ValueError, "changed during qualification"):
+            with mock.patch.dict(
+                os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}
+            ), self.assertRaisesRegex(ValueError, "changed during qualification"):
                 installed_module.qualify_claude_identity(
                     os.geteuid(),
                     expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
-                    expected_observed_identity_sha256=expected_digest,
+                    expected_observed_file_identity_sha256=expected_digest,
                 )
             self.assertEqual(fixture["current_path"].read_bytes(), current_bytes)
 
@@ -373,7 +606,12 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
             installed_module = load_script("claude_review_execution_race", fixture["launcher"])
-            executable, execution_identity = installed_module.qualified_execution(None, os.geteuid())
+            with mock.patch.dict(
+                os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}
+            ):
+                executable, execution_identity = installed_module.qualified_execution(
+                    None, os.geteuid()
+                )
             fixture["selector"].unlink()
             fixture["selector"].symlink_to(fixture["versions"][1])
             with self.assertRaisesRegex(
@@ -421,7 +659,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     receipt_bytes = b"{malformed\n"
                 else:
                     if scenario == "schema":
-                        receipt["schema_version"] = 2
+                        receipt["schema_version"] = 1
                     elif scenario == "entry_contract":
                         receipt["entry_contract_id"] = "sha256:" + "0" * 64
                     elif scenario == "selector":
@@ -476,13 +714,13 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             selector = root / "claude-directory"
             selector.symlink_to(non_regular)
             with self.assertRaisesRegex(ValueError, "regular file"):
-                self.launcher.executable_identity(selector, os.geteuid())
+                self.launcher.executable_file_identity(selector, os.geteuid())
 
             invalid_version = root / "invalid-version"
             invalid_version.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
             invalid_version.chmod(0o755)
             with self.assertRaisesRegex(ValueError, "version identity"):
-                self.launcher.executable_identity(invalid_version, os.geteuid())
+                self.launcher.qualified_executable_identity(invalid_version, os.geteuid())
 
             owned = root / "foreign-owned"
             owned.write_text("#!/bin/sh\necho fixture-claude\n", encoding="utf-8")
@@ -499,7 +737,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
             with mock.patch.object(path_type, "stat", foreign_target_owner):
                 with self.assertRaisesRegex(ValueError, "user-owned regular file"):
-                    self.launcher.executable_identity(owned, os.geteuid())
+                    self.launcher.executable_file_identity(owned, os.geteuid())
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
@@ -514,11 +752,14 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 '"failure_classification": "reviewer_identity_qualification_required"',
                 rejected.stderr,
             )
-            self.assertEqual(fixture["marker"].read_text(encoding="utf-8"), "fixture-claude 1\n")
+            self.assertEqual(
+                fixture["marker"].read_text(encoding="utf-8"),
+                "fixture-claude 1:version\n" * 3 + "fixture-claude 1:run\n",
+            )
 
     def test_production_selector_never_uses_inherited_path(self):
         with self.assertRaisesRegex(ValueError, "absolute path"):
-            self.launcher.executable_identity(Path("claude"), os.geteuid())
+            self.launcher.executable_file_identity(Path("claude"), os.geteuid())
 
     def test_installer_rule_replacement_requires_exact_prior_identity(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -542,19 +783,262 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             target.chmod(0o755)
             selector = root / "claude"
             selector.symlink_to(target.name)
-            identity = self.installer.exact_executable_identity(selector)
+            identity = self.installer.exact_executable_file_identity(selector)
             self.assertEqual(identity["requested_selector"], str(selector))
             self.assertEqual(identity["resolved_path"], str(target.resolve()))
             self.assertEqual(identity["selector_kind"], "symlink")
             target.chmod(0o775)
             with self.assertRaisesRegex(ValueError, "group/world-writable"):
-                self.installer.exact_executable_identity(selector)
+                self.installer.exact_executable_file_identity(selector)
 
     def test_installer_rejects_destinations_overlapping_forbidden_writable_roots(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
             with self.assertRaisesRegex(ValueError, "forbidden writable root"):
                 self.installer.validate_destination(root / "installed" / "claude-review", [root])
+
+    def test_installer_reruns_preserve_upgrade_and_rollback_lineage(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, targets = self.create_installer_targets(root)
+            initial, _ = self.run_installer(root, selector, "activation-1.json", "1" * 40)
+            launcher = Path(initial["installed_launcher_path"])
+            manifest_path = Path(initial["installation_manifest_path"])
+            current_path = Path(initial["current_selection_path"])
+            receipts = Path(initial["qualification_receipts_directory"])
+            active_rule = Path(initial["active_rule_path"])
+            immutable = {
+                "launcher": launcher.read_bytes(),
+                "manifest": manifest_path.read_bytes(),
+                "active_rule": active_rule.read_bytes(),
+                "entry": initial["entry_contract_id"],
+            }
+            installed_module = load_script("claude_review_installer_rerun", launcher)
+            initial_current = current_path.read_bytes()
+            initial_receipts = {path.name for path in receipts.iterdir()}
+            self.assertEqual(len(initial_receipts), 1)
+            initial_rerun, _ = self.run_installer(
+                root, selector, "activation-initial-rerun.json", "2" * 40
+            )
+            self.assertEqual(initial_rerun["entry_contract_id"], immutable["entry"])
+            self.assertEqual(current_path.read_bytes(), initial_current)
+            self.assertEqual({path.name for path in receipts.iterdir()}, initial_receipts)
+
+            for index, target in enumerate((targets[1], targets[2], targets[0]), start=3):
+                selector.unlink()
+                selector.symlink_to(target)
+                current = json.loads(current_path.read_text(encoding="utf-8"))
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                forbidden = [Path(value) for value in manifest["forbidden_roots"]]
+                observed = installed_module.executable_file_identity(
+                    selector, os.geteuid(), forbidden
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    self.assertEqual(
+                        installed_module.qualify_claude_identity(
+                            os.geteuid(),
+                            expected_current_receipt_sha256=current["receipt_sha256"],
+                            expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
+                        ),
+                        0,
+                    )
+                before_current = current_path.read_bytes()
+                before_receipts = {path.name for path in receipts.iterdir()}
+                rerun, activation = self.run_installer(
+                    root, selector, f"activation-{index}.json", f"{index}" * 40
+                )
+                self.assertEqual(rerun["entry_contract_id"], immutable["entry"])
+                self.assertEqual(launcher.read_bytes(), immutable["launcher"])
+                self.assertEqual(manifest_path.read_bytes(), immutable["manifest"])
+                self.assertEqual(active_rule.read_bytes(), immutable["active_rule"])
+                self.assertEqual(current_path.read_bytes(), before_current)
+                self.assertEqual({path.name for path in receipts.iterdir()}, before_receipts)
+                self.assertEqual(
+                    rerun["qualification_receipt_sha256"],
+                    json.loads(before_current)["receipt_sha256"],
+                )
+                self.assertTrue(activation.exists())
+                provenance = launcher.parent / f"source-provenance-{str(index) * 40}.json"
+                self.assertTrue(provenance.exists())
+
+    def test_installer_selector_drift_is_qualification_required_before_rule_or_receipt(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            marker = root / "unqualified-version-marker"
+            selector, targets = self.create_installer_targets(root)
+            initial, _ = self.run_installer(root, selector, "activation-1.json", "1" * 40)
+            malicious = targets[1]
+            malicious.write_text(
+                "#!/bin/sh\n"
+                f"touch {shlex.quote(str(marker))}\n"
+                "printf 'malicious 2\\n'\n",
+                encoding="utf-8",
+            )
+            malicious.chmod(0o755)
+            selector.unlink()
+            selector.symlink_to(malicious)
+            current_path = Path(initial["current_selection_path"])
+            receipts = Path(initial["qualification_receipts_directory"])
+            active_rule = Path(initial["active_rule_path"])
+            before_current = current_path.read_bytes()
+            before_receipts = {path.name for path in receipts.iterdir()}
+            active_rule.write_bytes(b"operator-prior-rule\n")
+            active_rule.chmod(0o600)
+            before_rule = active_rule.read_bytes()
+            activation = root / "activation" / "drift-rerun.json"
+            with self.assertRaisesRegex(self.installer.QualificationRequiredError, "qualification required"):
+                self.run_installer(root, selector, activation.name, "2" * 40)
+            self.assertFalse(marker.exists())
+            self.assertEqual(current_path.read_bytes(), before_current)
+            self.assertEqual({path.name for path in receipts.iterdir()}, before_receipts)
+            self.assertEqual(active_rule.read_bytes(), before_rule)
+            self.assertFalse(activation.exists())
+
+    def test_installer_and_launcher_share_the_full_invalid_state_matrix(self):
+        scenarios = (
+            "current_symlink", "receipt_symlink", "current_mode", "receipt_mode",
+            "foreign_owner", "malformed_current", "nonobject_current", "malformed_receipt",
+            "current_wrong_kind", "current_wrong_schema", "current_wrong_entry",
+            "current_wrong_selector", "wrong_kind", "wrong_schema", "wrong_entry",
+            "wrong_selector", "wrong_producer", "wrong_authority", "wrong_file_identity",
+            "missing_receipt",
+            "receipt_digest", "escaped_receipt", "ambiguous_predecessor",
+            "self_predecessor", "predecessor_digest",
+        )
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+                current = dict(fixture["current"])
+                receipt = json.loads(fixture["receipt_path"].read_text(encoding="utf-8"))
+
+                def write_current(record):
+                    fixture["current_path"].write_bytes(self.launcher.canonical_json_bytes(record))
+                    fixture["current_path"].chmod(0o600)
+
+                def select_receipt(payload, *, path=None):
+                    receipt_bytes = payload if isinstance(payload, bytes) else self.launcher.canonical_json_bytes(payload)
+                    receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
+                    selected = path or fixture["receipts"] / f"{receipt_sha256}.json"
+                    selected.parent.mkdir(parents=True, exist_ok=True)
+                    selected.write_bytes(receipt_bytes)
+                    selected.chmod(0o400)
+                    write_current({**current, "receipt_path": str(selected), "receipt_sha256": receipt_sha256})
+                    return selected
+
+                if scenario == "current_symlink":
+                    replacement = fixture["qualification"] / "replacement-current.json"
+                    replacement.write_bytes(fixture["current_path"].read_bytes())
+                    replacement.chmod(0o600)
+                    fixture["current_path"].unlink()
+                    fixture["current_path"].symlink_to(replacement)
+                elif scenario == "receipt_symlink":
+                    replacement = fixture["receipts"] / "replacement.json"
+                    replacement.write_bytes(fixture["receipt_path"].read_bytes())
+                    replacement.chmod(0o400)
+                    fixture["receipt_path"].unlink()
+                    fixture["receipt_path"].symlink_to(replacement)
+                elif scenario == "current_mode":
+                    fixture["current_path"].chmod(0o644)
+                elif scenario == "receipt_mode":
+                    fixture["receipt_path"].chmod(0o600)
+                elif scenario == "malformed_current":
+                    fixture["current_path"].write_bytes(b"{malformed\n")
+                elif scenario == "nonobject_current":
+                    fixture["current_path"].write_bytes(b"[]\n")
+                elif scenario.startswith("current_wrong_"):
+                    field, value = {
+                        "current_wrong_kind": ("kind", "wrong"),
+                        "current_wrong_schema": ("schema_version", 1),
+                        "current_wrong_entry": ("entry_contract_id", "sha256:" + "0" * 64),
+                        "current_wrong_selector": ("claude_selector", "/bin/echo"),
+                    }[scenario]
+                    write_current({**current, field: value})
+                elif scenario == "malformed_receipt":
+                    select_receipt(b"{malformed\n")
+                elif scenario in {
+                    "wrong_kind", "wrong_schema", "wrong_entry", "wrong_selector",
+                    "wrong_producer", "wrong_authority",
+                }:
+                    field, value = {
+                        "wrong_kind": ("kind", "wrong"),
+                        "wrong_schema": ("schema_version", 1),
+                        "wrong_entry": ("entry_contract_id", "sha256:" + "0" * 64),
+                        "wrong_selector": ("claude_selector", "/bin/echo"),
+                        "wrong_producer": ("producing_launcher_sha256", "0" * 64),
+                        "wrong_authority": ("authority_semantics", "approval proof"),
+                    }[scenario]
+                    select_receipt({**receipt, field: value})
+                elif scenario == "wrong_file_identity":
+                    select_receipt({
+                        **receipt,
+                        "file_identity": {
+                            **receipt["file_identity"],
+                            "resolved_sha256": "not-a-digest",
+                        },
+                    })
+                elif scenario == "missing_receipt":
+                    missing_sha = "a" * 64
+                    write_current({
+                        **current,
+                        "receipt_path": str(fixture["receipts"] / f"{missing_sha}.json"),
+                        "receipt_sha256": missing_sha,
+                    })
+                elif scenario == "receipt_digest":
+                    wrong_sha = "b" * 64
+                    wrong_path = fixture["receipts"] / f"{wrong_sha}.json"
+                    wrong_path.write_bytes(fixture["receipt_path"].read_bytes())
+                    wrong_path.chmod(0o400)
+                    write_current({**current, "receipt_path": str(wrong_path), "receipt_sha256": wrong_sha})
+                elif scenario == "escaped_receipt":
+                    select_receipt(receipt, path=Path(temporary_directory) / "escaped" / "receipt.json")
+                elif scenario == "ambiguous_predecessor":
+                    select_receipt({**receipt, "predecessor_receipt_sha256": "c" * 64})
+                elif scenario == "predecessor_digest":
+                    predecessor_sha = "d" * 64
+                    predecessor_path = fixture["receipts"] / f"{predecessor_sha}.json"
+                    predecessor_path.write_bytes(b"not-the-declared-digest\n")
+                    predecessor_path.chmod(0o400)
+                    select_receipt({
+                        **receipt,
+                        "predecessor_receipt_sha256": predecessor_sha,
+                        "predecessor_receipt_path": str(predecessor_path),
+                    })
+
+                if scenario == "foreign_owner":
+                    path_type = type(fixture["receipt_path"])
+                    original_lstat = path_type.lstat
+
+                    def foreign_lstat(path):
+                        metadata = original_lstat(path)
+                        if path == fixture["receipt_path"]:
+                            fields = list(metadata)
+                            fields[4] = metadata.st_uid + 1
+                            return os.stat_result(fields)
+                        return metadata
+
+                    context = mock.patch.object(path_type, "lstat", foreign_lstat)
+                elif scenario == "self_predecessor":
+                    self_sha = "e" * 64
+                    self_path = fixture["receipts"] / f"{self_sha}.json"
+                    self_receipt = {
+                        **receipt,
+                        "predecessor_receipt_sha256": self_sha,
+                        "predecessor_receipt_path": str(self_path),
+                    }
+                    self_path.write_bytes(self.launcher.canonical_json_bytes(self_receipt))
+                    self_path.chmod(0o400)
+                    write_current({**current, "receipt_path": str(self_path), "receipt_sha256": self_sha})
+                    context = contextlib.ExitStack()
+                    context.enter_context(mock.patch.object(self.installer, "digest", return_value=self_sha))
+                    context.enter_context(mock.patch.object(self.launcher, "sha256_bytes", return_value=self_sha))
+                else:
+                    context = contextlib.nullcontext()
+
+                with context:
+                    with self.assertRaises((OSError, ValueError)):
+                        self.installer.validated_existing_qualification(fixture["manifest"])
+                    with self.assertRaises((OSError, ValueError)):
+                        self.launcher.current_qualification(fixture["manifest"], os.geteuid())
 
     def test_temporary_production_install_binds_launcher_rule_and_claude_identity(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -589,11 +1073,15 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             selector.symlink_to(qualified)
             shadow.write_text(fake_body.replace("fixture-claude 1", "shadow-claude 1"), encoding="utf-8")
             shadow.chmod(0o755)
-            identity = self.launcher.executable_identity(selector, os.geteuid())
+            with mock.patch.dict(os.environ, {"FIXTURE_COUNT": str(count)}):
+                qualified_identity = self.launcher.qualified_executable_identity(
+                    selector, os.geteuid(), [candidate]
+                )
+            count.unlink(missing_ok=True)
             entry_contract = {
                 "entry_contract_schema_version": 1,
                 "installation_schema_version": 2,
-                "qualification_schema_version": 1,
+                "qualification_schema_version": 2,
                 "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
                 "rule_template_sha256": "fixture-rule-template",
                 "claude_selector": str(selector),
@@ -624,7 +1112,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 "claude_selector": str(selector),
                 "forbidden_roots": [str(candidate)],
                 "auth_diagnostics_directory": str(auth_diagnostics),
-                "qualification_schema_version": 1,
+                "qualification_schema_version": 2,
                 "qualification_directory": str(qualification),
                 "qualification_receipts_directory": str(receipts),
                 "current_selection_path": str(qualification / "current-selection.json"),
@@ -632,10 +1120,11 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             }
             receipt = {
                 "kind": "claude_reviewer_qualification_receipt",
-                "schema_version": 1,
+                "schema_version": 2,
                 "entry_contract_id": entry_contract_id,
                 "claude_selector": str(selector),
-                "observed_identity": identity,
+                "file_identity": qualified_identity["file_identity"],
+                "version": qualified_identity["version"],
                 "predecessor_receipt_sha256": None,
                 "predecessor_receipt_path": None,
                 "producing_launcher_path": str(launcher),
@@ -649,7 +1138,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             receipt_path.chmod(0o400)
             current = {
                 "kind": "claude_reviewer_current_selection",
-                "schema_version": 1,
+                "schema_version": 2,
                 "entry_contract_id": entry_contract_id,
                 "claude_selector": str(selector),
                 "receipt_path": str(receipt_path),

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import pwd
 import shlex
+import stat
 import subprocess
 import sys
 import tempfile
@@ -461,6 +462,66 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 self.assertEqual(fixture["current_path"].read_bytes(), before_current)
                 self.assertEqual({path.name for path in fixture["receipts"].iterdir()}, before_receipts)
 
+    def test_runtime_qualification_fsyncs_receipt_directory_before_current_selection(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            installed_module = load_script("claude_review_receipt_durability", fixture["launcher"])
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            observed = installed_module.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            events = []
+            original_replace = installed_module.atomic_replace_current_selection
+
+            def record_fsync(path):
+                events.append(("fsync", path))
+
+            def record_replace(*arguments):
+                events.append(("replace", arguments[0]))
+                return original_replace(*arguments)
+
+            with mock.patch.object(installed_module, "fsync_directory", record_fsync), mock.patch.object(
+                installed_module, "atomic_replace_current_selection", record_replace
+            ), mock.patch.dict(os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}):
+                installed_module.qualify_claude_identity(
+                    os.geteuid(),
+                    expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
+                    expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
+                )
+
+            receipt_fsync = events.index(("fsync", fixture["receipts"]))
+            current_replace = next(
+                index for index, event in enumerate(events) if event == ("replace", fixture["current_path"])
+            )
+            self.assertLess(receipt_fsync, current_replace)
+
+    def test_runtime_receipt_directory_fsync_failure_preserves_current_selection(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            installed_module = load_script("claude_review_receipt_fsync_failure", fixture["launcher"])
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            observed = installed_module.executable_file_identity(
+                fixture["selector"], os.geteuid(), [fixture["candidate"]]
+            )
+            before_current = fixture["current_path"].read_bytes()
+
+            with mock.patch.object(
+                installed_module,
+                "fsync_directory",
+                side_effect=OSError("fixture receipt-directory fsync failure"),
+            ), mock.patch.dict(os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}), self.assertRaisesRegex(
+                OSError, "receipt-directory fsync failure"
+            ):
+                installed_module.qualify_claude_identity(
+                    os.geteuid(),
+                    expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
+                    expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
+                )
+
+            self.assertEqual(fixture["current_path"].read_bytes(), before_current)
+
     def test_atomic_current_selection_cleanup_and_ambiguous_residue(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
@@ -690,6 +751,31 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     completed.stderr,
                 )
 
+    def test_installed_manifest_schema_and_contract_divergence_fail_closed(self):
+        scenarios = ("schema_v1", "wrong_entry_contract_id", "selector_contract_divergence")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+                manifest = json.loads(json.dumps(fixture["manifest"]))
+                if scenario == "schema_v1":
+                    manifest["schema_version"] = 1
+                elif scenario == "wrong_entry_contract_id":
+                    manifest["entry_contract_id"] = "sha256:" + "0" * 64
+                else:
+                    manifest["claude_selector"] = "/bin/echo"
+
+                fixture["manifest_path"].chmod(0o600)
+                fixture["manifest_path"].write_bytes(self.launcher.canonical_json_bytes(manifest))
+                fixture["manifest_path"].chmod(0o400)
+                self.assertEqual(stat.S_IMODE(fixture["manifest_path"].stat().st_mode), 0o400)
+
+                completed, _ = self.run_production_preflight(fixture, f"manifest-{scenario}")
+                self.assertEqual(completed.returncode, 70)
+                self.assertIn(
+                    '"failure_classification": "reviewer_executable_not_authorized"',
+                    completed.stderr,
+                )
+
     def test_foreign_owned_qualification_receipt_fails_closed(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
@@ -775,6 +861,82 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             )
             self.assertEqual(result["result"], "replaced")
             self.assertEqual(rule.read_bytes(), b"replacement\n")
+
+    def test_installer_existing_identical_rule_requires_safe_exact_file(self):
+        scenarios = ("safe", "group_writable", "world_writable", "foreign_owned", "symlink", "nonregular")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                root = Path(temporary_directory).resolve()
+                selector, _ = self.create_installer_targets(root)
+                initial, _ = self.run_installer(root, selector, "initial.json", "1" * 40)
+                active_rule = Path(initial["active_rule_path"])
+                active_rule_bytes = active_rule.read_bytes()
+                next_activation = root / "activation" / f"{scenario}.json"
+                context = contextlib.nullcontext()
+
+                if scenario == "group_writable":
+                    active_rule.chmod(0o620)
+                elif scenario == "world_writable":
+                    active_rule.chmod(0o602)
+                elif scenario == "foreign_owned":
+                    path_type = type(active_rule)
+                    original_lstat = path_type.lstat
+
+                    def foreign_lstat(path):
+                        metadata = original_lstat(path)
+                        if path == active_rule:
+                            fields = list(metadata)
+                            fields[4] = metadata.st_uid + 1
+                            return os.stat_result(fields)
+                        return metadata
+
+                    context = mock.patch.object(path_type, "lstat", foreign_lstat)
+                elif scenario == "symlink":
+                    target = root / "identical-rule-target"
+                    target.write_bytes(active_rule_bytes)
+                    target.chmod(0o600)
+                    active_rule.unlink()
+                    active_rule.symlink_to(target)
+                elif scenario == "nonregular":
+                    active_rule.unlink()
+                    active_rule.mkdir(mode=0o700)
+
+                with context:
+                    if scenario == "safe":
+                        rerun, receipt = self.run_installer(root, selector, next_activation.name, "2" * 40)
+                        self.assertEqual(rerun["active_rule_result"]["result"], "existing_identical")
+                        self.assertTrue(receipt.exists())
+                    else:
+                        with self.assertRaises((OSError, ValueError)):
+                            self.run_installer(root, selector, next_activation.name, "2" * 40)
+                        self.assertFalse(next_activation.exists())
+
+    def test_initial_installation_fsyncs_receipt_directory_before_current_selection(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            events = []
+            original_exclusive = self.installer.exclusive_or_identical
+
+            def record_fsync(path):
+                events.append(("fsync", path))
+
+            def record_exclusive(path, payload, mode):
+                if path.name == "current-selection.json":
+                    events.append(("current", path))
+                return original_exclusive(path, payload, mode)
+
+            with mock.patch.object(self.installer, "fsync_directory", record_fsync), mock.patch.object(
+                self.installer, "exclusive_or_identical", record_exclusive
+            ):
+                installed, _ = self.run_installer(root, selector, "initial.json", "1" * 40)
+
+            receipt_directory = Path(installed["qualification_receipt_path"]).parent
+            current_selection = receipt_directory.parent / "current-selection.json"
+            self.assertLess(
+                events.index(("fsync", receipt_directory)),
+                events.index(("current", current_selection)),
+            )
 
     def test_installer_qualifies_exact_selector_target_and_rejects_writable_target(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1999,9 +2161,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "    print(json.dumps({'type':'system','subtype':'api_retry','session_id':f's{attempt}','error':'server_error'}), flush=True)\n"
             "    print(json.dumps({'type':'result','subtype':'error_during_execution','is_error':True,'session_id':f's{attempt}'}), flush=True)\n"
             "    time.sleep(10)\n"
-            "if scenario in {'transient_once','transient_always','transient_with_lingering_child'} and (scenario == 'transient_always' or attempt == 1):\n"
+            "if scenario in {'transient_once','transient_always','transient_with_lingering_child','transient_then_executable_drift'} and (scenario == 'transient_always' or attempt == 1):\n"
             "    print(json.dumps({'type':'system','subtype':'api_retry','session_id':f's{attempt}','error':'server_error'}), flush=True)\n"
             "    print(json.dumps({'type':'result','subtype':'error_during_execution','is_error':True,'session_id':f's{attempt}'}), flush=True)\n"
+            "    if scenario == 'transient_then_executable_drift': pathlib.Path(sys.argv[0]).write_text(pathlib.Path(sys.argv[0]).read_text() + '# drift\\n')\n"
             "    raise SystemExit(1)\n"
             "if scenario == 'auth':\n"
             "    print(json.dumps({'type':'system','subtype':'api_retry','session_id':f's{attempt}','error':'authentication_failed'}), flush=True)\n"
@@ -2439,6 +2602,23 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(len(set(scratch_paths)), 2)
         self.assertTrue(all(receipt["attempt_scratch"]["cleanup"]["passed"] for receipt in receipts))
         self.assertTrue(all(not Path(path).exists() for path in scratch_paths))
+
+    def test_retry_identity_drift_preserves_prior_attempt_evidence_and_stops_before_second_spawn(self):
+        completed, diagnostic = self.run_governed("transient_then_executable_drift")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(self.count.read_text(encoding="utf-8"), "1")
+        self.assertEqual(diagnostic["failure_classification"], "reviewer_identity_changed_before_execution")
+        self.assertEqual(diagnostic["candidate_verdict"], "not_produced")
+        self.assertEqual(diagnostic["attempt_number"], 2)
+        self.assertTrue(diagnostic["substantive_review_started"])
+        self.assertTrue(diagnostic["automated_retry_attempted"])
+        self.assertEqual(len(diagnostic["attempts"]), 1)
+        prior_attempt = diagnostic["attempts"][0]
+        self.assertTrue(Path(prior_attempt["receipt"]).exists())
+        receipt = json.loads(Path(prior_attempt["receipt"]).read_text(encoding="utf-8"))
+        self.assertEqual(receipt["attempt_number"], 1)
+        self.assertTrue(Path(receipt["raw_output"]["path"]).exists())
+        self.assertEqual(len(self.receipts()), 1)
 
     def test_lingering_process_group_blocks_retry_until_terminal(self):
         completed, diagnostic = self.run_governed("transient_with_lingering_child")

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -9,6 +9,7 @@ import tempfile
 import textwrap
 import time
 import unittest
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,6 +37,143 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         cls.launcher = load_script("claude_review_identity_grammar", LAUNCHER)
         cls.installer = load_script("claude_review_installer", INSTALLER)
 
+    def create_installed_fixture(self, root: Path):
+        installed = root / "installed"
+        installed.mkdir(mode=0o700)
+        launcher = installed / "claude-review"
+        launcher_bytes = LAUNCHER.read_bytes()
+        launcher.write_bytes(launcher_bytes)
+        launcher.chmod(0o500)
+        active_rule = root / "active.rules"
+        active_rule.write_text("fixture active rule\n", encoding="utf-8")
+        active_rule.chmod(0o600)
+        auth_diagnostics = root / "auth-diagnostics"
+        auth_diagnostics.mkdir(mode=0o700)
+        candidate = root / "candidate"
+        candidate.mkdir()
+        marker = root / "provider-runs"
+        versions = []
+        for number in (1, 2, 3):
+            version = root / f"claude-{number}"
+            version.write_text(
+                "#!/usr/bin/env python3\n"
+                "import os, pathlib, sys\n"
+                f"VERSION = 'fixture-claude {number}'\n"
+                "if '--version' in sys.argv:\n"
+                "    print(VERSION)\n"
+                "    raise SystemExit(0)\n"
+                "pathlib.Path(os.environ['FIXTURE_PROVIDER_RUNS']).open('a').write(VERSION + '\\n')\n"
+                "print('CLAUDE_AUTH_OK')\n",
+                encoding="utf-8",
+            )
+            version.chmod(0o755)
+            versions.append(version)
+        selector = root / "claude"
+        selector.symlink_to(versions[0])
+        identity = self.launcher.executable_identity(selector, os.geteuid())
+        qualification_root = root / "qualification-root"
+        entry_contract = {
+            "entry_contract_schema_version": 1,
+            "installation_schema_version": 2,
+            "qualification_schema_version": 1,
+            "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+            "rule_template_sha256": "fixture-rule-template",
+            "claude_selector": str(selector),
+            "active_rule_path": str(active_rule),
+            "forbidden_roots": [str(candidate)],
+            "auth_diagnostics_directory": str(auth_diagnostics),
+            "qualification_root": str(qualification_root),
+        }
+        entry_contract_id = "sha256:" + self.launcher.sha256_bytes(
+            self.launcher.canonical_json_bytes(entry_contract)
+        )
+        qualification = qualification_root / entry_contract_id.removeprefix("sha256:")
+        receipts = qualification / "receipts"
+        receipts.mkdir(parents=True)
+        qualification_root.chmod(0o700)
+        qualification.chmod(0o700)
+        receipts.chmod(0o700)
+        lock = qualification / "qualification.lock"
+        lock.write_text("fixture lock\n", encoding="utf-8")
+        lock.chmod(0o600)
+        manifest = {
+            "schema_version": 2,
+            "entry_contract_id": entry_contract_id,
+            "entry_contract": entry_contract,
+            "installed_launcher_path": str(launcher),
+            "installed_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+            "active_rule_path": str(active_rule),
+            "active_rule_sha256": self.launcher.sha256_bytes(active_rule.read_bytes()),
+            "claude_selector": str(selector),
+            "forbidden_roots": [str(candidate)],
+            "auth_diagnostics_directory": str(auth_diagnostics),
+            "qualification_schema_version": 1,
+            "qualification_directory": str(qualification),
+            "qualification_receipts_directory": str(receipts),
+            "current_selection_path": str(qualification / "current-selection.json"),
+            "qualification_lock_path": str(lock),
+        }
+        receipt = {
+            "kind": "claude_reviewer_qualification_receipt",
+            "schema_version": 1,
+            "entry_contract_id": entry_contract_id,
+            "claude_selector": str(selector),
+            "observed_identity": identity,
+            "predecessor_receipt_sha256": None,
+            "predecessor_receipt_path": None,
+            "producing_launcher_path": str(launcher),
+            "producing_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+            "authority_semantics": "capability qualification only; grants zero task or review authority",
+        }
+        receipt_bytes = self.launcher.canonical_json_bytes(receipt)
+        receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
+        receipt_path = receipts / f"{receipt_sha256}.json"
+        receipt_path.write_bytes(receipt_bytes)
+        receipt_path.chmod(0o400)
+        current = {
+            "kind": "claude_reviewer_current_selection",
+            "schema_version": 1,
+            "entry_contract_id": entry_contract_id,
+            "claude_selector": str(selector),
+            "receipt_path": str(receipt_path),
+            "receipt_sha256": receipt_sha256,
+        }
+        current_path = qualification / "current-selection.json"
+        current_path.write_bytes(self.launcher.canonical_json_bytes(current))
+        current_path.chmod(0o600)
+        manifest_path = installed / "claude-review-installation.json"
+        manifest_path.write_bytes(self.launcher.canonical_json_bytes(manifest))
+        manifest_path.chmod(0o400)
+        return {
+            "launcher": launcher,
+            "launcher_bytes": launcher_bytes,
+            "active_rule": active_rule,
+            "auth_diagnostics": auth_diagnostics,
+            "candidate": candidate,
+            "marker": marker,
+            "versions": versions,
+            "selector": selector,
+            "manifest": manifest,
+            "manifest_path": manifest_path,
+            "qualification": qualification,
+            "receipts": receipts,
+            "current_path": current_path,
+            "current": current,
+            "receipt_path": receipt_path,
+        }
+
+    def run_production_preflight(self, fixture, name: str):
+        diagnostics = fixture["auth_diagnostics"] / f"{name}.json"
+        completed = subprocess.run(
+            [str(fixture["launcher"]), "--auth-preflight", "--diagnostics-file", str(diagnostics)],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, "FIXTURE_PROVIDER_RUNS": str(fixture["marker"])},
+        )
+        return completed, diagnostics
+
     def test_project_rule_never_allows_repository_relative_launcher(self):
         rule = CODEX_RULE.read_text(encoding="utf-8")
         self.assertNotIn('decision="allow"', rule)
@@ -47,7 +185,336 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         self.assertEqual(rendered.count('decision="allow"'), 2)
         self.assertIn('["/operator/libexec/cak-155/claude-review", "--auth-preflight"]', rendered)
         self.assertIn('["/operator/libexec/cak-155/claude-review", "--review-config"]', rendered)
+        self.assertIn('"--qualify-claude-identity"', rendered)
+        self.assertEqual(rendered.count('decision="prompt"'), 1)
         self.assertNotIn("./scripts/claude-review", rendered)
+
+    def test_entry_contract_identity_excludes_source_provenance(self):
+        contract = {
+            "launcher_sha256": "a" * 64,
+            "rule_template_sha256": "b" * 64,
+            "installation_schema_version": 2,
+            "qualification_schema_version": 1,
+        }
+        first = self.installer.entry_contract_identity(contract)
+        second = self.installer.entry_contract_identity({**contract})
+        self.assertEqual(first, second)
+        self.assertNotIn("source_commit", contract)
+        self.assertNotEqual(
+            first,
+            self.installer.entry_contract_identity({**contract, "launcher_sha256": "c" * 64}),
+        )
+        self.assertNotEqual(
+            first,
+            self.installer.entry_contract_identity({**contract, "qualification_schema_version": 2}),
+        )
+
+    def test_managed_selector_advance_uses_prompted_qualification_without_entry_or_rule_change(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            launcher_sha256 = self.launcher.sha256_bytes(fixture["launcher"].read_bytes())
+            rule_bytes = fixture["active_rule"].read_bytes()
+            current_bytes = fixture["current_path"].read_bytes()
+
+            accepted, accepted_diagnostics = self.run_production_preflight(fixture, "accepted-v1")
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertEqual(fixture["current_path"].read_bytes(), current_bytes)
+            first_record = json.loads(accepted_diagnostics.read_text(encoding="utf-8"))
+            self.assertEqual(
+                first_record["runtime"]["reviewer_execution_identity"]["qualification_receipt_sha256"],
+                fixture["current"]["receipt_sha256"],
+            )
+
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            rejected, _ = self.run_production_preflight(fixture, "rejected-v2")
+            self.assertEqual(rejected.returncode, 70)
+            self.assertIn('"failure_classification": "reviewer_identity_qualification_required"', rejected.stderr)
+            self.assertIn("--qualify-claude-identity", rejected.stderr)
+            self.assertEqual(fixture["marker"].read_text(encoding="utf-8"), "fixture-claude 1\n")
+
+            observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
+            observed_digest = self.launcher.observed_identity_digest(observed)
+            qualify = subprocess.run(
+                [
+                    str(fixture["launcher"]),
+                    "--qualify-claude-identity",
+                    "--expected-current-receipt-sha256",
+                    fixture["current"]["receipt_sha256"],
+                    "--expected-observed-identity-sha256",
+                    observed_digest,
+                ],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertEqual(qualify.returncode, 0, qualify.stderr)
+            qualification_result = json.loads(qualify.stdout)
+            self.assertEqual(qualification_result["observed_identity"]["resolved_path"], str(fixture["versions"][1]))
+            self.assertEqual(self.launcher.sha256_bytes(fixture["launcher"].read_bytes()), launcher_sha256)
+            self.assertEqual(fixture["active_rule"].read_bytes(), rule_bytes)
+            self.assertEqual(fixture["manifest_path"].read_bytes(), self.launcher.canonical_json_bytes(fixture["manifest"]))
+
+            post, post_diagnostics = self.run_production_preflight(fixture, "accepted-v2")
+            self.assertEqual(post.returncode, 0, post.stderr)
+            post_record = json.loads(post_diagnostics.read_text(encoding="utf-8"))
+            execution_identity = post_record["runtime"]["reviewer_execution_identity"]
+            self.assertEqual(execution_identity["resolved_path"], str(fixture["versions"][1]))
+            self.assertEqual(execution_identity["version"], "fixture-claude 2")
+            self.assertEqual(execution_identity["qualification_receipt_sha256"], qualification_result["qualification_receipt_sha256"])
+
+    def test_consecutive_upgrades_and_rollback_require_singular_lineage_transitions(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            predecessor = fixture["current"]["receipt_sha256"]
+            lineage = []
+            for target in (fixture["versions"][1], fixture["versions"][2], fixture["versions"][0]):
+                fixture["selector"].unlink()
+                fixture["selector"].symlink_to(target)
+                rejected, _ = self.run_production_preflight(fixture, f"reject-{target.name}")
+                self.assertEqual(rejected.returncode, 70)
+                observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
+                qualified = subprocess.run(
+                    [
+                        str(fixture["launcher"]),
+                        "--qualify-claude-identity",
+                        "--expected-current-receipt-sha256",
+                        predecessor,
+                        "--expected-observed-identity-sha256",
+                        self.launcher.observed_identity_digest(observed),
+                    ],
+                    check=False,
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                self.assertEqual(qualified.returncode, 0, qualified.stderr)
+                result = json.loads(qualified.stdout)
+                receipt = json.loads(Path(result["qualification_receipt_path"]).read_text(encoding="utf-8"))
+                self.assertEqual(receipt["predecessor_receipt_sha256"], predecessor)
+                predecessor = result["qualification_receipt_sha256"]
+                lineage.append(predecessor)
+                accepted, _ = self.run_production_preflight(fixture, f"accept-{target.name}")
+                self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertEqual(len(set(lineage)), 3)
+            self.assertEqual(len(list(fixture["receipts"].glob("*.json"))), 4)
+
+    def test_stale_or_arbitrary_qualification_request_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            observed = self.launcher.executable_identity(fixture["selector"], os.geteuid())
+            base = [str(fixture["launcher"]), "--qualify-claude-identity"]
+            stale = subprocess.run(
+                [
+                    *base,
+                    "--expected-current-receipt-sha256",
+                    "0" * 64,
+                    "--expected-observed-identity-sha256",
+                    self.launcher.observed_identity_digest(observed),
+                ],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertEqual(stale.returncode, 70)
+            self.assertIn("stale predecessor", stale.stderr)
+            arbitrary = subprocess.run(
+                [
+                    *base,
+                    "--claude-bin",
+                    "/bin/echo",
+                    "--expected-current-receipt-sha256",
+                    fixture["current"]["receipt_sha256"],
+                    "--expected-observed-identity-sha256",
+                    self.launcher.observed_identity_digest(observed),
+                ],
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertEqual(arbitrary.returncode, 2)
+            self.assertIn("derives the selector", arbitrary.stderr)
+
+    def test_qualification_rejects_selector_race_without_replacing_current_selection(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            installed_module = load_script("claude_review_qualification_race", fixture["launcher"])
+            expected = installed_module.executable_identity(fixture["selector"], os.geteuid())
+            expected_digest = installed_module.observed_identity_digest(expected)
+            original = installed_module.executable_identity
+            observations = 0
+
+            def move_after_first_observation(path, effective_uid):
+                nonlocal observations
+                observations += 1
+                if observations == 2:
+                    fixture["selector"].unlink()
+                    fixture["selector"].symlink_to(fixture["versions"][2])
+                return original(path, effective_uid)
+
+            installed_module.executable_identity = move_after_first_observation
+            current_bytes = fixture["current_path"].read_bytes()
+            with self.assertRaisesRegex(ValueError, "changed during qualification"):
+                installed_module.qualify_claude_identity(
+                    os.geteuid(),
+                    expected_current_receipt_sha256=fixture["current"]["receipt_sha256"],
+                    expected_observed_identity_sha256=expected_digest,
+                )
+            self.assertEqual(fixture["current_path"].read_bytes(), current_bytes)
+
+    def test_ordinary_execution_recheck_rejects_selector_change_before_spawn(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            installed_module = load_script("claude_review_execution_race", fixture["launcher"])
+            executable, execution_identity = installed_module.qualified_execution(None, os.geteuid())
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+            with self.assertRaisesRegex(
+                installed_module.QualificationRequiredError,
+                "new exact identity",
+            ):
+                installed_module.revalidate_execution_identity(
+                    executable,
+                    execution_identity,
+                    os.geteuid(),
+                )
+
+    def test_tampered_or_unsafe_qualification_state_fails_closed(self):
+        scenarios = ("receipt_mode", "receipt_symlink", "current_symlink")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+                if scenario == "receipt_mode":
+                    fixture["receipt_path"].chmod(0o600)
+                elif scenario == "receipt_symlink":
+                    receipt_bytes = fixture["receipt_path"].read_bytes()
+                    replacement = fixture["receipts"] / "replacement.json"
+                    replacement.write_bytes(receipt_bytes)
+                    replacement.chmod(0o400)
+                    fixture["receipt_path"].unlink()
+                    fixture["receipt_path"].symlink_to(replacement)
+                else:
+                    current_bytes = fixture["current_path"].read_bytes()
+                    replacement = fixture["qualification"] / "replacement-current.json"
+                    replacement.write_bytes(current_bytes)
+                    replacement.chmod(0o600)
+                    fixture["current_path"].unlink()
+                    fixture["current_path"].symlink_to(replacement)
+                completed, _ = self.run_production_preflight(fixture, f"unsafe-{scenario}")
+                self.assertEqual(completed.returncode, 70)
+                self.assertIn('"failure_classification": "reviewer_executable_not_authorized"', completed.stderr)
+
+    def test_malformed_or_mismatched_qualification_receipt_fails_closed(self):
+        scenarios = ("malformed", "schema", "entry_contract", "selector", "launcher")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
+                fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+                receipt = json.loads(fixture["receipt_path"].read_text(encoding="utf-8"))
+                if scenario == "malformed":
+                    receipt_bytes = b"{malformed\n"
+                else:
+                    if scenario == "schema":
+                        receipt["schema_version"] = 2
+                    elif scenario == "entry_contract":
+                        receipt["entry_contract_id"] = "sha256:" + "0" * 64
+                    elif scenario == "selector":
+                        receipt["claude_selector"] = "/bin/echo"
+                    else:
+                        receipt["producing_launcher_sha256"] = "0" * 64
+                    receipt_bytes = self.launcher.canonical_json_bytes(receipt)
+                receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
+                receipt_path = fixture["receipts"] / f"{receipt_sha256}.json"
+                receipt_path.write_bytes(receipt_bytes)
+                receipt_path.chmod(0o400)
+                current = {
+                    **fixture["current"],
+                    "receipt_path": str(receipt_path),
+                    "receipt_sha256": receipt_sha256,
+                }
+                fixture["current_path"].write_bytes(
+                    self.launcher.canonical_json_bytes(current)
+                )
+                fixture["current_path"].chmod(0o600)
+                completed, _ = self.run_production_preflight(
+                    fixture, f"mismatched-{scenario}"
+                )
+                self.assertEqual(completed.returncode, 70)
+                self.assertIn(
+                    '"failure_classification": "reviewer_executable_not_authorized"',
+                    completed.stderr,
+                )
+
+    def test_foreign_owned_qualification_receipt_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            path_type = type(fixture["receipt_path"])
+
+            def foreign_receipt_owner(path):
+                metadata = os.lstat(path)
+                if path == fixture["receipt_path"]:
+                    fields = list(metadata)
+                    fields[4] = metadata.st_uid + 1
+                    return os.stat_result(fields)
+                return metadata
+
+            with mock.patch.object(path_type, "lstat", foreign_receipt_owner):
+                with self.assertRaisesRegex(ValueError, "private regular file"):
+                    self.launcher.current_qualification(fixture["manifest"], os.geteuid())
+
+    def test_untrusted_or_same_path_drifted_executable_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            non_regular = root / "non-regular"
+            non_regular.mkdir()
+            selector = root / "claude-directory"
+            selector.symlink_to(non_regular)
+            with self.assertRaisesRegex(ValueError, "regular file"):
+                self.launcher.executable_identity(selector, os.geteuid())
+
+            invalid_version = root / "invalid-version"
+            invalid_version.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            invalid_version.chmod(0o755)
+            with self.assertRaisesRegex(ValueError, "version identity"):
+                self.launcher.executable_identity(invalid_version, os.geteuid())
+
+            owned = root / "foreign-owned"
+            owned.write_text("#!/bin/sh\necho fixture-claude\n", encoding="utf-8")
+            owned.chmod(0o755)
+            path_type = type(owned)
+
+            def foreign_target_owner(path, *, follow_symlinks=True):
+                metadata = os.stat(path, follow_symlinks=follow_symlinks)
+                if path == owned and follow_symlinks:
+                    fields = list(metadata)
+                    fields[4] = metadata.st_uid + 1
+                    return os.stat_result(fields)
+                return metadata
+
+            with mock.patch.object(path_type, "stat", foreign_target_owner):
+                with self.assertRaisesRegex(ValueError, "user-owned regular file"):
+                    self.launcher.executable_identity(owned, os.geteuid())
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
+            accepted, _ = self.run_production_preflight(fixture, "same-path-before-drift")
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            target = fixture["versions"][0]
+            target.write_text(target.read_text(encoding="utf-8") + "# drift\n", encoding="utf-8")
+            target.chmod(0o755)
+            rejected, _ = self.run_production_preflight(fixture, "same-path-after-drift")
+            self.assertEqual(rejected.returncode, 70)
+            self.assertIn(
+                '"failure_classification": "reviewer_identity_qualification_required"',
+                rejected.stderr,
+            )
+            self.assertEqual(fixture["marker"].read_text(encoding="utf-8"), "fixture-claude 1\n")
 
     def test_production_selector_never_uses_inherited_path(self):
         with self.assertRaisesRegex(ValueError, "absolute path"):
@@ -93,7 +560,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
             installed = root / "installed"
-            installed.mkdir()
+            installed.mkdir(mode=0o700)
             launcher = installed / "claude-review"
             launcher_bytes = LAUNCHER.read_bytes()
             launcher.write_bytes(launcher_bytes)
@@ -118,24 +585,82 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             )
             qualified.write_text(fake_body, encoding="utf-8")
             qualified.chmod(0o755)
+            selector = root / "claude"
+            selector.symlink_to(qualified)
             shadow.write_text(fake_body.replace("fixture-claude 1", "shadow-claude 1"), encoding="utf-8")
             shadow.chmod(0o755)
-            identity = self.launcher.executable_identity(qualified, os.geteuid())
+            identity = self.launcher.executable_identity(selector, os.geteuid())
+            entry_contract = {
+                "entry_contract_schema_version": 1,
+                "installation_schema_version": 2,
+                "qualification_schema_version": 1,
+                "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+                "rule_template_sha256": "fixture-rule-template",
+                "claude_selector": str(selector),
+                "active_rule_path": str(active_rule),
+                "forbidden_roots": [str(candidate)],
+                "auth_diagnostics_directory": str(auth_diagnostics),
+                "qualification_root": str(root / "qualification-root"),
+            }
+            entry_contract_id = "sha256:" + self.launcher.sha256_bytes(
+                self.launcher.canonical_json_bytes(entry_contract)
+            )
+            qualification = root / "qualification-root" / entry_contract_id.removeprefix("sha256:")
+            receipts = qualification / "receipts"
+            receipts.mkdir(parents=True, mode=0o700)
+            qualification.chmod(0o700)
+            receipts.chmod(0o700)
+            lock = qualification / "qualification.lock"
+            lock.write_text("fixture lock\n", encoding="utf-8")
+            lock.chmod(0o600)
             manifest = {
-                "schema_version": 1,
+                "schema_version": 2,
+                "entry_contract_id": entry_contract_id,
+                "entry_contract": entry_contract,
                 "installed_launcher_path": str(launcher),
                 "installed_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
                 "active_rule_path": str(active_rule),
                 "active_rule_sha256": self.launcher.sha256_bytes(active_rule.read_bytes()),
-                "claude_selector": str(qualified),
-                "claude_identity": identity,
+                "claude_selector": str(selector),
                 "forbidden_roots": [str(candidate)],
                 "auth_diagnostics_directory": str(auth_diagnostics),
-                "source_commit": "fixture",
-                "source_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+                "qualification_schema_version": 1,
+                "qualification_directory": str(qualification),
+                "qualification_receipts_directory": str(receipts),
+                "current_selection_path": str(qualification / "current-selection.json"),
+                "qualification_lock_path": str(lock),
             }
+            receipt = {
+                "kind": "claude_reviewer_qualification_receipt",
+                "schema_version": 1,
+                "entry_contract_id": entry_contract_id,
+                "claude_selector": str(selector),
+                "observed_identity": identity,
+                "predecessor_receipt_sha256": None,
+                "predecessor_receipt_path": None,
+                "producing_launcher_path": str(launcher),
+                "producing_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
+                "authority_semantics": "capability qualification only; grants zero task or review authority",
+            }
+            receipt_bytes = self.launcher.canonical_json_bytes(receipt)
+            receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
+            receipt_path = receipts / f"{receipt_sha256}.json"
+            receipt_path.write_bytes(receipt_bytes)
+            receipt_path.chmod(0o400)
+            current = {
+                "kind": "claude_reviewer_current_selection",
+                "schema_version": 1,
+                "entry_contract_id": entry_contract_id,
+                "claude_selector": str(selector),
+                "receipt_path": str(receipt_path),
+                "receipt_sha256": receipt_sha256,
+            }
+            current_path = qualification / "current-selection.json"
+            current_path.write_bytes(self.launcher.canonical_json_bytes(current))
+            current_path.chmod(0o600)
             manifest_path = installed / "claude-review-installation.json"
             manifest_path.write_bytes(self.launcher.canonical_json_bytes(manifest))
+            manifest_path.chmod(0o400)
             environment = os.environ.copy()
             environment.pop("CLAUDE_REVIEW_TEST_FIXTURE", None)
             environment.update({"FIXTURE_COUNT": str(count), "PATH": f"{candidate}{os.pathsep}/usr/bin:/bin"})
@@ -149,13 +674,13 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 stderr=subprocess.PIPE,
                 env=environment,
             )
-            self.assertEqual(accepted.returncode, 0)
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
             self.assertEqual(count.read_text(encoding="utf-8"), "run\n")
             accepted_record = json.loads(accepted_diagnostics.read_text(encoding="utf-8"))
             self.assertEqual(accepted_record["runtime"]["claude_executable"], str(qualified))
             self.assertEqual(
                 accepted_record["runtime"]["reviewer_execution_identity"]["qualification"],
-                "installed_exact_identity",
+                "current_qualification_receipt",
             )
 
             inherited_fixture_diagnostics = auth_diagnostics / "inherited-fixture.json"
@@ -242,9 +767,8 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertFalse(arbitrary_diagnostics.exists())
             self.assertEqual(count.read_text(encoding="utf-8"), "run\nrun\n")
 
-            manifest["claude_selector"] = str(shadow)
-            manifest["claude_identity"] = self.launcher.executable_identity(shadow, os.geteuid())
-            manifest_path.write_bytes(self.launcher.canonical_json_bytes(manifest))
+            selector.unlink()
+            selector.symlink_to(shadow)
             forbidden_diagnostics = auth_diagnostics / "forbidden.json"
             forbidden = subprocess.run(
                 [str(launcher), "--auth-preflight", "--diagnostics-file", str(forbidden_diagnostics)],
@@ -295,6 +819,7 @@ class ClaudeReviewLauncherTests(unittest.TestCase):
         rule = CODEX_RULE.read_text(encoding="utf-8")
 
         for mode in (
+            "--qualify-claude-identity",
             "--auth-preflight",
             "--review-config",
             "--permission-hook",

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -284,7 +284,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertIn("--qualify-claude-identity", rejected.stderr)
             self.assertEqual(
                 fixture["marker"].read_text(encoding="utf-8"),
-                "fixture-claude 1:version\n" * 3 + "fixture-claude 1:run\n",
+                "fixture-claude 1:version\n" * 2 + "fixture-claude 1:run\n",
             )
 
             observed = self.launcher.executable_file_identity(
@@ -478,12 +478,13 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 Path(source).chmod(0o644)
                 raise OSError("fixture replacement failure")
 
-            with mock.patch.object(self.launcher.os, "replace", contaminate_then_fail), self.assertRaisesRegex(
-                RuntimeError, "residue preserved"
-            ):
-                self.launcher.atomic_replace_current_selection(
-                    current, {"next": True}, b"prior\n", os.geteuid()
-                )
+            with mock.patch.object(self.launcher.os, "replace", contaminate_then_fail):
+                with self.assertRaisesRegex(RuntimeError, "residue preserved") as raised:
+                    self.launcher.atomic_replace_current_selection(
+                        current, {"next": True}, b"prior\n", os.geteuid()
+                    )
+            self.assertIsInstance(raised.exception.__cause__, OSError)
+            self.assertEqual(str(raised.exception.__cause__), "fixture replacement failure")
             residue = list(root.glob(".current-selection.json.*.tmp"))
             self.assertEqual(len(residue), 1)
             self.assertEqual(current.read_bytes(), b"prior\n")
@@ -754,7 +755,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             )
             self.assertEqual(
                 fixture["marker"].read_text(encoding="utf-8"),
-                "fixture-claude 1:version\n" * 3 + "fixture-claude 1:run\n",
+                "fixture-claude 1:version\n" * 2 + "fixture-claude 1:run\n",
             )
 
     def test_production_selector_never_uses_inherited_path(self):
@@ -790,6 +791,73 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             target.chmod(0o775)
             with self.assertRaisesRegex(ValueError, "group/world-writable"):
                 self.installer.exact_executable_file_identity(selector)
+
+    def test_installer_version_observation_matches_launcher_context_and_redaction(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            target = root / "claude-version"
+            target.write_text(
+                "#!/bin/sh\nprintf 'cwd=%s token=secret-value\\n' \"$PWD\"\n",
+                encoding="utf-8",
+            )
+            target.chmod(0o755)
+            selector = root / "claude"
+            selector.symlink_to(target.name)
+
+            installer_identity = self.installer.qualified_executable_identity(selector)
+            launcher_identity = self.launcher.qualified_executable_identity(
+                selector, os.geteuid()
+            )
+
+            self.assertEqual(installer_identity["version"], launcher_identity["version"])
+            self.assertIn(str(root), installer_identity["version"])
+            self.assertIn("[REDACTED]", installer_identity["version"])
+            self.assertNotIn("secret-value", installer_identity["version"])
+
+    def test_installer_rejects_nonprivate_existing_state_directories(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            activation = root / "activation"
+            activation.mkdir(mode=0o755)
+
+            with self.assertRaisesRegex(ValueError, "private operator-controlled"):
+                self.run_installer(root, selector, "receipt.json", "1" * 40)
+
+            activation.chmod(0o700)
+            contract_id = "sha256:" + "a" * 64
+            entry_directory = root / "install-root" / f"entry-{contract_id.removeprefix('sha256:')}"
+            entry_directory.mkdir(parents=True, mode=0o755)
+            with mock.patch.object(
+                self.installer, "entry_contract_identity", return_value=contract_id
+            ), self.assertRaisesRegex(ValueError, "private operator-controlled"):
+                self.run_installer(root, selector, "receipt-2.json", "2" * 40)
+
+    def test_drift_action_quotes_launcher_path(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve() / "review root"
+            root.mkdir()
+            fixture = self.create_installed_fixture(root)
+            fixture["selector"].unlink()
+            fixture["selector"].symlink_to(fixture["versions"][1])
+
+            rejected, _ = self.run_production_preflight(fixture, "quoted-action")
+
+            self.assertEqual(rejected.returncode, 70)
+            encoded = rejected.stderr.split("claude-review diagnostics: ", 1)[1].strip()
+            diagnostic = json.loads(encoded)
+            action = diagnostic["qualification_transition"]["next_qualification_action"]
+            self.assertEqual(
+                shlex.split(action),
+                [
+                    str(fixture["launcher"]),
+                    "--qualify-claude-identity",
+                    "--expected-current-receipt-sha256",
+                    fixture["current"]["receipt_sha256"],
+                    "--expected-observed-file-identity-sha256",
+                    diagnostic["qualification_transition"]["observed_file_identity_sha256"],
+                ],
+            )
 
     def test_installer_rejects_destinations_overlapping_forbidden_writable_roots(self):
         with tempfile.TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary and rationale

Implements [CAK-174](https://linear.app/ctrl-alt-keith/issue/CAK-174/decouple-governed-claude-review-approval-from-the-moving-version-symlink) with a stable, content-addressed schema-v2 reviewer entry point and a separate singular qualification for the currently selected Claude executable.

Installation and Codex-rule setup are one-time for an unchanged launcher/rule/schema contract. A managed Claude update does not require reinstalling the launcher, replacing the rule, creating issue-specific reviewer state, or restarting Codex. When executable bytes change, the recurring action is one exact prompt-gated identity qualification; ordinary auth/review remains read-only and fail-closed.

## Reconciliation and scope

- Integrated base and merge-base: `dd84697841e46a06e39db5777d5432fe73c272dc`.
- Current `origin/main` at reconciliation: `437d051d1969afc3be3b766c35d8b072d1bc6ac3`.
- Prior reviewed candidate: `842575ba8842d1ea64c45b5ca42df05635f10306`.
- Second-pass correction: `499f3436ce561a2e72ed2e56a1819c6fb7aaf854`.
- Final corrected candidate: `1bb5084efad7338a924050044d0802a212a04ffa`.
- Post-base `origin/main` changes touch only `docs/tool-adapters/chatgpt.md` and `tests/test_issue_owned_prompt_handoff.py`; there is no CAK-174 overlap.
- This CAK-174 task did not create or modify CAK-175 or CAK-176 work.

## Review finding dispositions

All four findings from review `CAK-174-842575b-corrected-common-git-exception-20260827` were accepted and corrected:

1. Retry-loop drift diagnostics now preserve prior attempts, record the exact attempt number and substantive-output state, and state that no candidate verdict was produced.
2. Qualification receipt creation now fsyncs the receipt directory, and initial current-selection creation fsyncs its containing directory.
3. Existing byte-identical active rules must also satisfy canonical path, regular-file, owner, and mode invariants.
4. Installed-manifest schema and contract divergence now have direct regression tests.

Full rereview `CAK-174-499f343-second-pass-common-git-exception-20260827` used the authorized one-run temporary common-Git exception and one provider attempt. Protected surfaces and common Git were unchanged. It found two direct incomplete implementations of those correction surfaces; both were accepted under the authorized bounded follow-up:

1. The post-attempt version probe could execute drifted launcher bytes. The receipt now reuses the admitted execution identity version, with tests proving the drift path starts no second provider process.
2. Initial current-selection creation did not fsync its containing directory. The installer now fsyncs that directory.

The bounded follow-up is commit `1bb5084efad7338a924050044d0802a212a04ffa`.

Focused governed review `CAK-174-1bb5084-focused-followup-common-git-exception-20260827` then completed with one provider attempt and no actionable findings in its authorized scope. Candidate, index, HEAD, worktree Git administration, permanent launcher, active Codex rule, and common Git all remained unchanged.

Two pre-existing, out-of-scope observations were preserved without candidate changes: the existing-current-selection installer branch does not fsync a newly created `qualification.lock` directory entry, and operator-gated mid-review requalification can run a version process on newly admitted bytes before reporting mismatch. They are not regressions in, or incomplete implementations of, the four authorized correction surfaces.

## Validation at final corrected commit

- Six focused correction tests: pass.
- `python3 -m unittest tests.test_claude_review_launcher`: 109 tests, pass.
- `make check`: markdown lint clean; 241 tests, pass.
- `make authoritative-source-check`: pass.
- `git diff --check`: pass.
- Python compilation of launcher, installer, and tests: pass.
- Exec-policy matrix: exact installed auth/review allow; qualification, permission, lifecycle, and repository-relative execution prompt; arbitrary Claude and shell-wrapped invocation have no matching rule.
- Hosted `authoritative-source-check`: [pass](https://github.com/ctrl-alt-keith/ai-workflow-playbook/actions/runs/33135826422/job/98735449610).
- Hosted `markdownlint`: [pass](https://github.com/ctrl-alt-keith/ai-workflow-playbook/actions/runs/33135826424/job/98735449671).

## Dropbox evidence

All listed objects are under `/artifacts/issues/CAK-174/`. New objects were absent-created with no overwrite or autorename and were independently downloaded once; raw bytes, size, SHA-256, source-local SHA-256, and Dropbox content hash matched.

| File | Dropbox ID | Revision | Bytes | SHA-256 | Dropbox content hash |
|---|---|---:|---:|---|---|
| `2026-08-27-cak-174-corrected-review-final-v1.md` | `id:FHKdoRfTdTUAAAAAAAAImg` | `0165a0ebb75e997000000037bda8cd3` | 8406 | `2f681cd3ddf0f725bfe4f8ce3a9a114a17ace28723d837c9c3658353b75fc6be` | `8343c01858a196810cad538cefee6c23c761d29525be4c6245dda8ebbf93f266` |
| `2026-08-27-cak-174-second-pass-finding-dispositions-v1.md` | `id:FHKdoRfTdTUAAAAAAAAIpw` | `0165a116b632fe9000000037bda8cd3` | 2863 | `66cb46bd18d6a9ffb2d9a8ddf8a601376d8195a693385159db795d8a9ef70a51` | `fdcd1ae9f75e4a167c33dd1f551d947bb4b02be18a7f9c388a3a17e406636fd9` |
| `2026-08-27-cak-174-second-pass-rereview-prompt-v1.txt` | `id:FHKdoRfTdTUAAAAAAAAIqA` | `0165a1271999970000000037bda8cd3` | 4295 | `65047fdcb8cadad7cde3e6620f41acfcd80ee3b0b25b6bd94d2336cf6daf4ba1` | `365ef9b3fc5831b2c9e7ee1c02f5dee1e1cf39a0fc828e021f3439e2ff327cb5` |
| `2026-08-27-cak-174-second-pass-rereview-config-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIqQ` | `0165a1271c9cff2000000037bda8cd3` | 3148 | `cbb169dcf2f61e9b4fe8445ce75bbac11c644a341167fd941a6f5cdd1baddca8` | `6413411b116e92fcf5ad5015a64dbcae0427813d6f62b1295e8b1a8d5e0075a0` |
| `2026-08-27-cak-174-second-pass-rereview-policy-exception-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIqg` | `0165a12722ba611000000037bda8cd3` | 462 | `55c90205dff722bec509714cd912b3924b0ef2aceeeebb83b5f7c6ce5b348c6c` | `07418bf4099901baf12f2f1e5d4413d41f86b097141d76b7a9c376cb213f4911` |
| `2026-08-27-cak-174-second-pass-rereview-temporary-reviewer-patch-v1.patch` | `id:FHKdoRfTdTUAAAAAAAAIqw` | `0165a1272668c4f000000037bda8cd3` | 18013 | `a778d36393d7fe3f8ed7675009f69be6ea7cd1bf6b47ea6bf911b09e6dab9b77` | `5c4db29bbe393514a2b52c6e5d9c0c2a3439c66771eb795661015037f0649120` |
| `2026-08-27-cak-174-second-pass-rereview-temporary-installation-manifest-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIrA` | `0165a1272a0d1ca000000037bda8cd3` | 3326 | `bb3ae96e97aaae9eebb5569ffeae4582010b972ab86471429c2ae8653f5c4586` | `5010ff28315d35b19f209fc50e051b74d20354ca00f4bbf3df31ceed9a23169c` |
| `2026-08-27-cak-174-second-pass-rereview-preflight-receipt-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIrQ` | `0165a12736905bb000000037bda8cd3` | 3643 | `c390027256c54d6c100742bac56ef56d2ef0b388b6b7a7fc2594a20fe3af4920` | `5b3289818c0f74b370facd780524fe58119553956c660639db49009e6013aa37` |
| `2026-08-27-cak-174-second-pass-rereview-stream-v1.jsonl` | `id:FHKdoRfTdTUAAAAAAAAIrg` | `0165a1274a729bd000000037bda8cd3` | 819528 | `62aed25a0a5c96811391d1aff2ffccbdcd24962533db3dc01ca3cdc6aa6f7b8b` | `6208878424365e02faac71a779cf388d60fde3a513fdda8e3ea59cdf734c3131` |
| `2026-08-27-cak-174-second-pass-rereview-terminal-receipt-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIrw` | `0165a12754e32ec000000037bda8cd3` | 14845 | `29ca0d6130fae6b07d19a6cbb8d9a60486495430ef9c59d807285b9046a0231d` | `8cff4306e27b4ab996627d1f0205c63c7c70e23eddface96df4f3e8e46c5a5e6` |
| `2026-08-27-cak-174-second-pass-rereview-final-v1.md` | `id:FHKdoRfTdTUAAAAAAAAIsA` | `0165a1275680f49000000037bda8cd3` | 7853 | `5255724c7a81241e23f0b0df66f0432940f3d10ff69d4691f32866f58513e673` | `4894051ea4df7e6b8cdf9c2cd93e86c412573026609e0b1b36ffc3fc037f6c19` |
| `2026-08-27-cak-174-second-pass-follow-up-finding-dispositions-v1.md` | `id:FHKdoRfTdTUAAAAAAAAIsQ` | `0165a12759ecf6a000000037bda8cd3` | 1427 | `de60e77cc6f34666bd83ab810b42753eea7e63232e7bdb1cb1aad41349903385` | `c9d21cc215a788b102910a66a8d1a044fa69c27550ab9e28c828c8a048d15f11` |
| `2026-08-27-cak-174-focused-rereview-prompt-v1.txt` | `id:FHKdoRfTdTUAAAAAAAAIsg` | `0165a127655dc99000000037bda8cd3` | 3440 | `b440df4ec5923bd9e0e23baca916e5b7521111dad30174d8f076857973ac169a` | `ab488f8f971f704ff5fa5df15acee722d1ce2db76b8776361e7c112d8ec9143e` |
| `2026-08-27-cak-174-focused-rereview-config-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIsw` | `0165a12767340b9000000037bda8cd3` | 3039 | `37209a85fef030f01830ab260c4098ee8f5baf3253fd5109ad34a9e511287e13` | `3d29635f18def64a00dcbf52be5c4619015c4dd43c506949da36ac24fc5939cb` |
| `2026-08-27-cak-174-focused-rereview-policy-exception-v1.json` | `id:FHKdoRfTdTUAAAAAAAAItA` | `0165a1276a759e3000000037bda8cd3` | 467 | `549b929e6ae091fa3e6f2522b722a3660197d5fcb4650c53af13c588c247326b` | `76000f5d88c41bfa3a9f13e0c50ef5a1a2430fc52ff1ffb76944ec57984fb404` |
| `2026-08-27-cak-174-focused-rereview-temporary-reviewer-patch-v1.patch` | `id:FHKdoRfTdTUAAAAAAAAItQ` | `0165a1276de4930000000037bda8cd3` | 18036 | `604b098db21efe6547801839235bb3bdc25dc80efccc3207b6c43970d2015ff7` | `84a1b397388f4eaca990305c554d426f7a24c1e1886963eedc87e5342dcb6b91` |
| `2026-08-27-cak-174-focused-rereview-temporary-installation-manifest-v1.json` | `id:FHKdoRfTdTUAAAAAAAAItg` | `0165a1277180402000000037bda8cd3` | 3332 | `1c58d62a1707e8e7284b3ce826869bcb31e9272474cb98319c896c99674af4cc` | `878d64667b196f161f495e250667aeb8b91b8cc4f207a4a3f5038670ef0f6cf7` |
| `2026-08-27-cak-174-focused-rereview-preflight-receipt-v1.json` | `id:FHKdoRfTdTUAAAAAAAAItw` | `0165a127840ff27000000037bda8cd3` | 3181 | `4eaa1781156dbcf48e56312104caaee22636ba0664ebe57a254a373a14d82e56` | `2de53fbfcd1fdb41b02f0433a0dbf753567dec9fb23fb7aba525f23e0710ea84` |
| `2026-08-27-cak-174-focused-rereview-stream-v1.jsonl` | `id:FHKdoRfTdTUAAAAAAAAIuA` | `0165a127862f3b7000000037bda8cd3` | 306693 | `728b88eac7c9ee68340ccbe3b959b12ae30ee810ba043184cae0354fdf72feb0` | `77ed0ba5178863827b76e56f0c5f0780bf292c990eea06beeb759ba11283e703` |
| `2026-08-27-cak-174-focused-rereview-terminal-receipt-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIuQ` | `0165a12788f27ba000000037bda8cd3` | 14208 | `7e9c0a1a5048316dbe1038082ccefb8102d285dfbe2e0f443582d2d7178ca538` | `a0b27fdc0c5b9ba615c87ccb06f067b592fc393b94c36ced57bb89de5c45e764` |
| `2026-08-27-cak-174-focused-rereview-final-v1.md` | `id:FHKdoRfTdTUAAAAAAAAIug` | `0165a1278b1168c000000037bda8cd3` | 5841 | `8870eda8f8916b5183eb444b3767cc20a5ee18444e2e5f78345589f8039bbb7d` | `a03b6b812ccdf53e20f9df0fb53b7b2172d9cbe0f329743f6f61aa14a9dee811` |
| `2026-08-27-cak-174-second-pass-validation-results-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIuw` | `0165a1278eb41bb000000037bda8cd3` | 3177 | `4d1cfe7b0b34f7c7e80b4147944a13f23482a746d16b41ed38531e768312508e` | `20d6dba47c3e3c246575706dc4b5378af3eeed77991ee3b3474cda85f2e4ddcd` |
| `2026-08-27-cak-174-second-pass-corrected-commits-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIvA` | `0165a1279238ac9000000037bda8cd3` | 625 | `91745255ddaa31f6dc2b5e357143d772322891310647276c01f6d6b373f0f57e` | `63ae31cfacf03425b891d38ea57c18d6941a27b982776759ffca99429cde80dc` |
| `2026-08-27-cak-174-second-pass-evidence-index-v1.json` | `id:FHKdoRfTdTUAAAAAAAAIvQ` | `0165a127ed09e86000000037bda8cd3` | 20668 | `364c110b4b456548376928dcd6aa3e3a7cc13a5f5b5fc4e20efc5aff520892c9` | `6983e7b0f50646c8f80f5e89a3575c4a28691f2e5406e59ddede0b3a2cb6275f` |

The complete second-pass evidence index is `id:FHKdoRfTdTUAAAAAAAAIvQ` at revision `0165a127ed09e86000000037bda8cd3` with SHA-256 `364c110b4b456548376928dcd6aa3e3a7cc13a5f5b5fc4e20efc5aff520892c9`.

## Authority and status

The implementation at exact head `1bb5084efad7338a924050044d0802a212a04ffa` is **ready for human review**. Keith authorized the normal ready-for-review transition after live revalidation.

Schema v2 was not installed or activated. The permanent reviewer and active Codex rule were not changed. Codex was not restarted. No merge, auto-merge, migration, cleanup, CAK-175/CAK-176 implementation, or CAK-174 closure occurred. Readiness grants no merge, cutover, activation, migration, cleanup, or issue-completion authority.

Exact next action: Keith performs final human review of PR #355 and separately decides whether to merge.

