### PR TITLE
docs: add Claude Code startup router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,14 @@
 This file routes Claude Code sessions to the canonical instruction sources.
 It is not an authority layer and contains no doctrine of its own.
 
-Read, in order:
+Read these routing sources in startup order:
 
-1. [`AGENTS.md`](AGENTS.md) — canonical repository execution layer.
-2. [`docs/start-here.md`](docs/start-here.md) — startup routing entry point.
+1. [`docs/start-here.md`](docs/start-here.md) — canonical startup route.
+2. [`AGENTS.md`](AGENTS.md) — repository execution layer.
 3. [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md) — Claude executor adapter.
+
+This list is startup order, not instruction precedence; the Playbook's
+Repository Instruction Hierarchy governs precedence.
 
 If anything here conflicts with those authoritative sources, they win and this
 file is wrong.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+This file routes Claude Code sessions to the canonical instruction sources.
+It is not an authority layer and contains no doctrine of its own.
+
+Read, in order:
+
+1. [`AGENTS.md`](AGENTS.md) — canonical repository execution layer.
+2. [`docs/start-here.md`](docs/start-here.md) — startup routing entry point.
+3. [`docs/tool-adapters/claude.md`](docs/tool-adapters/claude.md) — Claude executor adapter.
+
+If anything here conflicts with those authoritative sources, they win and this
+file is wrong.


### PR DESCRIPTION
## Summary

- Add a root `CLAUDE.md` that routes Claude Code to the canonical repository and adapter sources.
- Keep the router non-authoritative and free of duplicated doctrine.

## Validation

- `make check` (290 tests)