### PR TITLE
Name the durable operational-record location contract

### DIFF
--- a/docs/maintenance-automations.md
+++ b/docs/maintenance-automations.md
@@ -157,9 +157,26 @@ An automation that needs broader authority must stop and return evidence for a
 separate human-authorized action.
 
 Evidence should live in the owning repository's normal review surface when a
-repository change is proposed. Report-only or cross-repository runs should use
-the workspace's designated durable operational-record location. Runtime output
-paths and notification routing remain local configuration.
+repository change is proposed. Report-only and cross-repository runs have no
+such surface, so they use a **durable operational-record location** declared in
+advance by the owning workspace or local operational contract. An automation
+does not select or invent that location per run.
+
+A durable operational-record location must provide immutable dated or versioned
+artifact identities, exclusive no-overwrite creation, a producing receipt, and a
+stated retention or rotation rule. It is distinct from issue-owned
+governed-artifact storage: issue-owned storage carries bounded, human-governed
+work that reaches a disposition and closes, while operational records accrue on
+a recurring cadence and are not scoped to a single issue. Do not open an issue
+solely to obtain a destination for recurring automation output, and do not route
+issue-bounded work into the operational-record location.
+
+An automation whose declared destination is unavailable fails closed and reports
+the blocker. It does not fall back to a repository, a workspace root, a retired
+storage root, or the current working directory. Concrete locators, runtime
+output paths, retention windows, and notification routing remain local
+configuration; see
+[Architecture Versus Local Configuration](#architecture-versus-local-configuration).
 
 ## Execution Locality
 
@@ -274,6 +291,7 @@ Canonical playbook doctrine owns:
 - the existence and purpose of the autonomous maintenance layer
 - its responsibility and non-responsibility boundaries
 - its authority classes, stop conditions, and evidence contract
+- the required properties of a durable operational-record location
 - its execution-locality classes and classification invariants
 - its relationship to doctrine, executors, repositories, contracts, and human
   approval
@@ -285,6 +303,7 @@ a detail:
 - exact execution times and weekdays
 - scheduler product and execution runtime
 - workstation paths and machine-specific credentials
+- the concrete durable operational-record locator and its retention window
 - local automation identifiers
 - notification routing
 - per-machine concurrency settings
@@ -308,6 +327,7 @@ periodic review. Inspect for:
 - recurring findings that indicate a missing canonical contract
 - automations that repeatedly edit the same surfaces or undo one another
 - capability gaps that leave important doctrine or repository risks unchecked
+- automation definitions that still target a retired or superseded destination
 
 Preserve intentional differences between read-only inspection, proposal work,
 bounded hygiene, and repository-specific validation. The goal is coherent


### PR DESCRIPTION
# Summary

## What changed

`docs/maintenance-automations.md` — define what a **durable operational-record location** is, as a class with required properties, in the `Authority And Evidence Classes` section. Three supporting one-line additions place the new concept in the existing ownership split and health checklist.

- Required properties: immutable dated or versioned identities, exclusive no-overwrite creation, a producing receipt, a stated retention or rotation rule.
- Distinguished from issue-owned governed-artifact storage, with the anti-pattern named in both directions.
- Fail-closed rule stated: an unavailable destination does not degrade into a repository, workspace root, retired storage root, or the current working directory.
- `Architecture Versus Local Configuration` gains the required-properties line under doctrine and the concrete-locator line under local configuration, so the layering is explicit.
- `Maintenance-Layer Health` gains "automation definitions that still target a retired or superseded destination" as an inspection item.

No concrete path, provider, account, or namespace appears in the diff. Locators stay in local operational configuration.

## Why

`Authority And Evidence Classes` instructed report-only and cross-repository runs to use "the workspace's designated durable operational-record location." That phrase occurred **exactly once** in the entire docs corpus and no document defined it, named it, or stated what it must provide.

The consequence is concrete rather than cosmetic. An automation running `Observe and report` across repositories has no repository review surface by definition — that is what the sentence is for — so the unnamed location was its only destination, and it could not be derived from any source. In practice such runs fell back to a workspace-level directory, which the workspace contract prohibits.

The fix keeps the existing layering rather than changing it: doctrine owns the properties, local configuration owns the locator, consistent with `Architecture Versus Local Configuration`.

## Scope check

- [x] This PR contains one logical change.

## Interaction mode

Implementation — a bounded documentation change proposed from a read-only review finding.

## Validation

- [ ] `make check` — not run locally; this branch was created through the GitHub API rather than a local worktree, and the sandbox used for review has no push route to the remote. CI runs the canonical target on this PR.
- [x] Manual review — full-patch diff inspected after push: `+23 / −3` across four hunks, all intentional, no incidental drift in unchanged sections.
- [x] Lint pre-check — longest added line is 84 characters. `MD013` is disabled in `.markdownlint.json` and the file already carries an 89-character line on `main`, so no new violation is introduced.
- [x] Anchor check — `#architecture-versus-local-configuration` matches the existing `## Architecture Versus Local Configuration` heading in the same file.

## Source evidence

Finding originated in the `architecture-skeptic` recurring review, run 2026-08-28, authority class `Observe and report`. Artifacts:

- `/automations/claude/architecture-skeptic/2026-08-28-architecture-skeptic-ecosystem-synthesis-v1.md` (finding E8)
- `/automations/claude/architecture-skeptic/2026-08-28-architecture-skeptic-run-receipt-v1.md` (capability gaps section)

Supporting evidence in this repository:

- `docs/maintenance-automations.md:161` on `main` — the sole occurrence of the phrase; `grep -rn "operational.record" docs/` returns one line.
- The retired-root incident that surfaced it: CAK-146 retired workspace `logs/`; CAK-166 (Done, 2026-08-26) migrated active automations off it and required a fleet check for newly introduced dependencies on those roots. That check did not cover scheduled-task definitions, and the `architecture-skeptic` task definition still targeted `logs/architecture-reviews/`, recreating a retired root on the 2026-08-28 run.

## Residual risks / follow-ups

- **Not addressed here:** the workspace `AGENTS.md` that owns the concrete locator is untracked and version-controlled nowhere, so the local half of this contract still cannot be reviewed or diffed. Recorded as finding E11.
- The `architecture-skeptic` task definition and the workspace `AGENTS.md` were updated out-of-band on 2026-08-28 to match this contract. Neither is in this repository.
- `base-execution-surface-qualification` hardcodes a durable-store namespace constant that the 2026-08-28 store restructure invalidated. Separate repository, separate change.
- Rotation has no owner. CAK-153 is the natural owner and is currently Canceled.

## Issue closure

None — no Linear issue was opened for this finding.
