### PR TITLE
docs: specify Dropbox preview widget handoff

### DIFF
--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -193,90 +193,35 @@ existing [two-block inline presentation](#prompt-presentation). If access is
 unknown, inspect or attempt it before falling back. Material prompts also apply
 the durable profile below; routine prompts do not inherit it from transport.
 
-### Dropbox Widget Preview And Compact Executor Bootstrap
+### Dropbox Preview And Minimal Executor Handoff
 
-Selecting the Dropbox-backed prompt route is a conversation-minimization
-boundary. The complete prompt remains in Dropbox; the operator-facing
-conversation carries only a tiny operator-configuration preamble plus
-retrieval, exact-verification, and execution bootstrap data. It may contain
-only the tool-produced `file_preview` widget when a separate preview is
-intentionally selected, the two-field operator preamble below, one compact
-executor-bootstrap code block, and, when necessary, one short factual
-diagnostic that the requested widget did not visibly render.
+When optional operator preview is selected, exact-verify the durable prompt,
+then call Dropbox `file_preview` with `file_paths` containing the exact
+`file_id` returned by the write. Use the exact returned namespace path only
+when no file ID is available; never strip its namespace prefix. Present the
+tool-produced widget before minting the single-use download link.
 
-A successful `create_file` result is write-produced file metadata, not evidence
-that an operator-visible preview rendered. When a separate preview is
-intentionally selected, preserve this operation order:
+The preview call and connector metadata are not a visibly rendered preview.
+Do not substitute `open_in_dropbox_url`, copy or share links, thumbnail URLs,
+or metadata for the widget, and claim visible rendering only when the operator
+actually sees it. Preview remains optional and does not gate the handoff.
 
-1. Create the file.
-2. Exact-verify the durable object under its owning evidence contract.
-3. Invoke Dropbox `file_preview` with `file_paths` containing the exact
-   qualified locator returned by the write.
-4. Let the tool result render as the file surface.
-5. Mint the fresh single-use raw-download URL with `download_link`.
-6. Emit the compact executor bootstrap.
-
-Choose the `file_preview` locator deterministically: use the exact returned
-Dropbox `file_id` first, the exact returned namespace path only when `file_id`
-is unavailable, and the human display path only when neither qualified
-identifier is available. Never truncate or convert a namespace path by
-stripping its `ns:[id]//` prefix.
-
-Use the tool-produced preview widget itself as the preview surface. Do not
-replace or narrate it with `open_in_dropbox_url`, `copy_link_url`,
-`thumbnail_url`, a manually authored Markdown link, or an "Open in Dropbox"
-substitute. Connector success or returned preview metadata does not prove that
-the active ChatGPT client displayed the widget. Claim visible rendering only
-when the active client visibly rendered it; if preview metadata exists but no
-widget is visible, report only that observed limitation and do not call the
-preview successful. Selecting the exact returned `file_id` qualifies the
-connector input only; it is not evidence that the client visibly rendered the
-widget.
-
-Preview uses the durable file identity, never the executor's single-use
-raw-download URL. It must not mint, consume, prefetch, expose, or depend on that
-URL. Preview remains optional, non-authorizing, non-verifying, and non-gating;
-its absence does not block the machine-recipient handoff unless a narrower
-current human instruction explicitly requires visible inspection.
-
-The optional operator-only preamble contains exactly these two fields and no
-others. It is outside the executable bootstrap and is excluded from that code
-block's eight-line ceiling and strict field allowlist. Do not add thread
-routing, a reason, rationale, task content, or other operator metadata.
+Keep the complete prompt in Dropbox. Outside the optional widget, emit only the
+two operator fields and one compact retrieval, verification, and execution
+bootstrap shown below; do not summarize or reproduce the prompt.
 
 Recommended model: `[model]`
 
 Recommended reasoning level: `[level]`
 
-Emit the executor bootstrap as one code block with no more than eight non-empty
-lines. Its strict field allowlist is unchanged by the operator preamble. Use
-only these bootstrap fields: the fresh single-use raw-download URL; the exact
-Dropbox file identity and human locator where needed to disambiguate the
-object; expected byte size and SHA-256; one instruction to download, verify,
-and execute the complete prompt file; and one fail-closed instruction for a
-retrieval, identity, size, or digest mismatch. Keep the raw URL as literal text
-inside the code block, not a Markdown link or previewable card, and do not
-intentionally unfurl, preview, scan, or preflight it.
-
 ```text
 Download: [fresh single-use raw-download URL]
 Dropbox ID: [exact returned file ID]
-Prompt: [immutable human locator]
 Expected bytes: [byte count]
 Expected SHA-256: [digest]
 Execute: Download once, verify the exact identity, byte count, and SHA-256, then execute the complete prompt file.
 Stop: Fail closed on retrieval, identity, size, or digest mismatch; do not reconstruct the prompt from chat.
 ```
-
-The bootstrap is not a task summary. Reject and reduce any candidate that
-exceeds the field allowlist or line ceiling, repeats the complete prompt,
-adds `Role:`, `Goal:`, `Context:`, `Tasks:`, `Constraints:`, `Validation:`, or
-`Delivery:` headings or equivalent prose, summarizes rationale or workflow
-doctrine, adds delivery instructions beyond executing the downloaded complete
-prompt, includes operator, model, or reasoning metadata, includes preview
-metadata, or adds manually authored Dropbox open or share links. Accuracy does
-not excuse duplication: a wall-of-text bootstrap is noncompliant even when
-every repeated statement is correct.
 
 ### Issue-Owned Durable Prompt Capture And Handoff
 

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -197,11 +197,12 @@ the durable profile below; routine prompts do not inherit it from transport.
 
 Selecting the Dropbox-backed prompt route is a conversation-minimization
 boundary. The complete prompt remains in Dropbox; the operator-facing
-conversation carries only retrieval, exact-verification, and execution
-bootstrap data. It may contain only the tool-produced `file_preview` widget
-when a separate preview is intentionally selected, one compact executor
-bootstrap code block, and, when necessary, one short factual diagnostic that
-the requested widget did not visibly render.
+conversation carries only a tiny operator-configuration preamble plus
+retrieval, exact-verification, and execution bootstrap data. It may contain
+only the tool-produced `file_preview` widget when a separate preview is
+intentionally selected, the two-field operator preamble below, one compact
+executor-bootstrap code block, and, when necessary, one short factual
+diagnostic that the requested widget did not visibly render.
 
 A successful `create_file` result is write-produced file metadata, not evidence
 that an operator-visible preview rendered. When a separate preview is
@@ -228,7 +229,9 @@ substitute. Connector success or returned preview metadata does not prove that
 the active ChatGPT client displayed the widget. Claim visible rendering only
 when the active client visibly rendered it; if preview metadata exists but no
 widget is visible, report only that observed limitation and do not call the
-preview successful.
+preview successful. Selecting the exact returned `file_id` qualifies the
+connector input only; it is not evidence that the client visibly rendered the
+widget.
 
 Preview uses the durable file identity, never the executor's single-use
 raw-download URL. It must not mint, consume, prefetch, expose, or depend on that
@@ -236,10 +239,19 @@ URL. Preview remains optional, non-authorizing, non-verifying, and non-gating;
 its absence does not block the machine-recipient handoff unless a narrower
 current human instruction explicitly requires visible inspection.
 
+The optional operator-only preamble contains exactly these two fields and no
+others. It is outside the executable bootstrap and is excluded from that code
+block's eight-line ceiling and strict field allowlist. Do not add thread
+routing, a reason, rationale, task content, or other operator metadata.
+
+Recommended model: `[model]`
+
+Recommended reasoning level: `[level]`
+
 Emit the executor bootstrap as one code block with no more than eight non-empty
-lines and no surrounding explanation except the one permitted rendering
-diagnostic. Use only these fields: the fresh single-use raw-download URL; the
-exact Dropbox file identity and human locator where needed to disambiguate the
+lines. Its strict field allowlist is unchanged by the operator preamble. Use
+only these bootstrap fields: the fresh single-use raw-download URL; the exact
+Dropbox file identity and human locator where needed to disambiguate the
 object; expected byte size and SHA-256; one instruction to download, verify,
 and execute the complete prompt file; and one fail-closed instruction for a
 retrieval, identity, size, or digest mismatch. Keep the raw URL as literal text

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -207,12 +207,15 @@ or metadata for the widget, and claim visible rendering only when the operator
 actually sees it. Preview remains optional and does not gate the handoff.
 
 Keep the complete prompt in Dropbox. Outside the optional widget, emit only the
-two operator fields and one compact retrieval, verification, and execution
-bootstrap shown below; do not summarize or reproduce the prompt.
+normal concise operator metadata and one compact retrieval, verification, and
+execution bootstrap shown below; do not summarize or reproduce the prompt.
 
 Recommended model: `[model]`
 
 Recommended reasoning level: `[level]`
+
+Reason:
+`[one concise task-specific explanation]`
 
 ```text
 Download: [fresh single-use raw-download URL]

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -193,6 +193,79 @@ existing [two-block inline presentation](#prompt-presentation). If access is
 unknown, inspect or attempt it before falling back. Material prompts also apply
 the durable profile below; routine prompts do not inherit it from transport.
 
+### Dropbox Widget Preview And Compact Executor Bootstrap
+
+Selecting the Dropbox-backed prompt route is a conversation-minimization
+boundary. The complete prompt remains in Dropbox; the operator-facing
+conversation carries only retrieval, exact-verification, and execution
+bootstrap data. It may contain only the tool-produced `file_preview` widget
+when a separate preview is intentionally selected, one compact executor
+bootstrap code block, and, when necessary, one short factual diagnostic that
+the requested widget did not visibly render.
+
+A successful `create_file` result is write-produced file metadata, not evidence
+that an operator-visible preview rendered. When a separate preview is
+intentionally selected, preserve this operation order:
+
+1. Create the file.
+2. Exact-verify the durable object under its owning evidence contract.
+3. Invoke Dropbox `file_preview` with `file_paths` containing the exact
+   qualified locator returned by the write.
+4. Let the tool result render as the file surface.
+5. Mint the fresh single-use raw-download URL with `download_link`.
+6. Emit the compact executor bootstrap.
+
+Choose the `file_preview` locator deterministically: use the exact returned
+Dropbox `file_id` first, the exact returned namespace path only when `file_id`
+is unavailable, and the human display path only when neither qualified
+identifier is available. Never truncate or convert a namespace path by
+stripping its `ns:[id]//` prefix.
+
+Use the tool-produced preview widget itself as the preview surface. Do not
+replace or narrate it with `open_in_dropbox_url`, `copy_link_url`,
+`thumbnail_url`, a manually authored Markdown link, or an "Open in Dropbox"
+substitute. Connector success or returned preview metadata does not prove that
+the active ChatGPT client displayed the widget. Claim visible rendering only
+when the active client visibly rendered it; if preview metadata exists but no
+widget is visible, report only that observed limitation and do not call the
+preview successful.
+
+Preview uses the durable file identity, never the executor's single-use
+raw-download URL. It must not mint, consume, prefetch, expose, or depend on that
+URL. Preview remains optional, non-authorizing, non-verifying, and non-gating;
+its absence does not block the machine-recipient handoff unless a narrower
+current human instruction explicitly requires visible inspection.
+
+Emit the executor bootstrap as one code block with no more than eight non-empty
+lines and no surrounding explanation except the one permitted rendering
+diagnostic. Use only these fields: the fresh single-use raw-download URL; the
+exact Dropbox file identity and human locator where needed to disambiguate the
+object; expected byte size and SHA-256; one instruction to download, verify,
+and execute the complete prompt file; and one fail-closed instruction for a
+retrieval, identity, size, or digest mismatch. Keep the raw URL as literal text
+inside the code block, not a Markdown link or previewable card, and do not
+intentionally unfurl, preview, scan, or preflight it.
+
+```text
+Download: [fresh single-use raw-download URL]
+Dropbox ID: [exact returned file ID]
+Prompt: [immutable human locator]
+Expected bytes: [byte count]
+Expected SHA-256: [digest]
+Execute: Download once, verify the exact identity, byte count, and SHA-256, then execute the complete prompt file.
+Stop: Fail closed on retrieval, identity, size, or digest mismatch; do not reconstruct the prompt from chat.
+```
+
+The bootstrap is not a task summary. Reject and reduce any candidate that
+exceeds the field allowlist or line ceiling, repeats the complete prompt,
+adds `Role:`, `Goal:`, `Context:`, `Tasks:`, `Constraints:`, `Validation:`, or
+`Delivery:` headings or equivalent prose, summarizes rationale or workflow
+doctrine, adds delivery instructions beyond executing the downloaded complete
+prompt, includes operator, model, or reasoning metadata, includes preview
+metadata, or adds manually authored Dropbox open or share links. Accuracy does
+not excuse duplication: a wall-of-text bootstrap is noncompliant even when
+every repeated statement is correct.
+
 ### Issue-Owned Durable Prompt Capture And Handoff
 
 Apply the shared

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -210,12 +210,14 @@ Keep the complete prompt in Dropbox. Outside the optional widget, emit only the
 normal concise operator metadata and one compact retrieval, verification, and
 execution bootstrap shown below; do not summarize or reproduce the prompt.
 
-Recommended model: `[model]`
+Thread routing: [FRESH THREAD | SAME THREAD | CHILD TASK]
 
-Recommended reasoning level: `[level]`
+Recommended model: [model]
+
+Recommended reasoning level: [level]
 
 Reason:
-`[one concise task-specific explanation]`
+[one concise task-specific explanation]
 
 ```text
 Download: [fresh single-use raw-download URL]

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -303,6 +303,11 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         )
         self.assertIn("Claim visible rendering only when the active client visibly rendered it", preview)
         self.assertIn("do not call the preview successful", preview)
+        self.assertIn(
+            "Selecting the exact returned `file_id` qualifies the connector input only; "
+            "it is not evidence that the client visibly rendered the widget",
+            preview,
+        )
 
     def test_chatgpt_file_preview_uses_qualified_locator_precedence(self):
         preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
@@ -386,6 +391,31 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             "Delivery:",
         ):
             self.assertNotIn(forbidden_heading, blocks[0])
+
+    def test_chatgpt_operator_preamble_is_only_two_fields_and_outside_bootstrap(self):
+        section = self.chatgpt_dropbox_bootstrap
+        preamble_fields = re.findall(
+            r"^(Recommended (?:model|reasoning level): .+)$",
+            section,
+            re.MULTILINE,
+        )
+        self.assertEqual(
+            preamble_fields,
+            [
+                "Recommended model: `[model]`",
+                "Recommended reasoning level: `[level]`",
+            ],
+        )
+        bootstrap = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)[0]
+        for field in preamble_fields:
+            self.assertNotIn(field, bootstrap)
+        normalized_section = " ".join(section.split())
+        self.assertIn("contains exactly these two fields and no others", normalized_section)
+        self.assertIn("outside the executable bootstrap", normalized_section)
+        self.assertIn("excluded from that code block's eight-line ceiling", normalized_section)
+        self.assertIn("strict field allowlist is unchanged by the operator preamble", normalized_section)
+        for excluded in ("thread routing", "a reason", "rationale", "task content"):
+            self.assertIn(excluded, normalized_section)
 
     def test_chatgpt_bootstrap_rejects_prompt_restatement_and_url_unfurling(self):
         bootstrap = " ".join(self.chatgpt_dropbox_bootstrap.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -312,20 +312,22 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_chatgpt_example_has_normal_metadata_and_one_minimal_bootstrap(self):
         section = self.chatgpt_dropbox_bootstrap
-        self.assertEqual(
-            re.findall(r"^(Recommended [^:]+):", section, re.MULTILINE),
-            ["Recommended model", "Recommended reasoning level"],
-        )
-        self.assertLess(section.index("Reason:"), section.index("```text"))
-
+        block_start = section.index("```text")
+        metadata = section[:block_start]
         blocks = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)
         self.assertEqual(len(blocks), 1)
         bootstrap = blocks[0]
+        for field in (
+            "Thread routing:",
+            "Recommended model:",
+            "Recommended reasoning level:",
+            "Reason:",
+        ):
+            self.assertIn(field, metadata)
+            self.assertNotIn(field, bootstrap)
         self.assertLessEqual(len([line for line in bootstrap.splitlines() if line]), 8)
         for field in ("Download:", "Expected SHA-256:", "Execute:"):
             self.assertIn(field, bootstrap)
-        self.assertNotIn("Recommended ", bootstrap)
-        self.assertNotIn("Reason:", bootstrap)
         self.assertIn("Keep the complete prompt in Dropbox", section)
         self.assertIn("do not summarize or reproduce the prompt", section)
 

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -65,7 +65,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         )
         cls.chatgpt_dropbox_bootstrap = markdown_section(
             DOCS / "tool-adapters" / "chatgpt.md",
-            "### Dropbox Widget Preview And Compact Executor Bootstrap",
+            "### Dropbox Preview And Minimal Executor Handoff",
         )
 
     def test_prompt_contract_is_the_profile_owner(self):
@@ -289,153 +289,43 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertIn("use inline presentation rather than inventing a storage surface", presentation)
         self.assertIn("two-block inline presentation", self.chatgpt_presentation)
 
-    def test_chatgpt_write_metadata_does_not_claim_a_visible_preview(self):
+    def test_chatgpt_preview_prefers_the_returned_file_id(self):
         preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
-        self.assertIn(
-            "A successful `create_file` result is write-produced file metadata, "
-            "not evidence that an operator-visible preview rendered",
-            preview,
-        )
-        self.assertIn(
-            "Connector success or returned preview metadata does not prove that "
-            "the active ChatGPT client displayed the widget",
-            preview,
-        )
-        self.assertIn("Claim visible rendering only when the active client visibly rendered it", preview)
-        self.assertIn("do not call the preview successful", preview)
-        self.assertIn(
-            "Selecting the exact returned `file_id` qualifies the connector input only; "
-            "it is not evidence that the client visibly rendered the widget",
-            preview,
-        )
-
-    def test_chatgpt_file_preview_uses_qualified_locator_precedence(self):
-        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
-        self.assertIn("Invoke Dropbox `file_preview` with `file_paths`", preview)
-        file_id = preview.index("exact returned Dropbox `file_id` first")
-        namespace = preview.index("exact returned namespace path only when `file_id` is unavailable")
-        display = preview.index("human display path only when neither qualified identifier is available")
+        self.assertIn("Dropbox `file_preview` with `file_paths`", preview)
+        file_id = preview.index("`file_id` returned by the write")
+        namespace = preview.index("returned namespace path only when no file ID")
         self.assertLess(file_id, namespace)
-        self.assertLess(namespace, display)
-        self.assertIn("Never truncate or convert a namespace path", preview)
-        self.assertIn("stripping its `ns:[id]//` prefix", preview)
+        self.assertIn("before minting the single-use download link", preview)
 
-    def test_chatgpt_preview_widget_precedes_single_use_download_link(self):
-        preview = self.chatgpt_dropbox_bootstrap
-        create = preview.index("1. Create the file.")
-        verify = preview.index("2. Exact-verify the durable object")
-        widget = preview.index("3. Invoke Dropbox `file_preview`")
-        render = preview.index("4. Let the tool result render as the file surface.")
-        download = preview.index("5. Mint the fresh single-use raw-download URL")
-        bootstrap = preview.index("6. Emit the compact executor bootstrap.")
-        self.assertEqual(sorted((create, verify, widget, render, download, bootstrap)), [
-            create,
-            verify,
-            widget,
-            render,
-            download,
-            bootstrap,
-        ])
-        normalized_preview = " ".join(preview.split())
-        self.assertIn("Preview uses the durable file identity", normalized_preview)
-        self.assertIn("never the executor's single-use raw-download URL", normalized_preview)
-
-    def test_chatgpt_uses_the_tool_widget_without_manual_link_substitution(self):
+    def test_chatgpt_connector_results_are_not_the_visible_widget(self):
         preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
-        self.assertIn("Use the tool-produced preview widget itself as the preview surface", preview)
+        self.assertIn("connector metadata are not a visibly rendered preview", preview)
         for substitute in (
             "`open_in_dropbox_url`",
-            "`copy_link_url`",
-            "`thumbnail_url`",
-            'an "Open in Dropbox" substitute',
+            "copy or share links",
+            "thumbnail URLs",
+            "metadata for the widget",
         ):
             self.assertIn(substitute, preview)
-        self.assertIn("Do not replace or narrate it", preview)
+        self.assertIn("only when the operator actually sees it", preview)
+        self.assertIn("Preview remains optional and does not gate the handoff", preview)
 
-    def test_chatgpt_preview_remains_optional_and_non_blocking(self):
-        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
-        self.assertIn(
-            "Preview remains optional, non-authorizing, non-verifying, and non-gating",
-            preview,
-        )
-        self.assertIn("does not block the machine-recipient handoff", preview)
-        for gate_phrase in ("Approve", "Revise", "Reject preview", "before sending"):
-            self.assertNotIn(gate_phrase, preview)
-
-    def test_chatgpt_bootstrap_is_one_allowlisted_eight_line_code_block(self):
+    def test_chatgpt_example_is_two_operator_fields_and_one_minimal_bootstrap(self):
         section = self.chatgpt_dropbox_bootstrap
+        self.assertEqual(
+            re.findall(r"^(Recommended [^:]+):", section, re.MULTILINE),
+            ["Recommended model", "Recommended reasoning level"],
+        )
+
         blocks = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)
         self.assertEqual(len(blocks), 1)
-        lines = [line for line in blocks[0].splitlines() if line.strip()]
-        self.assertLessEqual(len(lines), 8)
-        self.assertEqual(
-            [line.split(":", 1)[0] for line in lines],
-            [
-                "Download",
-                "Dropbox ID",
-                "Prompt",
-                "Expected bytes",
-                "Expected SHA-256",
-                "Execute",
-                "Stop",
-            ],
-        )
-        self.assertNotRegex(blocks[0], re.compile(r"\]\(https?://"))
-        for forbidden_heading in (
-            "Role:",
-            "Goal:",
-            "Context:",
-            "Tasks:",
-            "Constraints:",
-            "Validation:",
-            "Delivery:",
-        ):
-            self.assertNotIn(forbidden_heading, blocks[0])
-
-    def test_chatgpt_operator_preamble_is_only_two_fields_and_outside_bootstrap(self):
-        section = self.chatgpt_dropbox_bootstrap
-        preamble_fields = re.findall(
-            r"^(Recommended (?:model|reasoning level): .+)$",
-            section,
-            re.MULTILINE,
-        )
-        self.assertEqual(
-            preamble_fields,
-            [
-                "Recommended model: `[model]`",
-                "Recommended reasoning level: `[level]`",
-            ],
-        )
-        bootstrap = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)[0]
-        for field in preamble_fields:
-            self.assertNotIn(field, bootstrap)
-        normalized_section = " ".join(section.split())
-        self.assertIn("contains exactly these two fields and no others", normalized_section)
-        self.assertIn("outside the executable bootstrap", normalized_section)
-        self.assertIn("excluded from that code block's eight-line ceiling", normalized_section)
-        self.assertIn("strict field allowlist is unchanged by the operator preamble", normalized_section)
-        for excluded in ("thread routing", "a reason", "rationale", "task content"):
-            self.assertIn(excluded, normalized_section)
-
-    def test_chatgpt_bootstrap_rejects_prompt_restatement_and_url_unfurling(self):
-        bootstrap = " ".join(self.chatgpt_dropbox_bootstrap.split())
-        self.assertIn("Selecting the Dropbox-backed prompt route is a conversation-minimization boundary", bootstrap)
-        self.assertIn("The complete prompt remains in Dropbox", bootstrap)
-        self.assertIn("The bootstrap is not a task summary", bootstrap)
-        self.assertIn("exceeds the field allowlist or line ceiling", bootstrap)
-        for forbidden_heading in (
-            "`Role:`",
-            "`Goal:`",
-            "`Context:`",
-            "`Tasks:`",
-            "`Constraints:`",
-            "`Validation:`",
-            "`Delivery:`",
-        ):
-            self.assertIn(forbidden_heading, bootstrap)
-        self.assertIn("a wall-of-text bootstrap is noncompliant", bootstrap)
-        self.assertIn("literal text inside the code block", bootstrap)
-        self.assertIn("do not intentionally unfurl, preview, scan, or preflight it", bootstrap)
+        bootstrap = blocks[0]
+        self.assertLessEqual(len([line for line in bootstrap.splitlines() if line]), 8)
+        for field in ("Download:", "Expected SHA-256:", "Execute:"):
+            self.assertIn(field, bootstrap)
+        self.assertNotIn("Recommended ", bootstrap)
+        self.assertIn("Keep the complete prompt in Dropbox", section)
+        self.assertIn("do not summarize or reproduce the prompt", section)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -63,6 +63,10 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             DOCS / "tool-adapters" / "chatgpt.md",
             "### Recipient-Capability Prompt Presentation",
         )
+        cls.chatgpt_dropbox_bootstrap = markdown_section(
+            DOCS / "tool-adapters" / "chatgpt.md",
+            "### Dropbox Widget Preview And Compact Executor Bootstrap",
+        )
 
     def test_prompt_contract_is_the_profile_owner(self):
         heading = "## Issue-Owned Durable Rendered-Prompt Handoff Profile"
@@ -284,6 +288,124 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertIn("A routine prompt delivered through a file does not", presentation)
         self.assertIn("use inline presentation rather than inventing a storage surface", presentation)
         self.assertIn("two-block inline presentation", self.chatgpt_presentation)
+
+    def test_chatgpt_write_metadata_does_not_claim_a_visible_preview(self):
+        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
+        self.assertIn(
+            "A successful `create_file` result is write-produced file metadata, "
+            "not evidence that an operator-visible preview rendered",
+            preview,
+        )
+        self.assertIn(
+            "Connector success or returned preview metadata does not prove that "
+            "the active ChatGPT client displayed the widget",
+            preview,
+        )
+        self.assertIn("Claim visible rendering only when the active client visibly rendered it", preview)
+        self.assertIn("do not call the preview successful", preview)
+
+    def test_chatgpt_file_preview_uses_qualified_locator_precedence(self):
+        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
+        self.assertIn("Invoke Dropbox `file_preview` with `file_paths`", preview)
+        file_id = preview.index("exact returned Dropbox `file_id` first")
+        namespace = preview.index("exact returned namespace path only when `file_id` is unavailable")
+        display = preview.index("human display path only when neither qualified identifier is available")
+        self.assertLess(file_id, namespace)
+        self.assertLess(namespace, display)
+        self.assertIn("Never truncate or convert a namespace path", preview)
+        self.assertIn("stripping its `ns:[id]//` prefix", preview)
+
+    def test_chatgpt_preview_widget_precedes_single_use_download_link(self):
+        preview = self.chatgpt_dropbox_bootstrap
+        create = preview.index("1. Create the file.")
+        verify = preview.index("2. Exact-verify the durable object")
+        widget = preview.index("3. Invoke Dropbox `file_preview`")
+        render = preview.index("4. Let the tool result render as the file surface.")
+        download = preview.index("5. Mint the fresh single-use raw-download URL")
+        bootstrap = preview.index("6. Emit the compact executor bootstrap.")
+        self.assertEqual(sorted((create, verify, widget, render, download, bootstrap)), [
+            create,
+            verify,
+            widget,
+            render,
+            download,
+            bootstrap,
+        ])
+        normalized_preview = " ".join(preview.split())
+        self.assertIn("Preview uses the durable file identity", normalized_preview)
+        self.assertIn("never the executor's single-use raw-download URL", normalized_preview)
+
+    def test_chatgpt_uses_the_tool_widget_without_manual_link_substitution(self):
+        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
+        self.assertIn("Use the tool-produced preview widget itself as the preview surface", preview)
+        for substitute in (
+            "`open_in_dropbox_url`",
+            "`copy_link_url`",
+            "`thumbnail_url`",
+            'an "Open in Dropbox" substitute',
+        ):
+            self.assertIn(substitute, preview)
+        self.assertIn("Do not replace or narrate it", preview)
+
+    def test_chatgpt_preview_remains_optional_and_non_blocking(self):
+        preview = " ".join(self.chatgpt_dropbox_bootstrap.split())
+        self.assertIn(
+            "Preview remains optional, non-authorizing, non-verifying, and non-gating",
+            preview,
+        )
+        self.assertIn("does not block the machine-recipient handoff", preview)
+        for gate_phrase in ("Approve", "Revise", "Reject preview", "before sending"):
+            self.assertNotIn(gate_phrase, preview)
+
+    def test_chatgpt_bootstrap_is_one_allowlisted_eight_line_code_block(self):
+        section = self.chatgpt_dropbox_bootstrap
+        blocks = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)
+        self.assertEqual(len(blocks), 1)
+        lines = [line for line in blocks[0].splitlines() if line.strip()]
+        self.assertLessEqual(len(lines), 8)
+        self.assertEqual(
+            [line.split(":", 1)[0] for line in lines],
+            [
+                "Download",
+                "Dropbox ID",
+                "Prompt",
+                "Expected bytes",
+                "Expected SHA-256",
+                "Execute",
+                "Stop",
+            ],
+        )
+        self.assertNotRegex(blocks[0], re.compile(r"\]\(https?://"))
+        for forbidden_heading in (
+            "Role:",
+            "Goal:",
+            "Context:",
+            "Tasks:",
+            "Constraints:",
+            "Validation:",
+            "Delivery:",
+        ):
+            self.assertNotIn(forbidden_heading, blocks[0])
+
+    def test_chatgpt_bootstrap_rejects_prompt_restatement_and_url_unfurling(self):
+        bootstrap = " ".join(self.chatgpt_dropbox_bootstrap.split())
+        self.assertIn("Selecting the Dropbox-backed prompt route is a conversation-minimization boundary", bootstrap)
+        self.assertIn("The complete prompt remains in Dropbox", bootstrap)
+        self.assertIn("The bootstrap is not a task summary", bootstrap)
+        self.assertIn("exceeds the field allowlist or line ceiling", bootstrap)
+        for forbidden_heading in (
+            "`Role:`",
+            "`Goal:`",
+            "`Context:`",
+            "`Tasks:`",
+            "`Constraints:`",
+            "`Validation:`",
+            "`Delivery:`",
+        ):
+            self.assertIn(forbidden_heading, bootstrap)
+        self.assertIn("a wall-of-text bootstrap is noncompliant", bootstrap)
+        self.assertIn("literal text inside the code block", bootstrap)
+        self.assertIn("do not intentionally unfurl, preview, scan, or preflight it", bootstrap)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -310,12 +310,13 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertIn("only when the operator actually sees it", preview)
         self.assertIn("Preview remains optional and does not gate the handoff", preview)
 
-    def test_chatgpt_example_is_two_operator_fields_and_one_minimal_bootstrap(self):
+    def test_chatgpt_example_has_normal_metadata_and_one_minimal_bootstrap(self):
         section = self.chatgpt_dropbox_bootstrap
         self.assertEqual(
             re.findall(r"^(Recommended [^:]+):", section, re.MULTILINE),
             ["Recommended model", "Recommended reasoning level"],
         )
+        self.assertLess(section.index("Reason:"), section.index("```text"))
 
         blocks = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)
         self.assertEqual(len(blocks), 1)
@@ -324,6 +325,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         for field in ("Download:", "Expected SHA-256:", "Execute:"):
             self.assertIn(field, bootstrap)
         self.assertNotIn("Recommended ", bootstrap)
+        self.assertNotIn("Reason:", bootstrap)
         self.assertIn("Keep the complete prompt in Dropbox", section)
         self.assertIn("do not summarize or reproduce the prompt", section)
 


### PR DESCRIPTION
## Summary

- tell ChatGPT to invoke Dropbox `file_preview` with the returned file ID, falling back to the returned namespace path only when necessary
- require the tool-produced widget instead of connector metadata or returned links, without claiming rendering the operator did not see
- keep the complete prompt in Dropbox and limit chat to normal operator metadata—thread routing, model, reasoning level, and reason—plus one compact retrieval, verification, and execution bootstrap
- protect those semantics with focused documentation tests

## Rationale

CAK-176 needs a small ChatGPT/Dropbox adapter rule: use `file_preview` correctly and keep the handoff minimal. The operator metadata now matches the normal prompt shape, while remaining outside the executable bootstrap. Shared exact-byte and single-use delivery semantics remain in their existing owners.

## Scope

- `docs/tool-adapters/chatgpt.md`: 35 added lines
- `tests/test_issue_owned_prompt_handoff.py`: 46 added lines
- net PR diff: 81 additions, 0 deletions across two files
- CAK-176 description reconciled to the same four-field operator-metadata shape

## Validation

- `make check` — 218 tests passed; Markdown lint reported 0 issues
- `git merge-tree --write-tree origin/main HEAD` — clean merge tree

## Runtime evidence

The first live trial failed: `file_preview` returned connector metadata or embedded-UI evidence, but Keith saw no operator-visible preview widget. This PR does not claim that file-ID invocation visibly rendered; client-visible preview remains unsatisfied runtime evidence.