### PR TITLE
feat: centralize CAK local tool ownership

### DIFF
--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -112,12 +112,12 @@ The repository [`claude-review`](../../scripts/claude-review) source composes
 these controls for governed review. Production auth and review run only through
 the exact machine-local installation rendered by
 [`install-claude-review`](../../scripts/install-claude-review). That installed
-launcher verifies its reviewed bytes, immutable schema-v2 entry contract,
-active Codex rule, singular current qualification receipt, and the exact
+launcher verifies its reviewed bytes, immutable schema-v3 entry contract,
+active Codex rule, singular flat current qualification receipt, and the exact
 absolute Claude selector plus resolved user-owned, non-writable executable
 file identity without starting unqualified bytes; it does not select `claude`
 from inherited `PATH`. Only after that non-executing identity matches the
-schema-v2 qualification receipt may it query the recorded version. It then
+schema-v3 qualification receipt may it query the recorded version. It then
 re-observes the file identity. Before provider process creation it repeats that
 ordering and compares the current receipt, entry contract, canonical path,
 ownership, mode, executable status, device, inode, size, digest, and version.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -526,7 +526,7 @@ hard-code a workstation username into reusable commands or configuration, and
 do not force this normalization on child CLIs without evidence that their
 behavior depends on login identity.
 
-### Enforcement-Backed Recursive Cleanup
+### Playbook-Managed Recursive Cleanup
 
 Direct `rm` and `rm -rf` remain approval-gated. When recursive cleanup is
 appropriate and every target is already known to be a disposable directory
@@ -534,16 +534,24 @@ beneath the current repository worktree, prefer the reviewed enforcement
 control:
 
 ```sh
-/Users/keith/.local/bin/codex-safe-rm -rf -- TARGET [TARGET ...]
+~/.local/bin/codex-safe-rm -rf -- TARGET [TARGET ...]
 ```
+
+The reusable `~` spelling above denotes the fixed location under the effective
+operator's account home. The installer exposes no alternate production
+destination. Enforcement's generated active rule must render and bind the
+exact resolved absolute executable path; it must not use `~`, `$HOME`, or
+`PATH` as runtime authority.
 
 The control validates the fixed invocation grammar and every operand, enforces
 containment beneath the invocation working directory, rejects `.git`, prevents
 symlink escape, rejects top-level files and symlinks, and safely ignores missing
-directories. The implementation, threat model, installation and verification
-workflow, rule fixture, and tests belong to
-[`ai-workflow-enforcement`](https://github.com/ctrl-alt-keith/ai-workflow-enforcement/blob/main/docs/codex-safe-rm.md);
-do not reproduce those mechanics in the playbook.
+directories. The executable source and its install, verification, and
+source-focused tests belong to this Playbook at
+[`scripts/codex-safe-rm`](../../scripts/codex-safe-rm) and
+[`scripts/install-codex-safe-rm`](../../scripts/install-codex-safe-rm).
+Enforcement owns the consumer policy and rule surface; it must not carry a
+second executable source or installer.
 
 The control establishes invocation and containment safety. It does not decide
 whether a directory is disposable. Do not use it to bypass approval when a
@@ -759,27 +767,31 @@ more than one repository.
 The installer verifies a clean exact source commit and derives one immutable,
 content-addressed entry contract from the launcher bytes, installation and
 qualification schemas, Codex rule-template bytes, configured Claude selector,
-active-rule path, forbidden roots, and private state destinations. An unrelated
-source commit remains provenance and does not change the entry path when those
-execution-contract inputs are identical. The installer copies the launcher and
-immutable schema-v2 manifest under an operator-controlled non-workspace root,
-creates the initial exact Claude qualification receipt and singular current
-selection in separate private state, and renders the user rule with the exact
-installed absolute path. It refuses a different existing installed object and
-requires the caller to name the expected digest before replacing an existing
-active rule. An identical-contract rerun securely validates and preserves any
-valid current receipt, including upgrade and rollback lineage, and appends only
-the new source provenance and requested activation evidence. Selector drift on
-a rerun is qualification-required and occurs before rule or activation-receipt
-mutation. Schema-v1 installations remain historical state; do not reinterpret
-or migrate them automatically. Supply every
+active-rule path, forbidden roots, and the exact installation directory. An
+unrelated source commit remains activation provenance and does not change the
+entry contract when those execution-contract inputs are identical. The
+installer publishes the stable command `~/.local/bin/claude-review` with one
+combined schema-v3 installation and current-qualification record at
+`~/.local/bin/.claude-review.json`. The content digest remains in that record
+and the entry contract, not in the command name. Qualification serializes on
+the stable executable and atomically replaces the combined record. It creates
+no other sidecar, `libexec`, state, cache, log, or historical receipt tree.
+The production installer derives that directory from the effective user's
+account home and exposes no relocation flag.
+The installer renders the user rule with the exact installed absolute path,
+refuses a different existing object, and requires the caller to name the
+expected digest before replacing an existing active rule. An identical-contract
+rerun securely validates and preserves the current receipt.
+Selector drift on a rerun is qualification-required and occurs before rule or
+activation-receipt mutation. Older installation schemas remain historical
+state; do not reinterpret or migrate them automatically. Supply every
 candidate, evidence, workspace, and attempt-scratch root as a forbidden root.
-The activation receipt's exact operator-controlled parent is also recorded as
-the auth-preflight diagnostics directory. An auto-approved auth preflight may
-create only one absent, path-safe JSON diagnostics file directly in that exact
-directory. Governed-review diagnostics must remain inside the config's exact
-evidence directory. A diagnostics-path or config failure is reported on the
-launcher's standard error without falling back to an unqualified file path.
+The activation receipt is explicit operation evidence and does not become
+durable launcher state. Production auth preflight reports its bounded record on
+standard error and does not accept a diagnostics-file destination. Governed
+review diagnostics remain inside the config's exact evidence directory. A
+diagnostics-path or config failure is reported on standard error without
+falling back to an unqualified file path.
 For example, using operator-selected absolute paths:
 
 ```sh
@@ -796,12 +808,11 @@ prefixes for that installed path. The exact
 `--qualify-claude-identity` prefix is `prompt`, as are lifecycle and
 permission-hook controls; repository-relative, alternate-path, arbitrary
 Claude-selection, and shell-wrapped forms are not allowed. The installed
-entry and rule are a one-time setup while their contract remains unchanged;
+command and rule are a one-time setup while their contract remains unchanged;
 a routine Claude update uses only the bounded qualification command emitted by
 the drift diagnostic, not another install, rule rewrite, or Codex restart. The
 installed launcher verifies its own bytes, immutable entry contract,
-active-rule hash,
-private current-selection record, immutable qualification receipt, and the
+active-rule hash, singular flat qualification receipt, and the
 selector's exact non-executing file identity before either allowed operation.
 Only matching already-qualified bytes may be queried for their recorded version,
 followed by a repeated file observation. It never resolves `claude` through
@@ -817,14 +828,13 @@ expected current receipt digest and expected observed file-identity digest; it
 derives the selector from the immutable entry manifest, recomputes the target,
 serializes the transition under the entry's exact lock, rejects no-op requests,
 then performs the first permitted version query. After another exact file
-observation it creates one no-overwrite lineage receipt and atomically
-compare-and-swap replaces the singular current record through a private flushed
-temporary file.
+observation it atomically compare-and-swap replaces the one current receipt
+through a flushed sidecar temporary file. The replacement records the prior
+receipt digest without retaining an accumulating local receipt history.
 It cannot select another executable or change the selector. After the operator
 approves and the transition succeeds, rerun the unchanged auth or review
-command through the unchanged rule. Historical receipts are provenance, not an
-allowlist: an upgrade, consecutive upgrade, or rollback each requires a new
-transition from the current receipt.
+command through the unchanged rule. An upgrade, consecutive upgrade, or
+rollback each requires a new transition from the current receipt.
 
 Codex loads rules at startup. After a genuine entry-contract install or rule
 update, validate the rendered rule without launching Claude, then restart Codex

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -37,9 +37,8 @@ GOVERNED_CONFIG_VERSION = 1
 MAX_GOVERNED_ATTEMPTS = 3
 TRANSIENT_OUTER_RETRY_ERRORS = {"overloaded", "server_error"}
 SAFE_EXECUTABLES = {"git", "shasum"}
-INSTALLATION_MANIFEST_NAME = "claude-review-installation.json"
-INSTALLATION_SCHEMA_VERSION = 2
-QUALIFICATION_SCHEMA_VERSION = 2
+INSTALLATION_SCHEMA_VERSION = 3
+QUALIFICATION_SCHEMA_VERSION = 3
 REVISION_ATOM = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64}|HEAD|origin/main)")
 REQUIRED_TOOLS = {"Bash", "Glob", "Grep", "Read"}
 WORKTREE_ADMIN_PATHS = ("HEAD", "index", "logs/HEAD", "COMMIT_EDITMSG", "ORIG_HEAD")
@@ -518,6 +517,22 @@ def secure_private_directory(path: Path, effective_uid: int) -> None:
         raise ValueError(f"state directory is not exact private operator-controlled state: {path}")
 
 
+def secure_install_directory(path: Path, effective_uid: int) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != effective_uid
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"install directory is not exact operator-controlled state: {path}")
+
+
+def installation_manifest_path(launcher: Path) -> Path:
+    return launcher.with_name(f".{launcher.name}.json")
+
+
 def load_installed_entry(effective_uid: int) -> tuple[Path, Path, dict[str, object]]:
     launcher = Path(__file__).resolve(strict=True)
     launcher_metadata = launcher.lstat()
@@ -528,15 +543,15 @@ def load_installed_entry(effective_uid: int) -> tuple[Path, Path, dict[str, obje
         or stat.S_IMODE(launcher_metadata.st_mode) != 0o500
     ):
         raise ValueError("the installed launcher is not the exact private executable object")
-    secure_private_directory(launcher.parent, effective_uid)
-    manifest_path = launcher.with_name(INSTALLATION_MANIFEST_NAME)
+    secure_install_directory(launcher.parent, effective_uid)
+    manifest_path = installation_manifest_path(launcher)
     try:
         manifest_bytes = secure_regular_bytes(manifest_path, effective_uid, modes={0o400})
         manifest = json.loads(manifest_bytes)
     except (OSError, json.JSONDecodeError) as error:
-        raise ValueError("production auth/review requires the exact schema-v2 installed entry manifest") from error
+        raise ValueError("production auth/review requires the exact schema-v3 installed entry manifest") from error
     if manifest.get("schema_version") != INSTALLATION_SCHEMA_VERSION:
-        raise ValueError("installed launcher schema is not supported; schema-v1 is not reinterpreted")
+        raise ValueError("installed launcher schema is not supported; older schemas are not reinterpreted")
     if manifest.get("installed_launcher_path") != str(launcher):
         raise ValueError("the installed launcher manifest does not name this exact launcher")
     launcher_bytes = launcher.read_bytes()
@@ -556,22 +571,14 @@ def load_installed_entry(effective_uid: int) -> tuple[Path, Path, dict[str, obje
         "claude_selector",
         "active_rule_path",
         "forbidden_roots",
-        "auth_diagnostics_directory",
     ):
         if manifest.get(field) != contract.get(field):
             raise ValueError(f"the entry manifest diverges from its immutable contract at {field}")
-    qualification_root = Path(str(contract.get("qualification_root", "")))
-    expected_qualification_directory = qualification_root / str(contract_id).removeprefix("sha256:")
-    if manifest.get("qualification_directory") != str(expected_qualification_directory):
-        raise ValueError("the qualification directory diverges from the immutable entry contract")
-    expected_state_paths = {
-        "qualification_receipts_directory": expected_qualification_directory / "receipts",
-        "current_selection_path": expected_qualification_directory / "current-selection.json",
-        "qualification_lock_path": expected_qualification_directory / "qualification.lock",
-    }
-    for field, expected_path in expected_state_paths.items():
-        if manifest.get(field) != str(expected_path):
-            raise ValueError(f"the entry manifest declares an invalid {field}")
+    installation_directory = Path(str(contract.get("installation_directory", "")))
+    if manifest.get("installation_directory") != str(installation_directory):
+        raise ValueError("the installation directory diverges from the immutable entry contract")
+    if installation_directory != launcher.parent:
+        raise ValueError("the installed launcher escaped the exact installation directory")
     active_rule = Path(str(manifest.get("active_rule_path", "")))
     if not active_rule.is_absolute():
         raise ValueError("the active Codex rule path is not exact")
@@ -588,60 +595,32 @@ def load_installed_entry(effective_uid: int) -> tuple[Path, Path, dict[str, obje
     forbidden_roots = manifest.get("forbidden_roots")
     if not isinstance(forbidden_roots, list) or not all(isinstance(value, str) for value in forbidden_roots):
         raise ValueError("the installation manifest does not declare exact forbidden writable roots")
-    for field in ("auth_diagnostics_directory", "qualification_directory", "qualification_receipts_directory"):
-        value = manifest.get(field)
-        if not isinstance(value, str) or not Path(value).is_absolute():
-            raise ValueError(f"the installation manifest does not declare an exact {field}")
-        secure_private_directory(Path(value), effective_uid)
+    auth_diagnostics = manifest.get("auth_diagnostics_directory")
+    if auth_diagnostics is not None:
+        if not isinstance(auth_diagnostics, str) or not Path(auth_diagnostics).is_absolute():
+            raise ValueError("the installation manifest declares invalid auth diagnostics")
+        secure_private_directory(Path(auth_diagnostics), effective_uid)
         if any(
-            contained(Path(value), Path(root)) or contained(Path(root), Path(value))
+            contained(Path(auth_diagnostics), Path(root))
+            or contained(Path(root), Path(auth_diagnostics))
             for root in forbidden_roots
         ):
-            raise ValueError(f"{field} overlaps a forbidden writable root")
+            raise ValueError("auth diagnostics overlaps a forbidden writable root")
     return launcher, manifest_path, manifest
 
 
 def current_qualification(
     manifest: dict[str, object], effective_uid: int
 ) -> tuple[dict[str, object], dict[str, object], bytes]:
-    current_path = Path(str(manifest.get("current_selection_path", "")))
-    receipts_directory = Path(str(manifest.get("qualification_receipts_directory", "")))
-    qualification_directory = Path(str(manifest.get("qualification_directory", "")))
-    if current_path.parent != qualification_directory or current_path.name != "current-selection.json":
-        raise ValueError("the current-selection path escaped its exact qualification directory")
-    current_bytes = secure_regular_bytes(current_path, effective_uid, modes={0o600})
-    try:
-        current = json.loads(current_bytes)
-    except json.JSONDecodeError as error:
-        raise ValueError("the current-selection record is malformed") from error
-    if not isinstance(current, dict):
-        raise ValueError("the current-selection record is malformed")
-    expected = {
-        "kind": "claude_reviewer_current_selection",
-        "schema_version": QUALIFICATION_SCHEMA_VERSION,
-        "entry_contract_id": manifest.get("entry_contract_id"),
-        "claude_selector": manifest.get("claude_selector"),
-    }
-    if any(current.get(key) != value for key, value in expected.items()):
-        raise ValueError("the current-selection record does not match the immutable entry contract")
-    receipt_path = Path(str(current.get("receipt_path", "")))
-    receipt_sha256 = current.get("receipt_sha256")
-    if (
-        not isinstance(receipt_sha256, str)
-        or receipt_path.parent != receipts_directory
-        or receipt_path.name != f"{receipt_sha256}.json"
-    ):
-        raise ValueError("the current qualification receipt identity is invalid")
+    launcher = Path(__file__).resolve(strict=True)
+    receipt_path = installation_manifest_path(launcher)
     receipt_bytes = secure_regular_bytes(receipt_path, effective_uid, modes={0o400})
-    if sha256_bytes(receipt_bytes) != receipt_sha256:
-        raise ValueError("the current qualification receipt digest is invalid")
     try:
         receipt = json.loads(receipt_bytes)
     except json.JSONDecodeError as error:
-        raise ValueError("the current qualification receipt is malformed") from error
+        raise ValueError("the combined installation and qualification record is malformed") from error
     if not isinstance(receipt, dict):
         raise ValueError("the current qualification receipt is malformed")
-    launcher = Path(__file__).resolve(strict=True)
     required = {
         "kind": "claude_reviewer_qualification_receipt",
         "schema_version": QUALIFICATION_SCHEMA_VERSION,
@@ -670,42 +649,22 @@ def current_qualification(
     ):
         raise ValueError("the qualification receipt lacks an exact qualified executable identity")
     predecessor_sha256 = receipt.get("predecessor_receipt_sha256")
-    predecessor_path_value = receipt.get("predecessor_receipt_path")
-    if (predecessor_sha256 is None) != (predecessor_path_value is None):
-        raise ValueError("the qualification receipt has ambiguous predecessor lineage")
-    if predecessor_sha256 is not None:
-        predecessor_path = Path(str(predecessor_path_value))
-        if (
-            not isinstance(predecessor_sha256, str)
-            or predecessor_sha256 == receipt_sha256
-            or predecessor_path.parent != receipts_directory
-            or predecessor_path.name != f"{predecessor_sha256}.json"
-        ):
-            raise ValueError("the qualification receipt has stale or invalid predecessor lineage")
-        predecessor_bytes = secure_regular_bytes(predecessor_path, effective_uid, modes={0o400})
-        if sha256_bytes(predecessor_bytes) != predecessor_sha256:
-            raise ValueError("the qualification predecessor receipt digest is invalid")
-        try:
-            predecessor = json.loads(predecessor_bytes)
-        except json.JSONDecodeError as error:
-            raise ValueError("the predecessor qualification receipt is malformed") from error
-        if not isinstance(predecessor, dict):
-            raise ValueError("the predecessor qualification receipt is malformed")
-        validate_recorded_file_identity(
-            predecessor.get("file_identity"),
-            str(manifest.get("claude_selector")),
-            forbidden_roots,
-            effective_uid,
-        )
-        if (
-            any(predecessor.get(key) != value for key, value in required.items())
-            or not isinstance(predecessor.get("version"), str)
-            or not predecessor["version"]
-            or predecessor.get("authority_semantics")
-            != "capability qualification only; grants zero task or review authority"
-        ):
-            raise ValueError("the predecessor qualification receipt belongs to another entry contract")
-    return current, receipt, current_bytes
+    receipt_sha256 = sha256_bytes(receipt_bytes)
+    if predecessor_sha256 is not None and (
+        not isinstance(predecessor_sha256, str)
+        or re.fullmatch(r"[0-9a-f]{64}", predecessor_sha256) is None
+        or predecessor_sha256 == receipt_sha256
+    ):
+        raise ValueError("the qualification receipt has stale or invalid predecessor lineage")
+    current = {
+        "kind": "claude_reviewer_current_selection",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest.get("entry_contract_id"),
+        "claude_selector": manifest.get("claude_selector"),
+        "receipt_path": str(receipt_path),
+        "receipt_sha256": receipt_sha256,
+    }
+    return current, receipt, receipt_bytes
 
 
 def file_identity_digest(identity: dict[str, object]) -> str:
@@ -723,7 +682,7 @@ def qualified_execution(
     if explicit_test_fixture:
         if selector is None:
             raise ValueError("test fixtures require an explicit absolute --claude-bin")
-        if launcher.with_name(INSTALLATION_MANIFEST_NAME).exists():
+        if installation_manifest_path(launcher).exists():
             raise ValueError("an installed production launcher cannot use test executable qualification")
         qualified = qualified_executable_identity(Path(selector), effective_uid)
         identity = {**qualified["file_identity"], "version": qualified["version"]}
@@ -789,9 +748,10 @@ def qualified_execution(
             "installation_manifest_sha256": sha256_bytes(manifest_path.read_bytes()),
             "installed_launcher_sha256": manifest.get("installed_launcher_sha256"),
             "active_rule_sha256": manifest.get("active_rule_sha256"),
-            "auth_diagnostics_directory": manifest.get("auth_diagnostics_directory"),
         }
     )
+    if manifest.get("auth_diagnostics_directory") is not None:
+        identity["auth_diagnostics_directory"] = manifest["auth_diagnostics_directory"]
     return str(Path(identity["resolved_path"])), identity
 
 
@@ -836,14 +796,13 @@ def qualify_claude_identity(
     expected_current_receipt_sha256: str,
     expected_observed_file_identity_sha256: str,
 ) -> int:
-    launcher, _, manifest = load_installed_entry(effective_uid)
-    lock_path = Path(str(manifest.get("qualification_lock_path", "")))
-    qualification_directory = Path(str(manifest.get("qualification_directory", "")))
-    if lock_path.parent != qualification_directory or lock_path.name != "qualification.lock":
-        raise ValueError("the qualification lock escaped its exact state directory")
-    secure_regular_bytes(lock_path, effective_uid, modes={0o600})
-    with lock_path.open("r+b") as lock_stream:
+    launcher, manifest_path, _ = load_installed_entry(effective_uid)
+    with launcher.open("rb") as lock_stream:
         fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
+        _, manifest_path, manifest = load_installed_entry(effective_uid)
+        predecessor_manifest_bytes = secure_regular_bytes(
+            manifest_path, effective_uid, modes={0o400}
+        )
         current, current_receipt, predecessor_current_bytes = current_qualification(manifest, effective_uid)
         if current["receipt_sha256"] != expected_current_receipt_sha256:
             raise ValueError("the qualification request names a stale predecessor receipt")
@@ -867,27 +826,20 @@ def qualify_claude_identity(
         if executable_file_identity(selector, effective_uid, forbidden_roots) != observed:
             raise ValueError("the Claude selector changed before qualification receipt creation")
         receipt = {
-            "kind": "claude_reviewer_qualification_receipt",
-            "schema_version": QUALIFICATION_SCHEMA_VERSION,
-            "entry_contract_id": manifest["entry_contract_id"],
-            "claude_selector": str(selector),
+            **manifest,
             "file_identity": observed,
             "version": version,
             "predecessor_receipt_sha256": current["receipt_sha256"],
-            "predecessor_receipt_path": current["receipt_path"],
             "producing_launcher_path": str(launcher),
             "producing_launcher_sha256": manifest["installed_launcher_sha256"],
+            "qualification_event": "identity_transition",
             "qualified_at_epoch": int(time.time()),
             "authority_semantics": "capability qualification only; grants zero task or review authority",
         }
         receipt_bytes = canonical_json_bytes(receipt)
         receipt_sha256 = sha256_bytes(receipt_bytes)
-        receipt_path = Path(str(manifest["qualification_receipts_directory"])) / f"{receipt_sha256}.json"
-        exclusive_write(receipt_path, receipt_bytes)
-        os.chmod(receipt_path, 0o400)
-        fsync_directory(receipt_path.parent)
-        current_path = Path(str(manifest["current_selection_path"]))
-        if secure_regular_bytes(current_path, effective_uid, modes={0o600}) != predecessor_current_bytes:
+        receipt_path = manifest_path
+        if predecessor_current_bytes != predecessor_manifest_bytes:
             raise ValueError("the current qualification changed before compare-and-swap")
         new_current = {
             "kind": "claude_reviewer_current_selection",
@@ -897,13 +849,16 @@ def qualify_claude_identity(
             "receipt_path": str(receipt_path),
             "receipt_sha256": receipt_sha256,
         }
-        atomic_replace_current_selection(
-            current_path,
-            new_current,
-            predecessor_current_bytes,
+        atomic_replace_qualification_receipt(
+            receipt_path,
+            receipt,
+            predecessor_manifest_bytes,
             effective_uid,
         )
-        validated_current, validated_receipt, _ = current_qualification(manifest, effective_uid)
+        _, _, validated_manifest = load_installed_entry(effective_uid)
+        validated_current, validated_receipt, _ = current_qualification(
+            validated_manifest, effective_uid
+        )
         if validated_current != new_current or validated_receipt != receipt:
             raise ValueError("the qualification compare-and-swap did not verify")
     print(json.dumps({"qualification_receipt_path": str(receipt_path), "qualification_receipt_sha256": receipt_sha256, "file_identity": observed, "version": version, "entry_contract_id": manifest["entry_contract_id"]}, sort_keys=True))
@@ -1138,22 +1093,23 @@ def fsync_directory(path: Path) -> None:
         os.close(descriptor)
 
 
-def atomic_replace_current_selection(
+def atomic_replace_qualification_receipt(
     path: Path,
     record: dict[str, Any],
     expected_bytes: bytes,
     effective_uid: int,
 ) -> None:
-    """Replace singular current state using an exact private compare-and-swap file."""
+    """Replace the singular current receipt using an exact compare-and-swap file."""
     temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
     created = False
     try:
         exclusive_write(temporary, canonical_json_bytes(record))
         created = True
-        temporary_bytes = secure_regular_bytes(temporary, effective_uid, modes={0o600})
+        os.chmod(temporary, 0o400)
+        temporary_bytes = secure_regular_bytes(temporary, effective_uid, modes={0o400})
         if temporary_bytes != canonical_json_bytes(record):
             raise ValueError(f"the qualification temporary state did not verify: {temporary}")
-        if secure_regular_bytes(path, effective_uid, modes={0o600}) != expected_bytes:
+        if secure_regular_bytes(path, effective_uid, modes={0o400}) != expected_bytes:
             raise ValueError("the current qualification changed before compare-and-swap")
         os.replace(temporary, path)
         created = False
@@ -1172,7 +1128,7 @@ def atomic_replace_current_selection(
                     and not temporary.is_symlink()
                     and stat.S_ISREG(metadata.st_mode)
                     and metadata.st_uid == effective_uid
-                    and stat.S_IMODE(metadata.st_mode) == 0o600
+                    and stat.S_IMODE(metadata.st_mode) == 0o400
                 ):
                     temporary.unlink()
                 else:
@@ -1912,8 +1868,40 @@ def classify_git_admin_changes(before: dict[str, object], after: dict[str, objec
             exact_other_admin = exact_other_worktree_admin(relative, old_identity, new_identity)
             admitted_worktree = admitted_other_worktree_change(relative, old_identity, new_identity)
             if lock_path(relative):
-                scope = "lock"
-                classification = "blocking_lock_change"
+                linked_identifier = (
+                    f"linked:{parts[1]}"
+                    if len(parts) >= 3 and parts[0] == "worktrees"
+                    else None
+                )
+                unlocked_ref = (
+                    ref_for_admin_path(relative.removesuffix(".lock"))
+                    if relative.endswith(".lock")
+                    else None
+                )
+                if linked_identifier in known_other_worktrees and protected_evidence_unchanged:
+                    scope = "other_linked_worktree"
+                    classification = "blocking_unattributed_other_worktree_administration"
+                    evidence = {
+                        "worktree_id": linked_identifier,
+                        "admitted_git_managed_path": relative,
+                        "provisional_attribution": "worktree_transition_not_yet_observed",
+                        "protected_candidate_evidence_unchanged": True,
+                    }
+                elif (
+                    unlocked_ref is not None
+                    and unlocked_ref not in protected_refs
+                    and protected_evidence_unchanged
+                ):
+                    scope = "unrelated_ref"
+                    classification = "blocking_unattributed_unrelated_ref_administration"
+                    evidence = {
+                        "ref": unlocked_ref,
+                        "provisional_attribution": "unrelated_ref_transition_not_yet_observed",
+                        "protected_candidate_evidence_unchanged": True,
+                    }
+                else:
+                    scope = "lock"
+                    classification = "blocking_lock_change"
             elif owner == "candidate_worktree":
                 scope = "candidate_worktree"
                 classification = "blocking_candidate_worktree_administration"
@@ -2091,7 +2079,12 @@ def provisional_attribution_only(comparison: dict[str, object]) -> bool:
             record["classification"] == "blocking_unattributed_other_worktree_administration"
             and evidence.get("provisional_attribution") == "worktree_transition_not_yet_observed"
         )
-        if not shared_object_provisional and not worktree_admin_provisional:
+        unrelated_ref_provisional = (
+            record["classification"] == "blocking_unattributed_unrelated_ref_administration"
+            and evidence.get("provisional_attribution")
+            == "unrelated_ref_transition_not_yet_observed"
+        )
+        if not shared_object_provisional and not worktree_admin_provisional and not unrelated_ref_provisional:
             return False
         repository_root = record.get("repository_root")
         prefix = f"git-admin:{repository_root}:" if repository_root else "git-admin:"
@@ -3108,7 +3101,7 @@ def run_governed_review(
             live_observed_tolerated_paths: set[str] = set()
             live_observed_git_admin_changes: dict[str, dict[str, object]] = {}
             provisional_object_change_since: float | None = None
-            provisional_object_stabilization_seconds = max(0.1, config.observation_interval * 2)
+            provisional_object_stabilization_seconds = max(1.0, config.observation_interval * 2)
             while process.poll() is None:
                 time.sleep(config.observation_interval)
                 external_state = merged_external_state(live_state_path, live_state)
@@ -3729,8 +3722,14 @@ def main(argv: list[str] | None = None) -> int:
             diagnostics_root = (
                 args.diagnostics_file.parent.resolve(strict=True)
                 if execution_identity.get("qualification") == "explicit_test_fixture"
-                else Path(str(execution_identity["auth_diagnostics_directory"]))
+                else Path(str(execution_identity.get("auth_diagnostics_directory", "")))
             )
+            if execution_identity.get("qualification") != "explicit_test_fixture" and not isinstance(
+                execution_identity.get("auth_diagnostics_directory"), str
+            ):
+                raise ValueError(
+                    "production auth diagnostics require an explicitly bound private directory"
+                )
             diagnostics_destination = qualified_diagnostics_destination(
                 args.diagnostics_file,
                 diagnostics_root,

--- a/scripts/codex-safe-rm
+++ b/scripts/codex-safe-rm
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Safely remove literal relative directory trees beneath the invocation cwd."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import sys
+
+
+CONTROL_NAME = "codex-safe-rm"
+CONTROL_VERSION = "1"
+_SAFE_COMPONENT = re.compile(r"[A-Za-z0-9._-]+\Z")
+
+
+class SafeRmError(Exception):
+    """A fail-closed validation or runtime-safety error."""
+
+
+@dataclass
+class PreparedTarget:
+    operand: str
+    parent_fd: int
+    leaf: str
+    exists: bool
+
+    def close(self) -> None:
+        os.close(self.parent_fd)
+
+
+def require_runtime_safety() -> None:
+    """Require the fd-relative and symlink-resistant primitives we rely on."""
+    missing: list[str] = []
+    if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+        missing.append("shutil.rmtree.avoids_symlink_attacks")
+    if "dir_fd" not in inspect.signature(shutil.rmtree).parameters:
+        missing.append("shutil.rmtree(dir_fd=...)")
+    if os.open not in os.supports_dir_fd:
+        missing.append("os.open(dir_fd=...)")
+    if os.stat not in os.supports_dir_fd:
+        missing.append("os.stat(dir_fd=...)")
+    if not hasattr(os, "O_DIRECTORY"):
+        missing.append("os.O_DIRECTORY")
+    if not hasattr(os, "O_NOFOLLOW"):
+        missing.append("os.O_NOFOLLOW")
+    if missing:
+        raise SafeRmError(
+            "runtime cannot provide required fd-relative, symlink-resistant removal: "
+            + ", ".join(missing)
+        )
+
+
+def validate_operand(operand: str, cwd: Path) -> tuple[str, ...]:
+    """Validate one literal relative directory operand."""
+    if not operand:
+        raise SafeRmError("empty deletion target is not allowed")
+    if os.path.isabs(operand):
+        raise SafeRmError(f"absolute deletion target is not allowed: {operand!r}")
+
+    components = tuple(operand.split("/"))
+    for component in components:
+        if not component:
+            raise SafeRmError(f"empty path component is not allowed: {operand!r}")
+        if component in {".", ".."}:
+            raise SafeRmError(f"dot path component is not allowed: {operand!r}")
+        if component.lower() == ".git":
+            raise SafeRmError(f"repository metadata directory is never removable: {operand!r}")
+        if _SAFE_COMPONENT.fullmatch(component) is None:
+            raise SafeRmError(f"non-literal or unsupported path component: {operand!r}")
+
+    resolved = (cwd / operand).resolve(strict=False)
+    try:
+        relative = resolved.relative_to(cwd)
+    except ValueError as error:
+        raise SafeRmError(
+            f"deletion target resolves outside the invocation cwd: {operand!r}"
+        ) from error
+    if not relative.parts:
+        raise SafeRmError(f"deletion target resolves to the invocation cwd: {operand!r}")
+    return components
+
+
+def remove_directories(operands: list[str], *, cwd: Path | None = None) -> None:
+    """Validate all operands, then remove them without pathname or shell fallback."""
+    require_runtime_safety()
+    if not operands:
+        raise SafeRmError("at least one directory operand is required")
+
+    invocation_cwd = (cwd or Path.cwd()).resolve(strict=True)
+    validated = [(operand, validate_operand(operand, invocation_cwd)) for operand in operands]
+    _reject_overlapping_targets(validated)
+
+    cwd_flags = os.O_RDONLY | os.O_DIRECTORY
+    if hasattr(os, "O_CLOEXEC"):
+        cwd_flags |= os.O_CLOEXEC
+    cwd_fd = os.open(invocation_cwd, cwd_flags)
+    prepared: list[PreparedTarget] = []
+    try:
+        for operand, components in validated:
+            prepared.append(_prepare_target(cwd_fd, operand, components))
+        for target in prepared:
+            if not target.exists:
+                continue
+            try:
+                shutil.rmtree(target.leaf, dir_fd=target.parent_fd)
+            except FileNotFoundError:
+                continue
+            except OSError as error:
+                raise SafeRmError(f"failed to remove {target.operand!r}: {error}") from error
+    finally:
+        for target in prepared:
+            target.close()
+        os.close(cwd_fd)
+
+
+def _prepare_target(cwd_fd: int, operand: str, components: tuple[str, ...]) -> PreparedTarget:
+    parent_fd = os.dup(cwd_fd)
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    try:
+        for component in components[:-1]:
+            try:
+                next_fd = os.open(component, flags, dir_fd=parent_fd)
+            except FileNotFoundError:
+                return PreparedTarget(operand, parent_fd, components[-1], False)
+            except OSError as error:
+                raise SafeRmError(
+                    "parent component is not a real directory or cannot be opened safely: "
+                    f"{operand!r}: {error}"
+                ) from error
+            os.close(parent_fd)
+            parent_fd = next_fd
+
+        leaf = components[-1]
+        try:
+            info = os.stat(leaf, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return PreparedTarget(operand, parent_fd, leaf, False)
+        if not stat.S_ISDIR(info.st_mode):
+            raise SafeRmError(f"deletion target is not a real directory: {operand!r}")
+        return PreparedTarget(operand, parent_fd, leaf, True)
+    except Exception:
+        os.close(parent_fd)
+        raise
+
+
+def _reject_overlapping_targets(validated: list[tuple[str, tuple[str, ...]]]) -> None:
+    for index, (left_operand, left) in enumerate(validated):
+        for right_operand, right in validated[index + 1 :]:
+            common = min(len(left), len(right))
+            if left[:common] == right[:common]:
+                raise SafeRmError(
+                    "overlapping deletion targets are not allowed: "
+                    f"{left_operand!r}, {right_operand!r}"
+                )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args == ["--version"]:
+        print(f"{CONTROL_NAME} {CONTROL_VERSION}")
+        return 0
+    if len(args) < 3 or args[:2] != ["-rf", "--"]:
+        print(f"usage: {CONTROL_NAME} -rf -- TARGET [TARGET ...]", file=sys.stderr)
+        return 2
+    try:
+        remove_directories(args[2:])
+    except (OSError, SafeRmError) as error:
+        print(f"{CONTROL_NAME}: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-claude-review
+++ b/scripts/install-claude-review
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import pwd
 import re
 import stat
 import subprocess
@@ -18,9 +19,9 @@ import tempfile
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_LAUNCHER = ROOT / "scripts" / "claude-review"
 RULE_TEMPLATE = ROOT / ".codex" / "rule-templates" / "claude-review.rules"
-INSTALLATION_SCHEMA_VERSION = 2
-QUALIFICATION_SCHEMA_VERSION = 2
-ENTRY_CONTRACT_SCHEMA_VERSION = 1
+INSTALLATION_SCHEMA_VERSION = 3
+QUALIFICATION_SCHEMA_VERSION = 3
+ENTRY_CONTRACT_SCHEMA_VERSION = 2
 MAX_ERROR_CHARS = 1_000
 
 
@@ -74,6 +75,33 @@ def git(*arguments: str) -> str:
 
 class QualificationRequiredError(ValueError):
     """Signal selector drift without mutating valid qualification state."""
+
+
+def effective_user_home() -> Path:
+    """Resolve the account home belonging to the effective user."""
+    try:
+        home = Path(pwd.getpwuid(os.geteuid()).pw_dir)
+    except KeyError as error:
+        raise ValueError("effective user has no account home directory") from error
+    if not home.is_absolute():
+        raise ValueError("effective user account home directory is not absolute")
+    try:
+        resolved_home = home.resolve(strict=True)
+    except OSError as error:
+        raise ValueError("effective user account home directory cannot be resolved") from error
+    if not resolved_home.is_dir():
+        raise ValueError("effective user account home is not a directory")
+    return resolved_home
+
+
+def production_install_root() -> Path:
+    """Return the one production publication directory."""
+    return effective_user_home() / ".local" / "bin"
+
+
+def production_active_rule() -> Path:
+    """Return the effective user's default active Codex rule path."""
+    return effective_user_home() / ".codex" / "rules" / "claude-review.rules"
 
 
 def exact_executable_file_identity(
@@ -285,6 +313,18 @@ def secure_private_directory(path: Path) -> None:
         raise ValueError(f"state directory is not exact private operator-controlled state: {path}")
 
 
+def secure_install_directory(path: Path) -> None:
+    metadata = path.lstat()
+    if (
+        path.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+        or path.resolve(strict=True) != path
+    ):
+        raise ValueError(f"install directory is not exact operator-controlled state: {path}")
+
+
 def secure_regular_bytes(path: Path, *, mode: int) -> bytes:
     metadata = path.lstat()
     if (
@@ -301,44 +341,12 @@ def secure_regular_bytes(path: Path, *, mode: int) -> bytes:
 def validated_existing_qualification(
     manifest: dict[str, object],
 ) -> tuple[dict[str, object], dict[str, object], bytes]:
-    """Apply the launcher's security invariants to existing singular state."""
-    qualification_directory = Path(str(manifest["qualification_directory"]))
-    receipts_directory = Path(str(manifest["qualification_receipts_directory"]))
-    current_path = Path(str(manifest["current_selection_path"]))
-    secure_private_directory(qualification_directory)
-    secure_private_directory(receipts_directory)
-    if receipts_directory.parent != qualification_directory or receipts_directory.name != "receipts":
-        raise ValueError("qualification receipts escaped the exact state directory")
-    if current_path.parent != qualification_directory or current_path.name != "current-selection.json":
-        raise ValueError("current selection escaped the exact state directory")
-    current_bytes = secure_regular_bytes(current_path, mode=0o600)
-    try:
-        current = json.loads(current_bytes)
-    except json.JSONDecodeError as error:
-        raise ValueError("existing current-selection record is malformed") from error
-    expected_current = {
-        "kind": "claude_reviewer_current_selection",
-        "schema_version": QUALIFICATION_SCHEMA_VERSION,
-        "entry_contract_id": manifest["entry_contract_id"],
-        "claude_selector": manifest["claude_selector"],
-    }
-    if not isinstance(current, dict) or any(
-        current.get(key) != value for key, value in expected_current.items()
-    ):
-        raise ValueError("existing current-selection record does not match the entry contract")
-    receipt_sha256 = current.get("receipt_sha256")
-    receipt_path = Path(str(current.get("receipt_path", "")))
-    if (
-        not isinstance(receipt_sha256, str)
-        or len(receipt_sha256) != 64
-        or any(character not in "0123456789abcdef" for character in receipt_sha256)
-        or receipt_path.parent != receipts_directory
-        or receipt_path.name != f"{receipt_sha256}.json"
-    ):
-        raise ValueError("existing current qualification receipt identity is invalid")
+    """Apply the launcher's security invariants to one combined entry record."""
+    launcher = Path(str(manifest["installed_launcher_path"]))
+    install_directory = Path(str(manifest["installation_directory"]))
+    receipt_path = install_directory / f".{launcher.name}.json"
+    secure_install_directory(install_directory)
     receipt_bytes = secure_regular_bytes(receipt_path, mode=0o400)
-    if digest(receipt_bytes) != receipt_sha256:
-        raise ValueError("existing current qualification receipt digest is invalid")
     try:
         receipt = json.loads(receipt_bytes)
     except json.JSONDecodeError as error:
@@ -368,39 +376,22 @@ def validated_existing_qualification(
     ):
         raise ValueError("existing qualification receipt does not match the entry contract")
     predecessor_sha256 = receipt.get("predecessor_receipt_sha256")
-    predecessor_path_value = receipt.get("predecessor_receipt_path")
-    if (predecessor_sha256 is None) != (predecessor_path_value is None):
-        raise ValueError("existing qualification receipt has ambiguous predecessor lineage")
-    if predecessor_sha256 is not None:
-        predecessor_path = Path(str(predecessor_path_value))
-        if (
-            not isinstance(predecessor_sha256, str)
-            or len(predecessor_sha256) != 64
-            or any(character not in "0123456789abcdef" for character in predecessor_sha256)
-            or predecessor_sha256 == receipt_sha256
-            or predecessor_path.parent != receipts_directory
-            or predecessor_path.name != f"{predecessor_sha256}.json"
-        ):
-            raise ValueError("existing qualification receipt has invalid predecessor lineage")
-        predecessor_bytes = secure_regular_bytes(predecessor_path, mode=0o400)
-        if digest(predecessor_bytes) != predecessor_sha256:
-            raise ValueError("existing qualification predecessor digest is invalid")
-        try:
-            predecessor = json.loads(predecessor_bytes)
-        except json.JSONDecodeError as error:
-            raise ValueError("existing qualification predecessor is malformed") from error
-        if not isinstance(predecessor, dict):
-            raise ValueError("existing qualification predecessor is malformed")
-        validate_recorded_file_identity(
-            predecessor.get("file_identity"), str(manifest["claude_selector"]), forbidden_roots
-        )
-        if (
-            any(predecessor.get(key) != value for key, value in required_receipt.items())
-            or not isinstance(predecessor.get("version"), str)
-            or not predecessor["version"]
-        ):
-            raise ValueError("existing qualification predecessor does not match the entry contract")
-    return current, receipt, current_bytes
+    if predecessor_sha256 is not None and (
+        not isinstance(predecessor_sha256, str)
+        or len(predecessor_sha256) != 64
+        or any(character not in "0123456789abcdef" for character in predecessor_sha256)
+        or predecessor_sha256 == digest(receipt_bytes)
+    ):
+        raise ValueError("existing qualification receipt has invalid predecessor lineage")
+    current = {
+        "kind": "claude_reviewer_current_selection",
+        "schema_version": QUALIFICATION_SCHEMA_VERSION,
+        "entry_contract_id": manifest["entry_contract_id"],
+        "claude_selector": manifest["claude_selector"],
+        "receipt_path": str(receipt_path),
+        "receipt_sha256": digest(receipt_bytes),
+    }
+    return current, receipt, receipt_bytes
 
 
 def replace_expected(path: Path, payload: bytes, expected_sha256: str | None) -> dict[str, object]:
@@ -439,38 +430,27 @@ def replace_expected(path: Path, payload: bytes, expected_sha256: str | None) ->
     return {"result": "replaced" if prior else "created", "prior": prior}
 
 
-def parse_arguments() -> argparse.Namespace:
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--claude-bin", required=True, type=Path)
     parser.add_argument(
-        "--install-root",
-        type=Path,
-        default=Path.home() / ".local" / "libexec" / "ai-workflow-playbook" / "claude-review",
-    )
-    parser.add_argument(
         "--active-rule",
         type=Path,
-        default=Path.home() / ".codex" / "rules" / "claude-review.rules",
+        default=production_active_rule(),
     )
     parser.add_argument("--activation-receipt", required=True, type=Path)
-    parser.add_argument(
-        "--qualification-root",
-        type=Path,
-        default=Path.home() / ".local" / "state" / "ai-workflow-playbook" / "claude-review",
-    )
     parser.add_argument("--expected-existing-rule-sha256")
     parser.add_argument("--forbidden-root", action="append", default=[], type=Path)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def main() -> int:
     args = parse_arguments()
-    args.install_root = args.install_root.resolve(strict=False)
+    args.install_root = production_install_root().resolve(strict=False)
     args.active_rule = args.active_rule.parent.resolve(strict=False) / args.active_rule.name
     args.activation_receipt = (
         args.activation_receipt.parent.resolve(strict=False) / args.activation_receipt.name
     )
-    args.qualification_root = args.qualification_root.resolve(strict=False)
     if args.activation_receipt.exists() or args.activation_receipt.is_symlink():
         raise ValueError("activation receipt destination must be absent")
     status = git("status", "--porcelain=v1", "--untracked-files=all")
@@ -485,10 +465,8 @@ def main() -> int:
     validate_destination(args.install_root, forbidden)
     validate_destination(args.active_rule, forbidden)
     validate_destination(args.activation_receipt, forbidden)
-    validate_destination(args.qualification_root, forbidden)
-    auth_diagnostics_directory = args.activation_receipt.parent
-    auth_diagnostics_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    secure_private_directory(auth_diagnostics_directory)
+    if args.activation_receipt.parent.exists():
+        secure_private_directory(args.activation_receipt.parent)
     initial_file_identity = exact_executable_file_identity(args.claude_bin, forbidden)
     immutable_contract = {
         "entry_contract_schema_version": ENTRY_CONTRACT_SCHEMA_VERSION,
@@ -499,34 +477,19 @@ def main() -> int:
         "claude_selector": str(args.claude_bin),
         "active_rule_path": str(args.active_rule),
         "forbidden_roots": [str(root) for root in forbidden],
-        "auth_diagnostics_directory": str(auth_diagnostics_directory),
-        "qualification_root": str(args.qualification_root),
+        "installation_directory": str(args.install_root),
     }
     contract_id = entry_contract_identity(immutable_contract)
-    version_directory = args.install_root / f"entry-{contract_id.removeprefix('sha256:')}"
-    version_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    secure_private_directory(version_directory)
-    installed_launcher = version_directory / "claude-review"
+    args.activation_receipt.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    secure_private_directory(args.activation_receipt.parent)
+    args.install_root.mkdir(parents=True, exist_ok=True, mode=0o755)
+    secure_install_directory(args.install_root)
+    launcher_name = "claude-review"
+    installed_launcher = args.install_root / launcher_name
     rendered_rule = RULE_TEMPLATE.read_text(encoding="utf-8").replace(
         "__CLAUDE_REVIEW_LAUNCHER__", str(installed_launcher)
     ).encode("utf-8")
     active_rule_sha256 = digest(rendered_rule)
-    qualification_directory = args.qualification_root / contract_id.removeprefix("sha256:")
-    receipts_directory = qualification_directory / "receipts"
-    qualification_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    receipts_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    for directory in (qualification_directory, receipts_directory):
-        metadata = directory.lstat()
-        if (
-            directory.is_symlink()
-            or not stat.S_ISDIR(metadata.st_mode)
-            or metadata.st_uid != os.geteuid()
-            or stat.S_IMODE(metadata.st_mode) & 0o077
-            or directory.resolve(strict=True) != directory
-        ):
-            raise ValueError("qualification state directory is not exact private operator-controlled state")
-    current_selection = qualification_directory / "current-selection.json"
-    qualification_lock = qualification_directory / "qualification.lock"
     manifest = {
         "schema_version": INSTALLATION_SCHEMA_VERSION,
         "entry_contract_id": contract_id,
@@ -537,60 +500,60 @@ def main() -> int:
         "active_rule_sha256": active_rule_sha256,
         "claude_selector": str(args.claude_bin),
         "forbidden_roots": [str(root) for root in forbidden],
-        "auth_diagnostics_directory": str(auth_diagnostics_directory),
         "qualification_schema_version": QUALIFICATION_SCHEMA_VERSION,
-        "qualification_directory": str(qualification_directory),
-        "qualification_receipts_directory": str(receipts_directory),
-        "current_selection_path": str(current_selection),
-        "qualification_lock_path": str(qualification_lock),
+        "installation_directory": str(args.install_root),
     }
     launcher_result = exclusive_or_identical(installed_launcher, launcher_bytes, 0o500)
-    manifest_path = version_directory / "claude-review-installation.json"
-    manifest_bytes = canonical(manifest)
-    manifest_result = exclusive_or_identical(manifest_path, manifest_bytes, 0o400)
-    exclusive_or_identical(qualification_lock, b"claude-review qualification lock\n", 0o600)
-    if current_selection.exists() or current_selection.is_symlink():
+    manifest_path = args.install_root / f".{launcher_name}.json"
+    if manifest_path.exists() or manifest_path.is_symlink():
+        manifest_bytes = secure_regular_bytes(manifest_path, mode=0o400)
+        try:
+            existing_manifest = json.loads(manifest_bytes)
+        except json.JSONDecodeError as error:
+            raise ValueError("existing combined installation record is malformed") from error
+        if not isinstance(existing_manifest, dict) or any(
+            existing_manifest.get(key) != value for key, value in manifest.items()
+        ):
+            raise ValueError("existing combined installation record does not match this entry")
+        manifest = existing_manifest
         current_record, current_receipt, _ = validated_existing_qualification(manifest)
         observed_file_identity = exact_executable_file_identity(args.claude_bin, forbidden)
         if current_receipt["file_identity"] != observed_file_identity:
             raise QualificationRequiredError(
                 "qualification required: the configured Claude selector no longer matches the valid current receipt"
             )
+        manifest_result = "existing_identical"
     else:
-        if any(receipts_directory.iterdir()):
-            raise ValueError("qualification receipts exist without singular current-selection state")
+        if launcher_result != "created":
+            raise ValueError(
+                "existing launcher is missing its combined installation and qualification record"
+            )
         qualified_identity = qualified_executable_identity(args.claude_bin, forbidden)
         if qualified_identity["file_identity"] != initial_file_identity:
             raise ValueError("Claude selector changed before initial qualification state creation")
-        initial_receipt = {
+        manifest.update({
             "kind": "claude_reviewer_qualification_receipt",
-            "schema_version": QUALIFICATION_SCHEMA_VERSION,
-            "entry_contract_id": contract_id,
-            "claude_selector": str(args.claude_bin),
             "file_identity": qualified_identity["file_identity"],
             "version": qualified_identity["version"],
             "predecessor_receipt_sha256": None,
-            "predecessor_receipt_path": None,
             "producing_launcher_path": str(installed_launcher),
             "producing_launcher_sha256": launcher_sha256,
             "qualification_event": "initial_installation",
             "authority_semantics": "capability qualification only; grants zero task or review authority",
-        }
-        initial_receipt_bytes = canonical(initial_receipt)
+        })
+        initial_receipt_bytes = canonical(manifest)
         initial_receipt_sha256 = digest(initial_receipt_bytes)
-        initial_receipt_path = receipts_directory / f"{initial_receipt_sha256}.json"
-        exclusive_or_identical(initial_receipt_path, initial_receipt_bytes, 0o400)
-        fsync_directory(receipts_directory)
+        manifest_result = exclusive_or_identical(manifest_path, initial_receipt_bytes, 0o400)
+        fsync_directory(args.install_root)
         current_record = {
             "kind": "claude_reviewer_current_selection",
             "schema_version": QUALIFICATION_SCHEMA_VERSION,
             "entry_contract_id": contract_id,
             "claude_selector": str(args.claude_bin),
-            "receipt_path": str(initial_receipt_path),
+            "receipt_path": str(manifest_path),
             "receipt_sha256": initial_receipt_sha256,
         }
-        exclusive_or_identical(current_selection, canonical(current_record), 0o600)
-        fsync_directory(qualification_directory)
+        manifest_bytes = initial_receipt_bytes
     source_provenance = {
         "kind": "claude_review_source_provenance",
         "schema_version": 1,
@@ -603,16 +566,13 @@ def main() -> int:
         "source_rule_template_path": str(RULE_TEMPLATE),
         "source_rule_template_sha256": source_rule_sha256,
     }
-    provenance_path = version_directory / f"source-provenance-{commit}.json"
-    provenance_result = exclusive_or_identical(provenance_path, canonical(source_provenance), 0o400)
     rule_result = replace_expected(args.active_rule, rendered_rule, args.expected_existing_rule_sha256)
     receipt = {
-        "kind": "claude_review_activation_receipt",
         **manifest,
+        "kind": "claude_review_activation_receipt",
         "source_commit": commit,
         "source_remote": source_remote,
-        "source_provenance_path": str(provenance_path),
-        "source_provenance_result": provenance_result,
+        "source_provenance": source_provenance,
         "installation_manifest_path": str(manifest_path),
         "installation_manifest_sha256": digest(manifest_bytes),
         "launcher_result": launcher_result,
@@ -621,7 +581,6 @@ def main() -> int:
         "qualification_receipt_path": current_record["receipt_path"],
         "qualification_receipt_sha256": current_record["receipt_sha256"],
     }
-    args.activation_receipt.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     exclusive_or_identical(args.activation_receipt, canonical(receipt), 0o600)
     print(json.dumps(receipt, sort_keys=True))
     return 0

--- a/scripts/install-codex-safe-rm
+++ b/scripts/install-codex-safe-rm
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Install, verify, and uninstall the reviewed codex-safe-rm control."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import pwd
+import stat
+import subprocess
+import sys
+import tempfile
+
+
+SCHEMA_VERSION = 2
+CONTROL_NAME = "codex-safe-rm"
+CONTROL_VERSION = "1"
+SOURCE_REPOSITORY = "ctrl-alt-keith/ai-workflow-playbook"
+SOURCE_RELATIVE_PATH = "scripts/codex-safe-rm"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LEGACY_SOURCE_REPOSITORY = "ctrl-alt-keith/ai-workflow-enforcement"
+LEGACY_SOURCE_RELATIVE_PATH = "enforcement/safe_rm.py"
+
+
+class InstallError(Exception):
+    """An installation ownership, provenance, or integrity error."""
+
+
+def production_destination() -> Path:
+    """Derive the single production destination from the effective user."""
+    try:
+        home = Path(pwd.getpwuid(os.geteuid()).pw_dir)
+    except KeyError as error:
+        raise InstallError("effective user has no account home directory") from error
+    if not home.is_absolute():
+        raise InstallError("effective user account home directory is not absolute")
+    try:
+        resolved_home = home.resolve(strict=True)
+    except OSError as error:
+        raise InstallError("effective user account home directory cannot be resolved") from error
+    if not resolved_home.is_dir():
+        raise InstallError("effective user account home is not a directory")
+    return resolved_home / ".local" / "bin" / CONTROL_NAME
+
+
+def metadata_path(destination: Path) -> Path:
+    return destination.with_name(f".{destination.name}.install.json")
+
+
+def install(
+    destination: Path,
+    *,
+    source: Path | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    source_path, root = _source_context(source, repo_root)
+    source_bytes, commit = _capture_install_source(root)
+    source_digest = _sha256(source_bytes)
+    metadata = {
+        "schema_version": SCHEMA_VERSION,
+        "control": CONTROL_NAME,
+        "control_version": CONTROL_VERSION,
+        "source_repository": SOURCE_REPOSITORY,
+        "source_path": SOURCE_RELATIVE_PATH,
+        "source_commit": commit,
+        "source_sha256": source_digest,
+        "installed_sha256": source_digest,
+    }
+
+    destination.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
+    _validate_install_directory(destination.parent)
+    record = metadata_path(destination)
+    if destination.exists() or destination.is_symlink() or record.exists() or record.is_symlink():
+        try:
+            _verify_owned_pair(destination, record)
+        except InstallError:
+            try:
+                _verify_legacy_owned_pair(destination, record)
+            except InstallError as legacy_error:
+                raise InstallError(
+                    f"refusing to replace unrecognized or inconsistent destination {destination}"
+                ) from legacy_error
+
+    executable_tmp = _write_temp(destination.parent, source_bytes, 0o755)
+    metadata_bytes = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    metadata_tmp = _write_temp(destination.parent, metadata_bytes, 0o644)
+    try:
+        os.replace(executable_tmp, destination)
+        os.replace(metadata_tmp, record)
+        _fsync_directory(destination.parent)
+    finally:
+        _unlink_if_present(executable_tmp)
+        _unlink_if_present(metadata_tmp)
+    return metadata
+
+
+def verify(
+    destination: Path,
+    *,
+    source: Path | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    source_path, root = _source_context(source, repo_root)
+    _validate_install_directory(destination.parent)
+    record = metadata_path(destination)
+    metadata = _verify_owned_pair(destination, record)
+    installed_digest = _sha256(destination.read_bytes())
+    source_digest = _sha256(source_path.read_bytes())
+    if installed_digest != source_digest or metadata.get("source_sha256") != source_digest:
+        raise InstallError("installed executable does not match the current reviewed Playbook source")
+    commit = _git_text(root, "rev-parse", "HEAD").strip()
+    if _git_status(root):
+        raise InstallError("source checkout is dirty")
+    if metadata.get("source_commit") != commit:
+        raise InstallError("installed provenance does not match the current Playbook checkout")
+    mode = destination.stat().st_mode
+    if not stat.S_ISREG(mode) or stat.S_IMODE(mode) != 0o755:
+        raise InstallError("installed control is not an exact regular executable file")
+    result = subprocess.run(
+        (str(destination), "--version"),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    expected = f"{CONTROL_NAME} {CONTROL_VERSION}"
+    if result.returncode != 0 or result.stdout.strip() != expected or result.stderr:
+        raise InstallError("installed control version check failed")
+    return metadata
+
+
+def uninstall(destination: Path) -> None:
+    record = metadata_path(destination)
+    if not destination.exists() and not destination.is_symlink() and not record.exists():
+        return
+    _validate_install_directory(destination.parent)
+    _verify_owned_pair(destination, record)
+    destination.unlink()
+    record.unlink()
+    _fsync_directory(destination.parent)
+
+
+def _source_context(source: Path | None, repo_root: Path | None) -> tuple[Path, Path]:
+    root = (repo_root or REPO_ROOT).resolve()
+    source_path = (source or root / SOURCE_RELATIVE_PATH).resolve()
+    if not source_path.is_file():
+        raise InstallError(f"reviewed source is missing: {source_path}")
+    return source_path, root
+
+
+def _capture_install_source(repo_root: Path) -> tuple[bytes, str]:
+    commit = _git_text(repo_root, "rev-parse", "HEAD").strip()
+    if _git_status(repo_root):
+        raise InstallError("source checkout is dirty; commit and review the exact source first")
+    return _git_bytes(repo_root, "show", f"{commit}:{SOURCE_RELATIVE_PATH}"), commit
+
+
+def _git_status(repo_root: Path) -> str:
+    return _git_text(repo_root, "status", "--porcelain=v1", "--untracked-files=all")
+
+
+def _git_text(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo_root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise InstallError(f"cannot determine source provenance: git {' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def _git_bytes(repo_root: Path, *args: str) -> bytes:
+    result = subprocess.run(
+        ("git", *args),
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip() or f"exit {result.returncode}"
+        raise InstallError(f"cannot read committed source: git {' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def _validate_install_directory(directory: Path) -> None:
+    metadata = directory.lstat()
+    if (
+        directory.is_symlink()
+        or not stat.S_ISDIR(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+        or directory.resolve(strict=True) != directory
+    ):
+        raise InstallError(f"install directory is not exact operator-controlled state: {directory}")
+
+
+def _verify_owned_pair(destination: Path, record: Path) -> dict[str, object]:
+    if not destination.exists() or destination.is_symlink():
+        raise InstallError("installed executable is missing or is a symlink")
+    if not record.is_file() or record.is_symlink():
+        raise InstallError("installation metadata is missing or is a symlink")
+    destination_metadata = destination.lstat()
+    record_metadata = record.lstat()
+    if (
+        destination_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(destination_metadata.st_mode) != 0o755
+        or record_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(record_metadata.st_mode) != 0o644
+    ):
+        raise InstallError("installed pair ownership or mode is invalid")
+    try:
+        metadata = json.loads(record.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise InstallError("installation metadata is unreadable or invalid") from error
+    expected_identity = {
+        "schema_version": SCHEMA_VERSION,
+        "control": CONTROL_NAME,
+        "control_version": CONTROL_VERSION,
+        "source_repository": SOURCE_REPOSITORY,
+        "source_path": SOURCE_RELATIVE_PATH,
+    }
+    for key, expected in expected_identity.items():
+        if metadata.get(key) != expected:
+            raise InstallError(f"installation metadata ownership mismatch: {key}")
+    digest = _sha256(destination.read_bytes())
+    if metadata.get("installed_sha256") != digest or metadata.get("source_sha256") != digest:
+        raise InstallError("installed executable and metadata digest mismatch")
+    if not isinstance(metadata.get("source_commit"), str) or not metadata["source_commit"]:
+        raise InstallError("installation metadata source commit is missing")
+    return metadata
+
+
+def _verify_legacy_owned_pair(destination: Path, record: Path) -> dict[str, object]:
+    """Recognize only the exact predecessor pair owned by Enforcement."""
+    if not destination.exists() or destination.is_symlink():
+        raise InstallError("legacy installed executable is missing or is a symlink")
+    if not record.is_file() or record.is_symlink():
+        raise InstallError("legacy installation metadata is missing or is a symlink")
+    destination_metadata = destination.lstat()
+    record_metadata = record.lstat()
+    if (
+        destination_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(destination_metadata.st_mode) != 0o755
+        or record_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(record_metadata.st_mode) != 0o644
+    ):
+        raise InstallError("legacy installed pair ownership or mode is invalid")
+    try:
+        metadata = json.loads(record.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise InstallError("legacy installation metadata is unreadable or invalid") from error
+    expected_identity = {
+        "schema_version": 1,
+        "control": CONTROL_NAME,
+        "control_version": CONTROL_VERSION,
+        "source_repository": LEGACY_SOURCE_REPOSITORY,
+        "source_path": LEGACY_SOURCE_RELATIVE_PATH,
+    }
+    for key, expected in expected_identity.items():
+        if metadata.get(key) != expected:
+            raise InstallError(f"legacy installation metadata ownership mismatch: {key}")
+    digest = _sha256(destination.read_bytes())
+    if metadata.get("installed_sha256") != digest or metadata.get("source_sha256") != digest:
+        raise InstallError("legacy installed executable and metadata digest mismatch")
+    if not isinstance(metadata.get("source_commit"), str) or not metadata["source_commit"]:
+        raise InstallError("legacy installation metadata source commit is missing")
+    if metadata.get("source_dirty") is not False:
+        raise InstallError("legacy installation metadata is not from a clean source checkout")
+    return metadata
+
+
+def _write_temp(directory: Path, content: bytes, mode: int) -> Path:
+    descriptor, raw_path = tempfile.mkstemp(prefix=f".{CONTROL_NAME}.", dir=directory)
+    path = Path(raw_path)
+    descriptor_open = True
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            descriptor_open = False
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except Exception:
+        if descriptor_open:
+            os.close(descriptor)
+        _unlink_if_present(path)
+        raise
+    return path
+
+
+def _fsync_directory(directory: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(directory, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _unlink_if_present(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    actions = parser.add_subparsers(dest="action", required=True)
+    for action in ("install", "verify", "uninstall"):
+        actions.add_parser(action)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        destination = production_destination()
+        if args.action == "install":
+            metadata = install(destination)
+            print(
+                f"installed {CONTROL_NAME} {metadata['control_version']} at {destination} "
+                f"from {metadata['source_commit']}"
+            )
+        elif args.action == "verify":
+            metadata = verify(destination)
+            print(
+                f"verified {CONTROL_NAME} {metadata['control_version']} at {destination} "
+                f"sha256={metadata['installed_sha256']}"
+            )
+        else:
+            uninstall(destination)
+            print(f"uninstalled {CONTROL_NAME} from {destination}")
+    except (InstallError, OSError) as error:
+        print(f"{CONTROL_NAME} installer: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cak_local_asset_path_ratchet.py
+++ b/tests/test_cak_local_asset_path_ratchet.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Ratchet CAK local placement across active code, policy, and guidance."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# These are the reviewed active references at the CAK-178 implementation
+# baseline. New entries require an explicit ownership review rather than
+# silently extending local placement.
+EXPECTED_LOCAL_REFERENCES = {
+    (
+        "docs/tool-adapters/claude.md",
+        "runtime `HOME` recorded in the attempt receipt and prove that `.local`,",
+    ),
+    (
+        "docs/tool-adapters/codex.md",
+        "~/.local/bin/codex-safe-rm -rf -- TARGET [TARGET ...]",
+    ),
+    (
+        "docs/tool-adapters/codex.md",
+        "installer publishes the stable command `~/.local/bin/claude-review` with one",
+    ),
+    (
+        "docs/tool-adapters/codex.md",
+        "`~/.local/bin/.claude-review.json`. The content digest remains in that record",
+    ),
+    (
+        "scripts/install-claude-review",
+        'return effective_user_home() / ".local" / "bin"',
+    ),
+    (
+        "scripts/install-codex-safe-rm",
+        'return resolved_home / ".local" / "bin" / CONTROL_NAME',
+    ),
+}
+
+# Executable sources, reusable guidance, and checked-in Codex policy/templates
+# are the active surfaces that can establish CAK-managed production placement.
+# Tests, fixtures, and historical evidence are intentionally outside this
+# placement-ownership guarantee.
+ACTIVE_SURFACE_ROOTS = (ROOT / "scripts", ROOT / "docs", ROOT / ".codex")
+
+
+class CakLocalAssetPathRatchetTests(unittest.TestCase):
+    def test_active_code_policy_and_guidance_local_references_do_not_expand(self) -> None:
+        observed: set[tuple[str, str]] = set()
+
+        for search_root in ACTIVE_SURFACE_ROOTS:
+            for path in search_root.rglob("*"):
+                if not path.is_file() or "__pycache__" in path.parts:
+                    continue
+                relative = path.relative_to(ROOT).as_posix()
+                for line in path.read_text(encoding="utf-8").splitlines():
+                    if ".local" in line:
+                        observed.add((relative, line.strip()))
+
+        self.assertEqual(EXPECTED_LOCAL_REFERENCES, observed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -43,8 +43,8 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
     def create_installed_fixture(self, root: Path):
         installed = root / "installed"
-        installed.mkdir(mode=0o700)
-        launcher = installed / "claude-review"
+        installed.mkdir(mode=0o755)
+        launcher = installed / "claude-review-fixture"
         launcher_bytes = LAUNCHER.read_bytes()
         launcher.write_bytes(launcher_bytes)
         launcher.chmod(0o500)
@@ -79,33 +79,24 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 selector, os.geteuid(), [candidate]
             )
         marker.unlink()
-        qualification_root = root / "qualification-root"
         entry_contract = {
-            "entry_contract_schema_version": 1,
-            "installation_schema_version": 2,
-            "qualification_schema_version": 2,
+            "entry_contract_schema_version": 2,
+            "installation_schema_version": 3,
+            "qualification_schema_version": 3,
             "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
             "rule_template_sha256": "fixture-rule-template",
             "claude_selector": str(selector),
             "active_rule_path": str(active_rule),
             "forbidden_roots": [str(candidate)],
             "auth_diagnostics_directory": str(auth_diagnostics),
-            "qualification_root": str(qualification_root),
+            "installation_directory": str(installed),
         }
         entry_contract_id = "sha256:" + self.launcher.sha256_bytes(
             self.launcher.canonical_json_bytes(entry_contract)
         )
-        qualification = qualification_root / entry_contract_id.removeprefix("sha256:")
-        receipts = qualification / "receipts"
-        receipts.mkdir(parents=True)
-        qualification_root.chmod(0o700)
-        qualification.chmod(0o700)
-        receipts.chmod(0o700)
-        lock = qualification / "qualification.lock"
-        lock.write_text("fixture lock\n", encoding="utf-8")
-        lock.chmod(0o600)
+        receipt_path = installed / f".{launcher.name}.json"
         manifest = {
-            "schema_version": 2,
+            "schema_version": 3,
             "entry_contract_id": entry_contract_id,
             "entry_contract": entry_contract,
             "installed_launcher_path": str(launcher),
@@ -115,44 +106,35 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             "claude_selector": str(selector),
             "forbidden_roots": [str(candidate)],
             "auth_diagnostics_directory": str(auth_diagnostics),
-            "qualification_schema_version": 2,
-            "qualification_directory": str(qualification),
-            "qualification_receipts_directory": str(receipts),
-            "current_selection_path": str(qualification / "current-selection.json"),
-            "qualification_lock_path": str(lock),
+            "qualification_schema_version": 3,
+            "installation_directory": str(installed),
         }
         receipt = {
             "kind": "claude_reviewer_qualification_receipt",
-            "schema_version": 2,
+            "schema_version": 3,
             "entry_contract_id": entry_contract_id,
             "claude_selector": str(selector),
             "file_identity": qualified_identity["file_identity"],
             "version": qualified_identity["version"],
             "predecessor_receipt_sha256": None,
-            "predecessor_receipt_path": None,
             "producing_launcher_path": str(launcher),
             "producing_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
             "authority_semantics": "capability qualification only; grants zero task or review authority",
         }
-        receipt_bytes = self.launcher.canonical_json_bytes(receipt)
+        manifest.update(receipt)
+        receipt_bytes = self.launcher.canonical_json_bytes(manifest)
         receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
-        receipt_path = receipts / f"{receipt_sha256}.json"
         receipt_path.write_bytes(receipt_bytes)
         receipt_path.chmod(0o400)
         current = {
             "kind": "claude_reviewer_current_selection",
-            "schema_version": 2,
+            "schema_version": 3,
             "entry_contract_id": entry_contract_id,
             "claude_selector": str(selector),
             "receipt_path": str(receipt_path),
             "receipt_sha256": receipt_sha256,
         }
-        current_path = qualification / "current-selection.json"
-        current_path.write_bytes(self.launcher.canonical_json_bytes(current))
-        current_path.chmod(0o600)
-        manifest_path = installed / "claude-review-installation.json"
-        manifest_path.write_bytes(self.launcher.canonical_json_bytes(manifest))
-        manifest_path.chmod(0o400)
+        manifest_path = receipt_path
         return {
             "launcher": launcher,
             "launcher_bytes": launcher_bytes,
@@ -164,9 +146,12 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             "selector": selector,
             "manifest": manifest,
             "manifest_path": manifest_path,
-            "qualification": qualification,
-            "receipts": receipts,
-            "current_path": current_path,
+            "installation_directory": installed,
+            # Compatibility aliases keep mutation-focused tests concise while
+            # the production schema stores one flat current receipt.
+            "qualification": installed,
+            "receipts": installed,
+            "current_path": receipt_path,
             "current": current,
             "receipt_path": receipt_path,
         }
@@ -187,10 +172,8 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         activation_receipt = root / "activation" / activation_name
         arguments = SimpleNamespace(
             claude_bin=selector,
-            install_root=root / "install-root",
             active_rule=root / "active.rules",
             activation_receipt=activation_receipt,
-            qualification_root=root / "qualification-root",
             expected_existing_rule_sha256=None,
             forbidden_root=[],
         )
@@ -205,9 +188,13 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             raise AssertionError(git_arguments)
 
         output = io.StringIO()
-        with mock.patch.object(self.installer, "parse_arguments", return_value=arguments), mock.patch.object(
-            self.installer, "git", side_effect=fake_git
-        ), contextlib.redirect_stdout(output):
+        with mock.patch.object(
+            self.installer, "parse_arguments", return_value=arguments
+        ), mock.patch.object(
+            self.installer, "production_install_root", return_value=root / "install-root"
+        ), mock.patch.object(self.installer, "git", side_effect=fake_git), contextlib.redirect_stdout(
+            output
+        ):
             self.assertEqual(self.installer.main(), 0)
         return json.loads(output.getvalue()), activation_receipt
 
@@ -231,12 +218,43 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
         self.assertNotIn('decision="allow"', rule)
         self.assertIn('decision="prompt"', rule)
 
+    def test_installer_cli_rejects_alternate_install_root_while_fixture_seam_isolated(self):
+        arguments = [
+            "--claude-bin",
+            "/operator/bin/claude",
+            "--activation-receipt",
+            "/private/receipt.json",
+            "--install-root",
+            "/alternate/bin",
+        ]
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            self.installer.parse_arguments(arguments)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            installed, _ = self.run_installer(root, selector, "activation.json", "1" * 40)
+            self.assertEqual(installed["installation_directory"], str(root / "install-root"))
+
+    def test_installer_production_root_uses_effective_account_home_not_environment(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            account_home = Path(temporary_directory).resolve() / "account-home"
+            account_home.mkdir()
+            account = mock.Mock(pw_dir=str(account_home))
+            with mock.patch.object(
+                self.installer.pwd, "getpwuid", return_value=account
+            ), mock.patch.dict(os.environ, {"HOME": "/attacker-selected-home"}):
+                self.assertEqual(
+                    self.installer.production_install_root(),
+                    account_home / ".local" / "bin",
+                )
+
     def test_rule_template_binds_only_one_exact_absolute_launcher(self):
         template = CODEX_RULE_TEMPLATE.read_text(encoding="utf-8")
-        rendered = template.replace("__CLAUDE_REVIEW_LAUNCHER__", "/operator/libexec/cak-155/claude-review")
+        rendered = template.replace("__CLAUDE_REVIEW_LAUNCHER__", "/operator/bin/claude-review")
         self.assertEqual(rendered.count('decision="allow"'), 2)
-        self.assertIn('["/operator/libexec/cak-155/claude-review", "--auth-preflight"]', rendered)
-        self.assertIn('["/operator/libexec/cak-155/claude-review", "--review-config"]', rendered)
+        self.assertIn('["/operator/bin/claude-review", "--auth-preflight"]', rendered)
+        self.assertIn('["/operator/bin/claude-review", "--review-config"]', rendered)
         self.assertIn('"--qualify-claude-identity"', rendered)
         self.assertEqual(rendered.count('decision="prompt"'), 1)
         self.assertNotIn("./scripts/claude-review", rendered)
@@ -312,7 +330,9 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertEqual(qualification_result["file_identity"]["resolved_path"], str(fixture["versions"][1]))
             self.assertEqual(self.launcher.sha256_bytes(fixture["launcher"].read_bytes()), launcher_sha256)
             self.assertEqual(fixture["active_rule"].read_bytes(), rule_bytes)
-            self.assertEqual(fixture["manifest_path"].read_bytes(), self.launcher.canonical_json_bytes(fixture["manifest"]))
+            updated_record = json.loads(fixture["manifest_path"].read_text(encoding="utf-8"))
+            self.assertEqual(updated_record["entry_contract"], fixture["manifest"]["entry_contract"])
+            self.assertEqual(updated_record["file_identity"], observed)
 
             post, post_diagnostics = self.run_production_preflight(fixture, "accepted-v2")
             self.assertEqual(post.returncode, 0, post.stderr)
@@ -384,6 +404,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             receipt = json.loads(Path(result["qualification_receipt_path"]).read_text(encoding="utf-8"))
             self.assertEqual(receipt["file_identity"], observed)
             self.assertEqual(receipt["version"], "malicious-claude 2")
+            self.assertEqual(receipt["qualification_event"], "identity_transition")
 
     def test_noop_qualification_is_rejected_without_execution_or_state_change(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -462,7 +483,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 self.assertEqual(fixture["current_path"].read_bytes(), before_current)
                 self.assertEqual({path.name for path in fixture["receipts"].iterdir()}, before_receipts)
 
-    def test_runtime_qualification_fsyncs_receipt_directory_before_current_selection(self):
+    def test_runtime_qualification_replaces_only_the_flat_receipt(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
             installed_module = load_script("claude_review_receipt_durability", fixture["launcher"])
@@ -472,17 +493,14 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 fixture["selector"], os.geteuid(), [fixture["candidate"]]
             )
             events = []
-            original_replace = installed_module.atomic_replace_current_selection
-
-            def record_fsync(path):
-                events.append(("fsync", path))
+            original_replace = installed_module.atomic_replace_qualification_receipt
 
             def record_replace(*arguments):
                 events.append(("replace", arguments[0]))
                 return original_replace(*arguments)
 
-            with mock.patch.object(installed_module, "fsync_directory", record_fsync), mock.patch.object(
-                installed_module, "atomic_replace_current_selection", record_replace
+            with mock.patch.object(
+                installed_module, "atomic_replace_qualification_receipt", record_replace
             ), mock.patch.dict(os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}):
                 installed_module.qualify_claude_identity(
                     os.geteuid(),
@@ -490,13 +508,9 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
                 )
 
-            receipt_fsync = events.index(("fsync", fixture["receipts"]))
-            current_replace = next(
-                index for index, event in enumerate(events) if event == ("replace", fixture["current_path"])
-            )
-            self.assertLess(receipt_fsync, current_replace)
+            self.assertEqual(events, [("replace", fixture["receipt_path"])])
 
-    def test_runtime_receipt_directory_fsync_failure_preserves_current_selection(self):
+    def test_runtime_receipt_replace_failure_preserves_current_receipt(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
             installed_module = load_script("claude_review_receipt_fsync_failure", fixture["launcher"])
@@ -509,10 +523,10 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
             with mock.patch.object(
                 installed_module,
-                "fsync_directory",
-                side_effect=OSError("fixture receipt-directory fsync failure"),
+                "atomic_replace_qualification_receipt",
+                side_effect=OSError("fixture receipt replacement failure"),
             ), mock.patch.dict(os.environ, {"FIXTURE_PROVIDER_RUNS": str(fixture["marker"])}), self.assertRaisesRegex(
-                OSError, "receipt-directory fsync failure"
+                OSError, "receipt replacement failure"
             ):
                 installed_module.qualify_claude_identity(
                     os.geteuid(),
@@ -522,18 +536,18 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
             self.assertEqual(fixture["current_path"].read_bytes(), before_current)
 
-    def test_atomic_current_selection_cleanup_and_ambiguous_residue(self):
+    def test_atomic_qualification_receipt_cleanup_and_ambiguous_residue(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
-            current = root / "current-selection.json"
+            current = root / ".claude-review.qualification.json"
             current.write_bytes(b"prior\n")
-            current.chmod(0o600)
+            current.chmod(0o400)
             with self.assertRaisesRegex(ValueError, "compare-and-swap"):
-                self.launcher.atomic_replace_current_selection(
+                self.launcher.atomic_replace_qualification_receipt(
                     current, {"next": True}, b"stale\n", os.geteuid()
                 )
             self.assertEqual(current.read_bytes(), b"prior\n")
-            self.assertEqual(list(root.glob(".current-selection.json.*.tmp")), [])
+            self.assertEqual(list(root.glob("..claude-review.qualification.json.*.tmp")), [])
 
             def contaminate_then_fail(source, destination):
                 Path(source).chmod(0o644)
@@ -541,12 +555,12 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
             with mock.patch.object(self.launcher.os, "replace", contaminate_then_fail):
                 with self.assertRaisesRegex(RuntimeError, "residue preserved") as raised:
-                    self.launcher.atomic_replace_current_selection(
+                    self.launcher.atomic_replace_qualification_receipt(
                         current, {"next": True}, b"prior\n", os.geteuid()
                     )
             self.assertIsInstance(raised.exception.__cause__, OSError)
             self.assertEqual(str(raised.exception.__cause__), "fixture replacement failure")
-            residue = list(root.glob(".current-selection.json.*.tmp"))
+            residue = list(root.glob("..claude-review.qualification.json.*.tmp"))
             self.assertEqual(len(residue), 1)
             self.assertEqual(current.read_bytes(), b"prior\n")
 
@@ -587,7 +601,10 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 accepted, _ = self.run_production_preflight(fixture, f"accept-{target.name}")
                 self.assertEqual(accepted.returncode, 0, accepted.stderr)
             self.assertEqual(len(set(lineage)), 3)
-            self.assertEqual(len(list(fixture["receipts"].glob("*.json"))), 4)
+            self.assertEqual(
+                list(fixture["installation_directory"].glob(".*.json")),
+                [fixture["receipt_path"]],
+            )
 
     def test_stale_or_arbitrary_qualification_request_fails_closed(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -687,7 +704,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 )
 
     def test_tampered_or_unsafe_qualification_state_fails_closed(self):
-        scenarios = ("receipt_mode", "receipt_symlink", "current_symlink")
+        scenarios = ("receipt_mode", "receipt_symlink")
         for scenario in scenarios:
             with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
                 fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
@@ -700,13 +717,6 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     replacement.chmod(0o400)
                     fixture["receipt_path"].unlink()
                     fixture["receipt_path"].symlink_to(replacement)
-                else:
-                    current_bytes = fixture["current_path"].read_bytes()
-                    replacement = fixture["qualification"] / "replacement-current.json"
-                    replacement.write_bytes(current_bytes)
-                    replacement.chmod(0o600)
-                    fixture["current_path"].unlink()
-                    fixture["current_path"].symlink_to(replacement)
                 completed, _ = self.run_production_preflight(fixture, f"unsafe-{scenario}")
                 self.assertEqual(completed.returncode, 70)
                 self.assertIn('"failure_classification": "reviewer_executable_not_authorized"', completed.stderr)
@@ -729,19 +739,9 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     else:
                         receipt["producing_launcher_sha256"] = "0" * 64
                     receipt_bytes = self.launcher.canonical_json_bytes(receipt)
-                receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
-                receipt_path = fixture["receipts"] / f"{receipt_sha256}.json"
-                receipt_path.write_bytes(receipt_bytes)
-                receipt_path.chmod(0o400)
-                current = {
-                    **fixture["current"],
-                    "receipt_path": str(receipt_path),
-                    "receipt_sha256": receipt_sha256,
-                }
-                fixture["current_path"].write_bytes(
-                    self.launcher.canonical_json_bytes(current)
-                )
-                fixture["current_path"].chmod(0o600)
+                fixture["receipt_path"].chmod(0o600)
+                fixture["receipt_path"].write_bytes(receipt_bytes)
+                fixture["receipt_path"].chmod(0o400)
                 completed, _ = self.run_production_preflight(
                     fixture, f"mismatched-{scenario}"
                 )
@@ -790,8 +790,9 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 return metadata
 
             with mock.patch.object(path_type, "lstat", foreign_receipt_owner):
+                installed_module = load_script("claude_review_foreign_receipt", fixture["launcher"])
                 with self.assertRaisesRegex(ValueError, "private regular file"):
-                    self.launcher.current_qualification(fixture["manifest"], os.geteuid())
+                    installed_module.current_qualification(fixture["manifest"], os.geteuid())
 
     def test_untrusted_or_same_path_drifted_executable_fails_closed(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -911,7 +912,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                             self.run_installer(root, selector, next_activation.name, "2" * 40)
                         self.assertFalse(next_activation.exists())
 
-    def test_initial_installation_fsyncs_receipt_directory_before_current_selection(self):
+    def test_initial_installation_fsyncs_flat_receipt_to_install_directory(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
             selector, _ = self.create_installer_targets(root)
@@ -922,8 +923,8 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 events.append(("fsync", path))
 
             def record_exclusive(path, payload, mode):
-                if path.name == "current-selection.json":
-                    events.append(("current", path))
+                if path.name == ".claude-review.json":
+                    events.append(("receipt", path))
                 return original_exclusive(path, payload, mode)
 
             with mock.patch.object(self.installer, "fsync_directory", record_fsync), mock.patch.object(
@@ -931,15 +932,11 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             ):
                 installed, _ = self.run_installer(root, selector, "initial.json", "1" * 40)
 
-            receipt_directory = Path(installed["qualification_receipt_path"]).parent
-            current_selection = receipt_directory.parent / "current-selection.json"
+            receipt = Path(installed["qualification_receipt_path"])
+            install_directory = Path(installed["installation_directory"])
             self.assertLess(
-                events.index(("fsync", receipt_directory)),
-                events.index(("current", current_selection)),
-            )
-            self.assertLess(
-                events.index(("current", current_selection)),
-                events.index(("fsync", receipt_directory.parent)),
+                events.index(("receipt", receipt)),
+                events.index(("fsync", install_directory)),
             )
 
     def test_installer_qualifies_exact_selector_target_and_rejects_writable_target(self):
@@ -980,7 +977,7 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             self.assertIn("[REDACTED]", installer_identity["version"])
             self.assertNotIn("secret-value", installer_identity["version"])
 
-    def test_installer_rejects_nonprivate_existing_state_directories(self):
+    def test_installer_rejects_unsafe_activation_and_install_directories(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
             selector, _ = self.create_installer_targets(root)
@@ -992,12 +989,33 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
             activation.chmod(0o700)
             contract_id = "sha256:" + "a" * 64
-            entry_directory = root / "install-root" / f"entry-{contract_id.removeprefix('sha256:')}"
-            entry_directory.mkdir(parents=True, mode=0o755)
+            install_directory = root / "install-root"
+            install_directory.mkdir()
+            install_directory.chmod(0o775)
             with mock.patch.object(
                 self.installer, "entry_contract_identity", return_value=contract_id
-            ), self.assertRaisesRegex(ValueError, "private operator-controlled"):
+            ), self.assertRaisesRegex(ValueError, "operator-controlled"):
                 self.run_installer(root, selector, "receipt-2.json", "2" * 40)
+
+    def test_installer_rejects_unsafe_activation_grandparent_before_mutation(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            unsafe_grandparent = root / "activation"
+            unsafe_grandparent.mkdir(mode=0o700)
+            unsafe_grandparent.chmod(0o777)
+            activation_parent = unsafe_grandparent / "new-private"
+
+            with self.assertRaisesRegex(ValueError, "destination ancestor"):
+                self.run_installer(
+                    root,
+                    selector,
+                    "new-private/receipt.json",
+                    "1" * 40,
+                )
+
+            self.assertFalse(activation_parent.exists())
+            self.assertFalse((root / "install-root").exists())
 
     def test_drift_action_quotes_launcher_path(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1037,31 +1055,34 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             selector, targets = self.create_installer_targets(root)
             initial, _ = self.run_installer(root, selector, "activation-1.json", "1" * 40)
             launcher = Path(initial["installed_launcher_path"])
+            self.assertEqual(launcher.name, "claude-review")
             manifest_path = Path(initial["installation_manifest_path"])
-            current_path = Path(initial["current_selection_path"])
-            receipts = Path(initial["qualification_receipts_directory"])
+            current_path = Path(initial["qualification_receipt_path"])
+            install_directory = Path(initial["installation_directory"])
             active_rule = Path(initial["active_rule_path"])
             immutable = {
                 "launcher": launcher.read_bytes(),
                 "manifest": manifest_path.read_bytes(),
+                "entry_contract": json.loads(manifest_path.read_text(encoding="utf-8"))[
+                    "entry_contract"
+                ],
                 "active_rule": active_rule.read_bytes(),
                 "entry": initial["entry_contract_id"],
             }
             installed_module = load_script("claude_review_installer_rerun", launcher)
             initial_current = current_path.read_bytes()
-            initial_receipts = {path.name for path in receipts.iterdir()}
-            self.assertEqual(len(initial_receipts), 1)
+            initial_files = {path.name for path in install_directory.iterdir()}
             initial_rerun, _ = self.run_installer(
                 root, selector, "activation-initial-rerun.json", "2" * 40
             )
             self.assertEqual(initial_rerun["entry_contract_id"], immutable["entry"])
             self.assertEqual(current_path.read_bytes(), initial_current)
-            self.assertEqual({path.name for path in receipts.iterdir()}, initial_receipts)
+            self.assertEqual({path.name for path in install_directory.iterdir()}, initial_files)
 
             for index, target in enumerate((targets[1], targets[2], targets[0]), start=3):
                 selector.unlink()
                 selector.symlink_to(target)
-                current = json.loads(current_path.read_text(encoding="utf-8"))
+                current_sha256 = self.launcher.sha256_bytes(current_path.read_bytes())
                 manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
                 forbidden = [Path(value) for value in manifest["forbidden_roots"]]
                 observed = installed_module.executable_file_identity(
@@ -1071,29 +1092,61 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                     self.assertEqual(
                         installed_module.qualify_claude_identity(
                             os.geteuid(),
-                            expected_current_receipt_sha256=current["receipt_sha256"],
+                            expected_current_receipt_sha256=current_sha256,
                             expected_observed_file_identity_sha256=installed_module.file_identity_digest(observed),
                         ),
                         0,
                     )
                 before_current = current_path.read_bytes()
-                before_receipts = {path.name for path in receipts.iterdir()}
+                before_files = {path.name for path in install_directory.iterdir()}
                 rerun, activation = self.run_installer(
                     root, selector, f"activation-{index}.json", f"{index}" * 40
                 )
                 self.assertEqual(rerun["entry_contract_id"], immutable["entry"])
                 self.assertEqual(launcher.read_bytes(), immutable["launcher"])
-                self.assertEqual(manifest_path.read_bytes(), immutable["manifest"])
+                self.assertEqual(
+                    json.loads(manifest_path.read_text(encoding="utf-8"))["entry_contract"],
+                    immutable["entry_contract"],
+                )
                 self.assertEqual(active_rule.read_bytes(), immutable["active_rule"])
                 self.assertEqual(current_path.read_bytes(), before_current)
-                self.assertEqual({path.name for path in receipts.iterdir()}, before_receipts)
+                self.assertEqual({path.name for path in install_directory.iterdir()}, before_files)
                 self.assertEqual(
                     rerun["qualification_receipt_sha256"],
-                    json.loads(before_current)["receipt_sha256"],
+                    self.launcher.sha256_bytes(before_current),
                 )
                 self.assertTrue(activation.exists())
-                provenance = launcher.parent / f"source-provenance-{str(index) * 40}.json"
-                self.assertTrue(provenance.exists())
+                self.assertEqual(rerun["source_provenance"]["source_commit"], str(index) * 40)
+
+    def test_activation_receipt_keeps_its_distinct_record_identity(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            installed, activation = self.run_installer(
+                root, selector, "activation.json", "1" * 40
+            )
+
+            self.assertEqual(installed["kind"], "claude_review_activation_receipt")
+            self.assertEqual(
+                json.loads(activation.read_text(encoding="utf-8"))["kind"],
+                "claude_review_activation_receipt",
+            )
+            combined = json.loads(
+                Path(installed["installation_manifest_path"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(combined["kind"], "claude_reviewer_qualification_receipt")
+
+    def test_existing_launcher_without_combined_record_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            selector, _ = self.create_installer_targets(root)
+            installed, _ = self.run_installer(root, selector, "initial.json", "1" * 40)
+            record = Path(installed["installation_manifest_path"])
+            record.unlink()
+
+            with self.assertRaisesRegex(ValueError, "missing its combined"):
+                self.run_installer(root, selector, "replacement.json", "2" * 40)
+            self.assertFalse((root / "activation" / "replacement.json").exists())
 
     def test_installer_selector_drift_is_qualification_required_before_rule_or_receipt(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1111,11 +1164,11 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
             malicious.chmod(0o755)
             selector.unlink()
             selector.symlink_to(malicious)
-            current_path = Path(initial["current_selection_path"])
-            receipts = Path(initial["qualification_receipts_directory"])
+            current_path = Path(initial["qualification_receipt_path"])
+            install_directory = Path(initial["installation_directory"])
             active_rule = Path(initial["active_rule_path"])
             before_current = current_path.read_bytes()
-            before_receipts = {path.name for path in receipts.iterdir()}
+            before_files = {path.name for path in install_directory.iterdir()}
             active_rule.write_bytes(b"operator-prior-rule\n")
             active_rule.chmod(0o600)
             before_rule = active_rule.read_bytes()
@@ -1124,71 +1177,47 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 self.run_installer(root, selector, activation.name, "2" * 40)
             self.assertFalse(marker.exists())
             self.assertEqual(current_path.read_bytes(), before_current)
-            self.assertEqual({path.name for path in receipts.iterdir()}, before_receipts)
+            self.assertEqual({path.name for path in install_directory.iterdir()}, before_files)
             self.assertEqual(active_rule.read_bytes(), before_rule)
             self.assertFalse(activation.exists())
 
     def test_installer_and_launcher_share_the_full_invalid_state_matrix(self):
         scenarios = (
-            "current_symlink", "receipt_symlink", "current_mode", "receipt_mode",
-            "foreign_owner", "malformed_current", "nonobject_current", "malformed_receipt",
-            "current_wrong_kind", "current_wrong_schema", "current_wrong_entry",
-            "current_wrong_selector", "wrong_kind", "wrong_schema", "wrong_entry",
-            "wrong_selector", "wrong_producer", "wrong_authority", "wrong_file_identity",
-            "missing_receipt",
-            "receipt_digest", "escaped_receipt", "ambiguous_predecessor",
-            "self_predecessor", "predecessor_digest",
+            "receipt_symlink", "receipt_mode", "foreign_owner", "malformed_receipt",
+            "wrong_kind", "wrong_schema", "wrong_entry", "wrong_selector",
+            "wrong_producer", "wrong_authority", "wrong_file_identity",
+            "missing_receipt", "invalid_predecessor",
+            "self_predecessor",
         )
         for scenario in scenarios:
             with self.subTest(scenario=scenario), tempfile.TemporaryDirectory() as temporary_directory:
                 fixture = self.create_installed_fixture(Path(temporary_directory).resolve())
-                current = dict(fixture["current"])
                 receipt = json.loads(fixture["receipt_path"].read_text(encoding="utf-8"))
+                manifest = dict(fixture["manifest"])
+                installed_module = load_script(
+                    f"claude_review_invalid_flat_state_{scenario}", fixture["launcher"]
+                )
 
-                def write_current(record):
-                    fixture["current_path"].write_bytes(self.launcher.canonical_json_bytes(record))
-                    fixture["current_path"].chmod(0o600)
+                def write_receipt(payload):
+                    payload_bytes = (
+                        payload
+                        if isinstance(payload, bytes)
+                        else self.launcher.canonical_json_bytes(payload)
+                    )
+                    fixture["receipt_path"].chmod(0o600)
+                    fixture["receipt_path"].write_bytes(payload_bytes)
+                    fixture["receipt_path"].chmod(0o400)
 
-                def select_receipt(payload, *, path=None):
-                    receipt_bytes = payload if isinstance(payload, bytes) else self.launcher.canonical_json_bytes(payload)
-                    receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
-                    selected = path or fixture["receipts"] / f"{receipt_sha256}.json"
-                    selected.parent.mkdir(parents=True, exist_ok=True)
-                    selected.write_bytes(receipt_bytes)
-                    selected.chmod(0o400)
-                    write_current({**current, "receipt_path": str(selected), "receipt_sha256": receipt_sha256})
-                    return selected
-
-                if scenario == "current_symlink":
-                    replacement = fixture["qualification"] / "replacement-current.json"
-                    replacement.write_bytes(fixture["current_path"].read_bytes())
-                    replacement.chmod(0o600)
-                    fixture["current_path"].unlink()
-                    fixture["current_path"].symlink_to(replacement)
-                elif scenario == "receipt_symlink":
-                    replacement = fixture["receipts"] / "replacement.json"
+                if scenario == "receipt_symlink":
+                    replacement = fixture["installation_directory"] / "replacement.json"
                     replacement.write_bytes(fixture["receipt_path"].read_bytes())
                     replacement.chmod(0o400)
                     fixture["receipt_path"].unlink()
                     fixture["receipt_path"].symlink_to(replacement)
-                elif scenario == "current_mode":
-                    fixture["current_path"].chmod(0o644)
                 elif scenario == "receipt_mode":
                     fixture["receipt_path"].chmod(0o600)
-                elif scenario == "malformed_current":
-                    fixture["current_path"].write_bytes(b"{malformed\n")
-                elif scenario == "nonobject_current":
-                    fixture["current_path"].write_bytes(b"[]\n")
-                elif scenario.startswith("current_wrong_"):
-                    field, value = {
-                        "current_wrong_kind": ("kind", "wrong"),
-                        "current_wrong_schema": ("schema_version", 1),
-                        "current_wrong_entry": ("entry_contract_id", "sha256:" + "0" * 64),
-                        "current_wrong_selector": ("claude_selector", "/bin/echo"),
-                    }[scenario]
-                    write_current({**current, field: value})
                 elif scenario == "malformed_receipt":
-                    select_receipt(b"{malformed\n")
+                    write_receipt(b"{malformed\n")
                 elif scenario in {
                     "wrong_kind", "wrong_schema", "wrong_entry", "wrong_selector",
                     "wrong_producer", "wrong_authority",
@@ -1201,9 +1230,9 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                         "wrong_producer": ("producing_launcher_sha256", "0" * 64),
                         "wrong_authority": ("authority_semantics", "approval proof"),
                     }[scenario]
-                    select_receipt({**receipt, field: value})
+                    write_receipt({**receipt, field: value})
                 elif scenario == "wrong_file_identity":
-                    select_receipt({
+                    write_receipt({
                         **receipt,
                         "file_identity": {
                             **receipt["file_identity"],
@@ -1211,32 +1240,11 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                         },
                     })
                 elif scenario == "missing_receipt":
-                    missing_sha = "a" * 64
-                    write_current({
-                        **current,
-                        "receipt_path": str(fixture["receipts"] / f"{missing_sha}.json"),
-                        "receipt_sha256": missing_sha,
-                    })
-                elif scenario == "receipt_digest":
-                    wrong_sha = "b" * 64
-                    wrong_path = fixture["receipts"] / f"{wrong_sha}.json"
-                    wrong_path.write_bytes(fixture["receipt_path"].read_bytes())
-                    wrong_path.chmod(0o400)
-                    write_current({**current, "receipt_path": str(wrong_path), "receipt_sha256": wrong_sha})
-                elif scenario == "escaped_receipt":
-                    select_receipt(receipt, path=Path(temporary_directory) / "escaped" / "receipt.json")
-                elif scenario == "ambiguous_predecessor":
-                    select_receipt({**receipt, "predecessor_receipt_sha256": "c" * 64})
-                elif scenario == "predecessor_digest":
-                    predecessor_sha = "d" * 64
-                    predecessor_path = fixture["receipts"] / f"{predecessor_sha}.json"
-                    predecessor_path.write_bytes(b"not-the-declared-digest\n")
-                    predecessor_path.chmod(0o400)
-                    select_receipt({
-                        **receipt,
-                        "predecessor_receipt_sha256": predecessor_sha,
-                        "predecessor_receipt_path": str(predecessor_path),
-                    })
+                    fixture["receipt_path"].unlink()
+                elif scenario == "invalid_predecessor":
+                    write_receipt({**receipt, "predecessor_receipt_sha256": "not-a-digest"})
+                elif scenario == "self_predecessor":
+                    write_receipt({**receipt, "predecessor_receipt_sha256": "e" * 64})
 
                 if scenario == "foreign_owner":
                     path_type = type(fixture["receipt_path"])
@@ -1252,34 +1260,28 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
 
                     context = mock.patch.object(path_type, "lstat", foreign_lstat)
                 elif scenario == "self_predecessor":
-                    self_sha = "e" * 64
-                    self_path = fixture["receipts"] / f"{self_sha}.json"
-                    self_receipt = {
-                        **receipt,
-                        "predecessor_receipt_sha256": self_sha,
-                        "predecessor_receipt_path": str(self_path),
-                    }
-                    self_path.write_bytes(self.launcher.canonical_json_bytes(self_receipt))
-                    self_path.chmod(0o400)
-                    write_current({**current, "receipt_path": str(self_path), "receipt_sha256": self_sha})
                     context = contextlib.ExitStack()
-                    context.enter_context(mock.patch.object(self.installer, "digest", return_value=self_sha))
-                    context.enter_context(mock.patch.object(self.launcher, "sha256_bytes", return_value=self_sha))
+                    context.enter_context(
+                        mock.patch.object(self.installer, "digest", return_value="e" * 64)
+                    )
+                    context.enter_context(
+                        mock.patch.object(installed_module, "sha256_bytes", return_value="e" * 64)
+                    )
                 else:
                     context = contextlib.nullcontext()
 
                 with context:
                     with self.assertRaises((OSError, ValueError)):
-                        self.installer.validated_existing_qualification(fixture["manifest"])
+                        self.installer.validated_existing_qualification(manifest)
                     with self.assertRaises((OSError, ValueError)):
-                        self.launcher.current_qualification(fixture["manifest"], os.geteuid())
+                        installed_module.current_qualification(manifest, os.geteuid())
 
     def test_temporary_production_install_binds_launcher_rule_and_claude_identity(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory).resolve()
             installed = root / "installed"
-            installed.mkdir(mode=0o700)
-            launcher = installed / "claude-review"
+            installed.mkdir(mode=0o755)
+            launcher = installed / "claude-review-fixture"
             launcher_bytes = LAUNCHER.read_bytes()
             launcher.write_bytes(launcher_bytes)
             launcher.chmod(0o500)
@@ -1313,30 +1315,23 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 )
             count.unlink(missing_ok=True)
             entry_contract = {
-                "entry_contract_schema_version": 1,
-                "installation_schema_version": 2,
-                "qualification_schema_version": 2,
+                "entry_contract_schema_version": 2,
+                "installation_schema_version": 3,
+                "qualification_schema_version": 3,
                 "launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
                 "rule_template_sha256": "fixture-rule-template",
                 "claude_selector": str(selector),
                 "active_rule_path": str(active_rule),
                 "forbidden_roots": [str(candidate)],
                 "auth_diagnostics_directory": str(auth_diagnostics),
-                "qualification_root": str(root / "qualification-root"),
+                "installation_directory": str(installed),
             }
             entry_contract_id = "sha256:" + self.launcher.sha256_bytes(
                 self.launcher.canonical_json_bytes(entry_contract)
             )
-            qualification = root / "qualification-root" / entry_contract_id.removeprefix("sha256:")
-            receipts = qualification / "receipts"
-            receipts.mkdir(parents=True, mode=0o700)
-            qualification.chmod(0o700)
-            receipts.chmod(0o700)
-            lock = qualification / "qualification.lock"
-            lock.write_text("fixture lock\n", encoding="utf-8")
-            lock.chmod(0o600)
+            receipt_path = installed / f".{launcher.name}.json"
             manifest = {
-                "schema_version": 2,
+                "schema_version": 3,
                 "entry_contract_id": entry_contract_id,
                 "entry_contract": entry_contract,
                 "installed_launcher_path": str(launcher),
@@ -1346,44 +1341,27 @@ class ClaudeReviewIdentityAndGrammarTests(unittest.TestCase):
                 "claude_selector": str(selector),
                 "forbidden_roots": [str(candidate)],
                 "auth_diagnostics_directory": str(auth_diagnostics),
-                "qualification_schema_version": 2,
-                "qualification_directory": str(qualification),
-                "qualification_receipts_directory": str(receipts),
-                "current_selection_path": str(qualification / "current-selection.json"),
-                "qualification_lock_path": str(lock),
+                "qualification_schema_version": 3,
+                "installation_directory": str(installed),
             }
             receipt = {
                 "kind": "claude_reviewer_qualification_receipt",
-                "schema_version": 2,
+                "schema_version": 3,
                 "entry_contract_id": entry_contract_id,
                 "claude_selector": str(selector),
                 "file_identity": qualified_identity["file_identity"],
                 "version": qualified_identity["version"],
                 "predecessor_receipt_sha256": None,
-                "predecessor_receipt_path": None,
                 "producing_launcher_path": str(launcher),
                 "producing_launcher_sha256": self.launcher.sha256_bytes(launcher_bytes),
                 "authority_semantics": "capability qualification only; grants zero task or review authority",
             }
-            receipt_bytes = self.launcher.canonical_json_bytes(receipt)
+            manifest.update(receipt)
+            receipt_bytes = self.launcher.canonical_json_bytes(manifest)
             receipt_sha256 = self.launcher.sha256_bytes(receipt_bytes)
-            receipt_path = receipts / f"{receipt_sha256}.json"
             receipt_path.write_bytes(receipt_bytes)
             receipt_path.chmod(0o400)
-            current = {
-                "kind": "claude_reviewer_current_selection",
-                "schema_version": 2,
-                "entry_contract_id": entry_contract_id,
-                "claude_selector": str(selector),
-                "receipt_path": str(receipt_path),
-                "receipt_sha256": receipt_sha256,
-            }
-            current_path = qualification / "current-selection.json"
-            current_path.write_bytes(self.launcher.canonical_json_bytes(current))
-            current_path.chmod(0o600)
-            manifest_path = installed / "claude-review-installation.json"
-            manifest_path.write_bytes(self.launcher.canonical_json_bytes(manifest))
-            manifest_path.chmod(0o400)
+            manifest_path = receipt_path
             environment = os.environ.copy()
             environment.pop("CLAUDE_REVIEW_TEST_FIXTURE", None)
             environment.update({"FIXTURE_COUNT": str(count), "PATH": f"{candidate}{os.pathsep}/usr/bin:/bin"})
@@ -3354,6 +3332,83 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(record["classification"], "blocking_unknown_other_worktree_administration")
         self.assertEqual(record["disposition"], "blocking")
 
+    def test_other_linked_worktree_lock_is_bounded_provisional_activity(self):
+        module = load_script("claude_review_other_worktree_lock", LAUNCHER)
+        environment = os.environ.copy()
+        linked = self.root / "lock-worktree"
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.candidate),
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                "fixture-lock",
+                str(linked),
+            ],
+            check=True,
+        )
+        gitdir = Path(
+            subprocess.run(
+                ["git", "-C", str(linked), "rev-parse", "--absolute-git-dir"],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            ).stdout.strip()
+        ).resolve()
+        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
+        lock = gitdir / "index.lock"
+        lock.write_text("in-progress unrelated commit\n", encoding="utf-8")
+        changed = module.source_snapshot([self.candidate], self.candidate, environment)
+        comparison = module.snapshot_comparison(baseline, changed)
+        self.assertFalse(comparison["passed"])
+        record = next(
+            record
+            for record in comparison["git_admin_changes"]
+            if record["path"].endswith("index.lock")
+        )
+        self.assertEqual(
+            record["classification"],
+            "blocking_unattributed_other_worktree_administration",
+        )
+        self.assertEqual(record["disposition"], "blocking")
+        self.assertTrue(module.provisional_attribution_only(comparison))
+
+    def test_unprotected_ref_lock_is_bounded_provisional_activity(self):
+        module = load_script("claude_review_unprotected_ref_lock", LAUNCHER)
+        environment = os.environ.copy()
+        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
+        common = Path(
+            subprocess.run(
+                ["git", "-C", str(self.candidate), "rev-parse", "--git-common-dir"],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            ).stdout.strip()
+        )
+        if not common.is_absolute():
+            common = self.candidate / common
+        common = common.resolve()
+        lock = common / "refs" / "heads" / "unrelated.lock"
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("in-progress unrelated ref update\n", encoding="utf-8")
+        changed = module.source_snapshot([self.candidate], self.candidate, environment)
+        comparison = module.snapshot_comparison(baseline, changed)
+        self.assertFalse(comparison["passed"])
+        record = next(
+            record
+            for record in comparison["git_admin_changes"]
+            if record["path"] == "refs/heads/unrelated.lock"
+        )
+        self.assertEqual(
+            record["classification"],
+            "blocking_unattributed_unrelated_ref_administration",
+        )
+        self.assertEqual(record["disposition"], "blocking")
+        self.assertTrue(module.provisional_attribution_only(comparison))
+
     def test_unrelated_linked_commit_with_arbitrary_admin_contamination_is_blocking(self):
         module = load_script("claude_review_other_worktree_mixed_admin", LAUNCHER)
         environment = os.environ.copy()
@@ -3669,9 +3724,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             check=True,
         )
         completed, diagnostic = self.run_governed("unrelated_worktree_commit_then_wait", body=self.config_body(max_attempts=1))
-        self.assertEqual(completed.returncode, 0, diagnostic)
+        receipts = self.receipts()
+        self.assertEqual(completed.returncode, 0, {"diagnostic": diagnostic, "receipts": receipts})
         self.assertIsNone(diagnostic["failure_classification"])
-        receipt = self.receipts()[0]
+        receipt = receipts[0]
         self.assertTrue(receipt["no_delta_postflight"]["passed"])
         self.assertEqual(receipt["no_delta_postflight"]["changed_paths"], [])
         self.assertTrue(receipt["no_delta_postflight"]["raw_changed_paths"])

--- a/tests/test_codex_safe_rm.py
+++ b/tests/test_codex_safe_rm.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import importlib.machinery
+import importlib.util
+import hashlib
+import json
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SAFE_RM_PATH = ROOT / "scripts" / "codex-safe-rm"
+INSTALLER_PATH = ROOT / "scripts" / "install-codex-safe-rm"
+
+
+def load_script(name: str, path: Path):
+    loader = importlib.machinery.SourceFileLoader(name, str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
+
+
+safe_rm = load_script("playbook_codex_safe_rm", SAFE_RM_PATH)
+installer = load_script("playbook_install_codex_safe_rm", INSTALLER_PATH)
+
+
+class CodexSafeRmTests(unittest.TestCase):
+    def test_accepts_literal_relative_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            cwd = Path(temporary_directory).resolve()
+            for operand in ("build", ".pytest_cache", "docs/_build", "foo/bar.baz_qux-1"):
+                with self.subTest(operand=operand):
+                    self.assertTrue(safe_rm.validate_operand(operand, cwd))
+
+    def test_rejects_unsafe_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            cwd = Path(temporary_directory).resolve()
+            rejected = (
+                "*", ".", "./", "..", "../foo", "/tmp/foo", "~/foo",
+                "${DIR}", "$(pwd)", "foo/../bar", "foo//bar", "foo/",
+                "build;whoami", "path with spaces", ".git", "repo/.git/objects",
+            )
+            for operand in rejected:
+                with self.subTest(operand=operand), self.assertRaises(safe_rm.SafeRmError):
+                    safe_rm.validate_operand(operand, cwd)
+
+    def test_removes_only_validated_trees_and_does_not_follow_internal_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory).resolve()
+            cwd = root / "repo"
+            outside = root / "outside"
+            (cwd / "build" / "nested").mkdir(parents=True)
+            outside.mkdir()
+            protected = outside / "protected.txt"
+            protected.write_text("keep\n", encoding="utf-8")
+            (cwd / "build" / "outside-link").symlink_to(outside, target_is_directory=True)
+            safe_rm.remove_directories(["build", "missing"], cwd=cwd)
+            self.assertFalse((cwd / "build").exists())
+            self.assertTrue(protected.is_file())
+
+    def test_rejects_top_level_symlinks_files_and_overlapping_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            cwd = Path(temporary_directory).resolve()
+            (cwd / "real" / "nested").mkdir(parents=True)
+            (cwd / "link").symlink_to(cwd / "real", target_is_directory=True)
+            (cwd / "file").write_text("keep\n", encoding="utf-8")
+            for operand in ("link", "file"):
+                with self.subTest(operand=operand), self.assertRaisesRegex(
+                    safe_rm.SafeRmError, "not a real directory"
+                ):
+                    safe_rm.remove_directories([operand], cwd=cwd)
+            with self.assertRaisesRegex(safe_rm.SafeRmError, "overlapping"):
+                safe_rm.remove_directories(["real", "real/nested"], cwd=cwd)
+
+    def test_fails_closed_without_symlink_resistant_runtime(self) -> None:
+        with mock.patch.object(shutil.rmtree, "avoids_symlink_attacks", False):
+            with self.assertRaisesRegex(safe_rm.SafeRmError, "symlink-resistant"):
+                safe_rm.remove_directories(["missing"], cwd=Path.cwd())
+
+    def test_cli_grammar_and_version_are_exact(self) -> None:
+        for arguments in ([], ["-r", "--", "build"], ["-rf", "build"], ["-rf", "--"]):
+            with self.subTest(arguments=arguments):
+                stdout = StringIO()
+                stderr = StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    self.assertEqual(safe_rm.main(arguments), 2)
+                self.assertIn("usage:", stderr.getvalue())
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            self.assertEqual(safe_rm.main(["--version"]), 0)
+        self.assertEqual(stdout.getvalue(), "codex-safe-rm 1\n")
+
+
+class CodexSafeRmInstallerTests(unittest.TestCase):
+    def test_production_cli_rejects_relocation_and_uses_fixed_destination(self) -> None:
+        alternate = "/tmp/alternate-codex-safe-rm"
+        for action in ("install", "verify", "uninstall"):
+            with self.subTest(action=action), redirect_stderr(StringIO()), self.assertRaises(
+                SystemExit
+            ):
+                installer.build_parser().parse_args([action, "--destination", alternate])
+
+        destination = Path("/effective/home/.local/bin/codex-safe-rm")
+        metadata = {"control_version": "1", "source_commit": "1" * 40}
+        with mock.patch.object(
+            installer, "production_destination", return_value=destination
+        ), mock.patch.object(
+            installer, "install", return_value=metadata
+        ) as install_call, redirect_stdout(StringIO()):
+            self.assertEqual(installer.main(["install"]), 0)
+        install_call.assert_called_once_with(destination)
+
+    def test_production_destination_uses_effective_account_home_not_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            account_home = Path(temporary_directory).resolve() / "account-home"
+            account_home.mkdir()
+            account = mock.Mock(pw_dir=str(account_home))
+            with mock.patch.object(
+                installer.pwd, "getpwuid", return_value=account
+            ), mock.patch.dict("os.environ", {"HOME": "/attacker-selected-home"}):
+                self.assertEqual(
+                    installer.production_destination(),
+                    account_home / ".local" / "bin" / "codex-safe-rm",
+                )
+
+    def test_clean_install_is_exact_recorded_and_verifiable(self) -> None:
+        with installation_fixture() as fixture:
+            metadata = installer.install(
+                fixture.destination, source=fixture.source, repo_root=fixture.repo
+            )
+            self.assertEqual(fixture.source.read_bytes(), fixture.destination.read_bytes())
+            self.assertEqual(stat.S_IMODE(fixture.destination.stat().st_mode), 0o755)
+            self.assertEqual(
+                metadata,
+                installer.verify(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                ),
+            )
+
+    def test_dirty_enforcement_owned_predecessor_is_rejected(self) -> None:
+        with installation_fixture() as fixture:
+            fixture.destination.parent.mkdir(parents=True)
+            predecessor_bytes = fixture.source.read_bytes()
+            fixture.destination.write_bytes(predecessor_bytes)
+            fixture.destination.chmod(0o755)
+            digest = hashlib.sha256(predecessor_bytes).hexdigest()
+            legacy = {
+                "schema_version": 1,
+                "control": "codex-safe-rm",
+                "control_version": "1",
+                "source_repository": "ctrl-alt-keith/ai-workflow-enforcement",
+                "source_path": "enforcement/safe_rm.py",
+                "source_commit": "1" * 40,
+                "source_dirty": True,
+                "source_sha256": digest,
+                "installed_sha256": digest,
+            }
+            record = installer.metadata_path(fixture.destination)
+            record.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+            record.chmod(0o644)
+
+            with self.assertRaisesRegex(installer.InstallError, "unrecognized"):
+                installer.install(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+
+    def test_dirty_source_and_unrecognized_destination_fail_closed(self) -> None:
+        with installation_fixture() as fixture:
+            (fixture.repo / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+            with self.assertRaisesRegex(installer.InstallError, "dirty"):
+                installer.install(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+        with installation_fixture() as fixture:
+            fixture.destination.parent.mkdir(parents=True)
+            fixture.destination.write_text("unrelated\n", encoding="utf-8")
+            with self.assertRaises(installer.InstallError):
+                installer.install(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+            self.assertEqual(fixture.destination.read_text(encoding="utf-8"), "unrelated\n")
+
+    def test_exact_enforcement_owned_predecessor_is_migrated(self) -> None:
+        with installation_fixture() as fixture:
+            fixture.destination.parent.mkdir(parents=True)
+            predecessor_bytes = fixture.source.read_bytes()
+            fixture.destination.write_bytes(predecessor_bytes)
+            fixture.destination.chmod(0o755)
+            digest = hashlib.sha256(predecessor_bytes).hexdigest()
+            legacy = {
+                "schema_version": 1,
+                "control": "codex-safe-rm",
+                "control_version": "1",
+                "source_repository": "ctrl-alt-keith/ai-workflow-enforcement",
+                "source_path": "enforcement/safe_rm.py",
+                "source_commit": "1" * 40,
+                "source_dirty": False,
+                "source_sha256": digest,
+                "installed_sha256": digest,
+            }
+            record = installer.metadata_path(fixture.destination)
+            record.write_text(json.dumps(legacy) + "\n", encoding="utf-8")
+            record.chmod(0o644)
+
+            metadata = installer.install(
+                fixture.destination, source=fixture.source, repo_root=fixture.repo
+            )
+
+            self.assertEqual(metadata["source_repository"], "ctrl-alt-keith/ai-workflow-playbook")
+            self.assertEqual(
+                metadata,
+                installer.verify(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                ),
+            )
+
+    def test_verify_rejects_byte_metadata_and_mode_drift(self) -> None:
+        with installation_fixture() as fixture:
+            installer.install(fixture.destination, source=fixture.source, repo_root=fixture.repo)
+            fixture.destination.write_text("modified\n", encoding="utf-8")
+            with self.assertRaisesRegex(installer.InstallError, "digest"):
+                installer.verify(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+        with installation_fixture() as fixture:
+            installer.install(fixture.destination, source=fixture.source, repo_root=fixture.repo)
+            fixture.destination.chmod(0o775)
+            with self.assertRaisesRegex(installer.InstallError, "mode"):
+                installer.verify(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+
+    def test_uninstall_removes_only_a_recognized_pair(self) -> None:
+        with installation_fixture() as fixture:
+            installer.install(fixture.destination, source=fixture.source, repo_root=fixture.repo)
+            installer.uninstall(fixture.destination)
+            self.assertFalse(fixture.destination.exists())
+            self.assertFalse(installer.metadata_path(fixture.destination).exists())
+        with installation_fixture() as fixture:
+            fixture.destination.parent.mkdir(parents=True)
+            fixture.destination.write_text("unrelated\n", encoding="utf-8")
+            with self.assertRaises(installer.InstallError):
+                installer.uninstall(fixture.destination)
+            self.assertTrue(fixture.destination.exists())
+
+    def test_group_writable_install_directory_is_rejected(self) -> None:
+        with installation_fixture() as fixture:
+            fixture.destination.parent.mkdir(parents=True)
+            fixture.destination.parent.chmod(0o775)
+            with self.assertRaisesRegex(installer.InstallError, "install directory"):
+                installer.install(
+                    fixture.destination, source=fixture.source, repo_root=fixture.repo
+                )
+
+
+class InstallationFixture:
+    def __init__(self, root: Path):
+        self.repo = root / "repo"
+        self.destination = root / "bin" / "codex-safe-rm"
+        self.source = self.repo / "scripts" / "codex-safe-rm"
+
+    def prepare(self) -> "InstallationFixture":
+        (self.repo / "scripts").mkdir(parents=True)
+        self.source.write_bytes(SAFE_RM_PATH.read_bytes())
+        self.source.chmod(0o755)
+        git(self.repo, "init")
+        git(self.repo, "config", "user.email", "tests@example.com")
+        git(self.repo, "config", "user.name", "Tests")
+        git(self.repo, "config", "commit.gpgsign", "false")
+        git(self.repo, "add", "scripts/codex-safe-rm")
+        git(self.repo, "commit", "-m", "Add reviewed source")
+        return self
+
+
+class InstallationContext:
+    def __init__(self):
+        self.temporary = tempfile.TemporaryDirectory()
+
+    def __enter__(self) -> InstallationFixture:
+        return InstallationFixture(Path(self.temporary.name).resolve()).prepare()
+
+    def __exit__(self, *args: object) -> None:
+        self.temporary.cleanup()
+
+
+def installation_fixture() -> InstallationContext:
+    return InstallationContext()
+
+
+def git(cwd: Path, *arguments: str) -> None:
+    result = subprocess.run(
+        ("git", *arguments),
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"git {' '.join(arguments)} failed: {result.stderr or result.stdout}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Linear: CAK-178

## Summary

- make ai-workflow-playbook the sole source owner for codex-safe-rm and claude-review installation
- enforce ~/.local/bin as the single production publication surface, derived from the effective user's account home with no CLI relocation flags
- publish each managed executable with only its narrowly bound sidecar; create no libexec, state, cache, log, or receipt-history tree
- keep Enforcement as the consumer-policy owner without a second executable source or installer
- replace Claude qualification history with one atomically replaced current receipt carrying only its predecessor digest
- ratchet active executable sources, reusable guidance, and checked-in Codex policy/templates so new `.local` placement requires explicit ownership review

## Migration and activation

- the safe-rm installer recognizes only a clean, digest-consistent legacy Enforcement-owned pair before replacing it with Playbook-owned bytes
- the live Claude reviewer uses ~/.local/bin/claude-review plus ~/.local/bin/.claude-review.json; the live safe-removal tool uses ~/.local/bin/codex-safe-rm plus ~/.local/bin/.codex-safe-rm.install.json
- the correction changed installer, test, and documentation bytes only; both live executable files remain byte-identical to the executable sources at the corrected head, so no reinstall was required

## Validation

- 21 focused installer, migration, lineage, and placement-ratchet tests passed
- `make check` passed (markdownlint and 290 tests)
- hosted markdownlint and authoritative-source checks passed for exact commit 424fe8ce524074a730b845a1f26113886e913cc2
- Claude 2.1.246 authentication preflight passed through the unchanged installed stable launcher
- one focused governed Claude review accepted exact commit 424fe8ce524074a730b845a1f26113886e913cc2

## Review disposition

- accepted the review verdict with no blocking findings
- retained the ratchet's intentional canonical-owner boundary (`scripts/`, `docs/`, and `.codex/`) rather than expanding this correction into distribution and root-file policy
- retained eager default active-rule home resolution as a non-blocking robustness note; production already requires a resolvable effective account home and this does not create a relocation path
