### PR TITLE
docs: add role and surface-class vocabulary; fix validation and maintenance-lock handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ help: ## List available repo-local Makefile targets with short descriptions.
 check: ## Run canonical local validation for local work and CI.
 	@if command -v markdownlint-cli2 >/dev/null 2>&1; then \
 		echo "Running markdownlint-cli2"; \
-		markdownlint-cli2 "**/*.md"; \
+		markdownlint-cli2 "**/*.md" "!.worktrees/**"; \
 	elif command -v markdownlint >/dev/null 2>&1; then \
 		echo "Running markdownlint"; \
-		markdownlint "**/*.md"; \
+		markdownlint --ignore ".worktrees" "**/*.md"; \
 	else \
 		echo "markdownlint is not installed."; \
 		echo "Install markdownlint-cli2 or markdownlint, then rerun 'make check'."; \

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -189,22 +189,32 @@ here or in an executor adapter.
 ### Surface Classes
 
 A surface class describes what an execution surface can structurally do,
-independent of vendor or product. Executor adapters map their concrete
-products onto these classes; this document does not enumerate products.
+independent of vendor or product. It states repository locality only. It does
+not state who started the run.
 
 - **Conversational** — no filesystem and no repository locality. Context
   arrives per thread, and any startup contract that depends on reading
   repository files is best-effort rather than guaranteed.
-- **Agentic-local** — real filesystem and repository locality. A startup
-  contract that reads repository and repo-local instruction files genuinely
-  runs.
-- **Agentic-hosted** — agentic execution that may begin with no human present
-  and without guaranteed local filesystem locality.
+- **Agentic-local** — filesystem and repository locality. A startup contract
+  that reads repository and repo-local instruction files genuinely runs.
+- **Agentic-remote** — agentic execution without guaranteed local repository
+  locality. Sources are reached through a connector or another retrieval
+  route rather than through the filesystem.
 
-Surface class constrains which roles a surface can actually perform; it does
-not assign a role, and it does not rank surfaces. Any actor may occupy any
-role its surface class can structurally support. When a required contract
-depends on a capability the current surface class lacks, fail closed and
+Initiation is a separate property rather than a fourth class. A run is either
+human-initiated or unattended, and either may occur on any class. An
+unattended run on an agentic-local surface remains agentic-local; what
+changes is that no human is present to resolve an ambiguity, which the owning
+workflow handles rather than the class.
+
+Surface class does not assign a role and does not rank surfaces. Any actor may
+occupy any role its surface class can structurally support.
+
+Executor adapters own the mapping from their concrete products onto these
+classes; this document enumerates no products. Until an adapter declares the
+class for a surface, that surface has no class under this vocabulary and this
+section places no obligation on it. Where an adapter has declared a class and
+a required contract depends on a capability that class lacks, fail closed and
 report the capability gap rather than substituting a weaker route.
 
 ## Kickoff Mutation Boundaries

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -172,6 +172,41 @@ and current authority, refresh mutable facts from their owning sources, and
 fail closed where the applicable contract or exact recoverable state cannot be
 resolved.
 
+### Independent Review As A Third Role
+
+Independent review is a semantic role in the same sense as interactive control
+and bounded execution: it is scoped to a run rather than to a product, vendor,
+model, effort setting, or thread. A reviewer produces evidence about work it
+did not itself produce.
+
+This section establishes only that the role exists alongside interactive
+control and bounded execution.
+[`external-ai-reviewer.md`](external-ai-reviewer.md) remains the canonical
+owner of what independence requires, how a reviewer is selected, and how
+reviewer failure or substitution is handled. Do not restate those requirements
+here or in an executor adapter.
+
+### Surface Classes
+
+A surface class describes what an execution surface can structurally do,
+independent of vendor or product. Executor adapters map their concrete
+products onto these classes; this document does not enumerate products.
+
+- **Conversational** — no filesystem and no repository locality. Context
+  arrives per thread, and any startup contract that depends on reading
+  repository files is best-effort rather than guaranteed.
+- **Agentic-local** — real filesystem and repository locality. A startup
+  contract that reads repository and repo-local instruction files genuinely
+  runs.
+- **Agentic-hosted** — agentic execution that may begin with no human present
+  and without guaranteed local filesystem locality.
+
+Surface class constrains which roles a surface can actually perform; it does
+not assign a role, and it does not rank surfaces. Any actor may occupy any
+role its surface class can structurally support. When a required contract
+depends on a capability the current surface class lacks, fail closed and
+report the capability gap rather than substituting a weaker route.
+
 ## Kickoff Mutation Boundaries
 
 Kickoff is neither a universally read-only phase nor permission to begin every

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -1683,11 +1683,40 @@ def lock_path(relative: str) -> bool:
 # repository when any actor runs an ordinary Git command there. The reviewer
 # cannot prevent it: auto-maintenance runs under the acting process, not the
 # observing one, and an unrelated worktree's operator does not share the
-# reviewer's environment. Admitting it is therefore required for the
-# unrelated-worktree concurrency guarantee, and it is admitted only as an exact
-# path and only while protected candidate evidence is unchanged. Every other
-# lock, including any other path under objects/, remains fail-closed.
+# reviewer's environment.
+#
+# The admission is deliberately narrower than "this path is tolerated". Four
+# conditions must hold together, and each closes a distinct masking route:
+#
+#   1. Live monitoring only. Terminal postflight remains fully fail-closed, so
+#      a lock that survives the attempt is still blocking. This preserves the
+#      external-ai-reviewer contract, which permits a live-monitor exception
+#      and prohibits extending it to terminal postflight.
+#   2. Creation only. A removal, replacement, content change, or mode change to
+#      this path is a mutation of pre-existing state and stays blocking.
+#   3. Regular file or already vanished. A symlink or directory at this path is
+#      never admitted, so it cannot be used to reach outside the object store.
+#   4. Protected candidate evidence unchanged, as for every other admission.
+#
+# Every other lock, including any other path under objects/, remains
+# fail-closed in both live monitoring and terminal postflight.
 GIT_BACKGROUND_MAINTENANCE_LOCKS = frozenset({"objects/maintenance.lock"})
+
+
+def admissible_background_maintenance_lock(
+    relative: str,
+    before: object | None,
+    after: object | None,
+) -> bool:
+    """Whether one observed change is a bare creation of a known Git maintenance lock."""
+
+    if relative not in GIT_BACKGROUND_MAINTENANCE_LOCKS:
+        return False
+    if before is not None:
+        return False
+    if not isinstance(after, dict):
+        return False
+    return after.get("kind") in {"file", "vanished_during_snapshot"}
 
 
 def object_storage_path(relative: str) -> bool:
@@ -1731,7 +1760,12 @@ def object_storage_layout_change(relative: str, before: object | None, after: ob
     )
 
 
-def classify_git_admin_changes(before: dict[str, object], after: dict[str, object]) -> list[dict[str, object]]:
+def classify_git_admin_changes(
+    before: dict[str, object],
+    after: dict[str, object],
+    *,
+    live_monitoring: bool = False,
+) -> list[dict[str, object]]:
     protected_evidence_unchanged = (
         before.get("head") == after.get("head")
         and before.get("protected_revisions") == after.get("protected_revisions")
@@ -1911,7 +1945,8 @@ def classify_git_admin_changes(before: dict[str, object], after: dict[str, objec
                         "protected_candidate_evidence_unchanged": True,
                     }
                 elif (
-                    relative in GIT_BACKGROUND_MAINTENANCE_LOCKS
+                    live_monitoring
+                    and admissible_background_maintenance_lock(relative, old_identity, new_identity)
                     and protected_evidence_unchanged
                 ):
                     scope = "git_background_maintenance"
@@ -1919,6 +1954,9 @@ def classify_git_admin_changes(before: dict[str, object], after: dict[str, objec
                     disposition = "tolerated"
                     evidence = {
                         "admitted_git_managed_path": relative,
+                        "admitted_observation_scope": "live_monitoring_only",
+                        "admitted_change_type": "added",
+                        "observed_kind": new_identity.get("kind") if isinstance(new_identity, dict) else None,
                         "protected_candidate_evidence_unchanged": True,
                     }
                 else:
@@ -2027,7 +2065,12 @@ def classify_git_admin_changes(before: dict[str, object], after: dict[str, objec
     return records
 
 
-def snapshot_comparison(before: dict[str, object], after: dict[str, object]) -> dict[str, object]:
+def snapshot_comparison(
+    before: dict[str, object],
+    after: dict[str, object],
+    *,
+    live_monitoring: bool = False,
+) -> dict[str, object]:
     before_body = before["body"]
     after_body = after["body"]
     blocking_paths: list[str] = []
@@ -2046,7 +2089,11 @@ def snapshot_comparison(before: dict[str, object], after: dict[str, object]) -> 
     if before_body["git_index"] != after_body["git_index"]:
         blocking_paths.append("git-index")
         raw_paths.append("git-index")
-    candidate_admin_changes = classify_git_admin_changes(before_body["git_admin"], after_body["git_admin"])
+    candidate_admin_changes = classify_git_admin_changes(
+        before_body["git_admin"],
+        after_body["git_admin"],
+        live_monitoring=live_monitoring,
+    )
     git_admin_changes.extend(candidate_admin_changes)
     before_repositories = before_body.get("guarded_git_repositories", {})
     after_repositories = after_body.get("guarded_git_repositories", {})
@@ -3182,7 +3229,9 @@ def run_governed_review(
                         )
                     else:
                         assert live_snapshot is not None
-                        live_comparison = snapshot_comparison(attempt_snapshot, live_snapshot)
+                        live_comparison = snapshot_comparison(
+                            attempt_snapshot, live_snapshot, live_monitoring=True
+                        )
                         live_changes = list(live_comparison["blocking_paths"])
                         live_observed_raw_paths.update(live_comparison["raw_changed_paths"])
                         live_observed_tolerated_paths.update(live_comparison["tolerated_paths"])
@@ -3267,7 +3316,9 @@ def run_governed_review(
                         )
                     else:
                         assert live_snapshot is not None
-                        live_comparison = snapshot_comparison(attempt_snapshot, live_snapshot)
+                        live_comparison = snapshot_comparison(
+                            attempt_snapshot, live_snapshot, live_monitoring=True
+                        )
                         live_changes = list(live_comparison["blocking_paths"])
                         live_observed_raw_paths.update(live_comparison["raw_changed_paths"])
                         live_observed_tolerated_paths.update(live_comparison["tolerated_paths"])

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -1679,52 +1679,6 @@ def lock_path(relative: str) -> bool:
     return any(part.endswith(".lock") for part in Path(relative).parts)
 
 
-# Git's own background auto-maintenance creates this lock in the candidate
-# repository when any actor runs an ordinary Git command there. The reviewer
-# cannot prevent it: auto-maintenance runs under the acting process, not the
-# observing one, and an unrelated worktree's operator does not share the
-# reviewer's environment.
-#
-# This path is never tolerated. `external-ai-reviewer.md` admits exactly one
-# tolerated lock, and that one must be identified by exact path, actor, and
-# lifetime; the reviewer cannot establish the actor here, because the writing
-# process is another operator's Git rather than the controller's. So the
-# observation stays blocking and is only made eligible for the bounded
-# stabilization window, which discriminates on the one property that is
-# actually observable: lifetime. A lock that vanishes within the window leaves
-# no blocking change behind. A lock that persists still blocks, and terminal
-# postflight is untouched and remains decisive.
-#
-# Four conditions must hold together before the window applies:
-#
-#   1. Live monitoring only. Terminal postflight never defers.
-#   2. Creation only. A removal, replacement, content change, or mode change to
-#      this path is a mutation of pre-existing state and blocks immediately.
-#   3. Regular file or already vanished. A symlink or directory at this path is
-#      never eligible, so it cannot be used to reach outside the object store.
-#   4. Protected candidate evidence unchanged.
-#
-# Every other lock, including any other path under objects/, blocks immediately
-# in both live monitoring and terminal postflight.
-GIT_BACKGROUND_MAINTENANCE_LOCKS = frozenset({"objects/maintenance.lock"})
-
-
-def admissible_background_maintenance_lock(
-    relative: str,
-    before: object | None,
-    after: object | None,
-) -> bool:
-    """Whether one observed change is a bare creation of a known Git maintenance lock."""
-
-    if relative not in GIT_BACKGROUND_MAINTENANCE_LOCKS:
-        return False
-    if before is not None:
-        return False
-    if not isinstance(after, dict):
-        return False
-    return after.get("kind") in {"file", "vanished_during_snapshot"}
-
-
 def object_storage_path(relative: str) -> bool:
     if re.fullmatch(r"objects/[0-9a-f]{2}", relative):
         return True
@@ -1766,12 +1720,7 @@ def object_storage_layout_change(relative: str, before: object | None, after: ob
     )
 
 
-def classify_git_admin_changes(
-    before: dict[str, object],
-    after: dict[str, object],
-    *,
-    live_monitoring: bool = False,
-) -> list[dict[str, object]]:
+def classify_git_admin_changes(before: dict[str, object], after: dict[str, object]) -> list[dict[str, object]]:
     protected_evidence_unchanged = (
         before.get("head") == after.get("head")
         and before.get("protected_revisions") == after.get("protected_revisions")
@@ -1950,21 +1899,6 @@ def classify_git_admin_changes(
                         "provisional_attribution": "unrelated_ref_transition_not_yet_observed",
                         "protected_candidate_evidence_unchanged": True,
                     }
-                elif (
-                    live_monitoring
-                    and admissible_background_maintenance_lock(relative, old_identity, new_identity)
-                    and protected_evidence_unchanged
-                ):
-                    scope = "git_background_maintenance"
-                    classification = "blocking_unattributed_background_maintenance_lock"
-                    evidence = {
-                        "admitted_git_managed_path": relative,
-                        "admitted_observation_scope": "live_monitoring_only",
-                        "admitted_change_type": "added",
-                        "observed_kind": new_identity.get("kind") if isinstance(new_identity, dict) else None,
-                        "provisional_attribution": "background_maintenance_lifetime_not_yet_observed",
-                        "protected_candidate_evidence_unchanged": True,
-                    }
                 else:
                     scope = "lock"
                     classification = "blocking_lock_change"
@@ -2099,12 +2033,7 @@ def classify_git_admin_changes(
     return records
 
 
-def snapshot_comparison(
-    before: dict[str, object],
-    after: dict[str, object],
-    *,
-    live_monitoring: bool = False,
-) -> dict[str, object]:
+def snapshot_comparison(before: dict[str, object], after: dict[str, object]) -> dict[str, object]:
     before_body = before["body"]
     after_body = after["body"]
     blocking_paths: list[str] = []
@@ -2123,11 +2052,7 @@ def snapshot_comparison(
     if before_body["git_index"] != after_body["git_index"]:
         blocking_paths.append("git-index")
         raw_paths.append("git-index")
-    candidate_admin_changes = classify_git_admin_changes(
-        before_body["git_admin"],
-        after_body["git_admin"],
-        live_monitoring=live_monitoring,
-    )
+    candidate_admin_changes = classify_git_admin_changes(before_body["git_admin"], after_body["git_admin"])
     git_admin_changes.extend(candidate_admin_changes)
     before_repositories = before_body.get("guarded_git_repositories", {})
     after_repositories = after_body.get("guarded_git_repositories", {})
@@ -2187,17 +2112,7 @@ def provisional_attribution_only(comparison: dict[str, object]) -> bool:
             and evidence.get("provisional_attribution")
             == "unrelated_ref_transition_not_yet_observed"
         )
-        background_maintenance_provisional = (
-            record["classification"] == "blocking_unattributed_background_maintenance_lock"
-            and evidence.get("provisional_attribution")
-            == "background_maintenance_lifetime_not_yet_observed"
-        )
-        if (
-            not shared_object_provisional
-            and not worktree_admin_provisional
-            and not unrelated_ref_provisional
-            and not background_maintenance_provisional
-        ):
+        if not shared_object_provisional and not worktree_admin_provisional and not unrelated_ref_provisional:
             return False
         repository_root = record.get("repository_root")
         prefix = f"git-admin:{repository_root}:" if repository_root else "git-admin:"
@@ -3273,9 +3188,7 @@ def run_governed_review(
                         )
                     else:
                         assert live_snapshot is not None
-                        live_comparison = snapshot_comparison(
-                            attempt_snapshot, live_snapshot, live_monitoring=True
-                        )
+                        live_comparison = snapshot_comparison(attempt_snapshot, live_snapshot)
                         live_changes = list(live_comparison["blocking_paths"])
                         live_observed_raw_paths.update(live_comparison["raw_changed_paths"])
                         live_observed_tolerated_paths.update(live_comparison["tolerated_paths"])
@@ -3360,9 +3273,7 @@ def run_governed_review(
                         )
                     else:
                         assert live_snapshot is not None
-                        live_comparison = snapshot_comparison(
-                            attempt_snapshot, live_snapshot, live_monitoring=True
-                        )
+                        live_comparison = snapshot_comparison(attempt_snapshot, live_snapshot)
                         live_changes = list(live_comparison["blocking_paths"])
                         live_observed_raw_paths.update(live_comparison["raw_changed_paths"])
                         live_observed_tolerated_paths.update(live_comparison["tolerated_paths"])

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -2002,8 +2002,36 @@ def classify_git_admin_changes(
                 linked_identifier = f"linked:{parts[1]}"
                 if linked_identifier in known_other_worktrees:
                     scope = "other_linked_worktree"
-                    classification = "blocking_unknown_other_worktree_administration"
-                    evidence = {"linked_worktree_id": linked_identifier}
+                    if (
+                        "/".join(parts[2:]) in WORKTREE_ADMIN_PATHS
+                        and protected_evidence_unchanged
+                        and safely_tolerable_identity_change(old_identity, new_identity)
+                    ):
+                        # Git writes another worktree's administration before the
+                        # HEAD/ref transition that attributes it becomes observable,
+                        # and a file created mid-attempt is absent from the recorded
+                        # admin_paths that exact_other_worktree_admin matches against.
+                        # Such a change remains blocking, but is eligible for one
+                        # bounded stabilization interval so live monitoring
+                        # reclassifies from a fresh complete snapshot instead of
+                        # emergency-stopping on an intermediate observation. If the
+                        # transition never becomes observable it still blocks, and
+                        # terminal postflight is unaffected.
+                        #
+                        # Restricted to the exact Git-managed per-worktree
+                        # administration files. Any other path under another
+                        # worktree's Git directory stays non-deferrable, so an
+                        # arbitrary planted file cannot buy itself a window.
+                        classification = "blocking_unattributed_other_worktree_administration"
+                        evidence = {
+                            "worktree_id": linked_identifier,
+                            "admitted_git_managed_path": relative,
+                            "provisional_attribution": "worktree_transition_not_yet_observed",
+                            "protected_candidate_evidence_unchanged": True,
+                        }
+                    else:
+                        classification = "blocking_unknown_other_worktree_administration"
+                        evidence = {"linked_worktree_id": linked_identifier}
             elif ref is not None:
                 if ref in protected_refs or ref.startswith("refs/replace/"):
                     scope = "candidate_relevant_shared_state"

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -1685,21 +1685,27 @@ def lock_path(relative: str) -> bool:
 # observing one, and an unrelated worktree's operator does not share the
 # reviewer's environment.
 #
-# The admission is deliberately narrower than "this path is tolerated". Four
-# conditions must hold together, and each closes a distinct masking route:
+# This path is never tolerated. `external-ai-reviewer.md` admits exactly one
+# tolerated lock, and that one must be identified by exact path, actor, and
+# lifetime; the reviewer cannot establish the actor here, because the writing
+# process is another operator's Git rather than the controller's. So the
+# observation stays blocking and is only made eligible for the bounded
+# stabilization window, which discriminates on the one property that is
+# actually observable: lifetime. A lock that vanishes within the window leaves
+# no blocking change behind. A lock that persists still blocks, and terminal
+# postflight is untouched and remains decisive.
 #
-#   1. Live monitoring only. Terminal postflight remains fully fail-closed, so
-#      a lock that survives the attempt is still blocking. This preserves the
-#      external-ai-reviewer contract, which permits a live-monitor exception
-#      and prohibits extending it to terminal postflight.
+# Four conditions must hold together before the window applies:
+#
+#   1. Live monitoring only. Terminal postflight never defers.
 #   2. Creation only. A removal, replacement, content change, or mode change to
-#      this path is a mutation of pre-existing state and stays blocking.
+#      this path is a mutation of pre-existing state and blocks immediately.
 #   3. Regular file or already vanished. A symlink or directory at this path is
-#      never admitted, so it cannot be used to reach outside the object store.
-#   4. Protected candidate evidence unchanged, as for every other admission.
+#      never eligible, so it cannot be used to reach outside the object store.
+#   4. Protected candidate evidence unchanged.
 #
-# Every other lock, including any other path under objects/, remains
-# fail-closed in both live monitoring and terminal postflight.
+# Every other lock, including any other path under objects/, blocks immediately
+# in both live monitoring and terminal postflight.
 GIT_BACKGROUND_MAINTENANCE_LOCKS = frozenset({"objects/maintenance.lock"})
 
 
@@ -1950,13 +1956,13 @@ def classify_git_admin_changes(
                     and protected_evidence_unchanged
                 ):
                     scope = "git_background_maintenance"
-                    classification = "tolerated_git_background_maintenance_lock"
-                    disposition = "tolerated"
+                    classification = "blocking_unattributed_background_maintenance_lock"
                     evidence = {
                         "admitted_git_managed_path": relative,
                         "admitted_observation_scope": "live_monitoring_only",
                         "admitted_change_type": "added",
                         "observed_kind": new_identity.get("kind") if isinstance(new_identity, dict) else None,
+                        "provisional_attribution": "background_maintenance_lifetime_not_yet_observed",
                         "protected_candidate_evidence_unchanged": True,
                     }
                 else:
@@ -2181,7 +2187,17 @@ def provisional_attribution_only(comparison: dict[str, object]) -> bool:
             and evidence.get("provisional_attribution")
             == "unrelated_ref_transition_not_yet_observed"
         )
-        if not shared_object_provisional and not worktree_admin_provisional and not unrelated_ref_provisional:
+        background_maintenance_provisional = (
+            record["classification"] == "blocking_unattributed_background_maintenance_lock"
+            and evidence.get("provisional_attribution")
+            == "background_maintenance_lifetime_not_yet_observed"
+        )
+        if (
+            not shared_object_provisional
+            and not worktree_admin_provisional
+            and not unrelated_ref_provisional
+            and not background_maintenance_provisional
+        ):
             return False
         repository_root = record.get("repository_root")
         prefix = f"git-admin:{repository_root}:" if repository_root else "git-admin:"

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -1679,6 +1679,17 @@ def lock_path(relative: str) -> bool:
     return any(part.endswith(".lock") for part in Path(relative).parts)
 
 
+# Git's own background auto-maintenance creates this lock in the candidate
+# repository when any actor runs an ordinary Git command there. The reviewer
+# cannot prevent it: auto-maintenance runs under the acting process, not the
+# observing one, and an unrelated worktree's operator does not share the
+# reviewer's environment. Admitting it is therefore required for the
+# unrelated-worktree concurrency guarantee, and it is admitted only as an exact
+# path and only while protected candidate evidence is unchanged. Every other
+# lock, including any other path under objects/, remains fail-closed.
+GIT_BACKGROUND_MAINTENANCE_LOCKS = frozenset({"objects/maintenance.lock"})
+
+
 def object_storage_path(relative: str) -> bool:
     if re.fullmatch(r"objects/[0-9a-f]{2}", relative):
         return True
@@ -1897,6 +1908,17 @@ def classify_git_admin_changes(before: dict[str, object], after: dict[str, objec
                     evidence = {
                         "ref": unlocked_ref,
                         "provisional_attribution": "unrelated_ref_transition_not_yet_observed",
+                        "protected_candidate_evidence_unchanged": True,
+                    }
+                elif (
+                    relative in GIT_BACKGROUND_MAINTENANCE_LOCKS
+                    and protected_evidence_unchanged
+                ):
+                    scope = "git_background_maintenance"
+                    classification = "tolerated_git_background_maintenance_lock"
+                    disposition = "tolerated"
+                    evidence = {
+                        "admitted_git_managed_path": relative,
                         "protected_candidate_evidence_unchanged": True,
                     }
                 else:

--- a/tests/test_cak_local_asset_path_ratchet.py
+++ b/tests/test_cak_local_asset_path_ratchet.py
@@ -3,11 +3,38 @@
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def tracked_files(search_root: Path) -> list[Path]:
+    """Return files Git tracks under ``search_root``.
+
+    The ratchet governs the repository's committed active surfaces. Walking the
+    filesystem instead would also read untracked local artifacts — editor state,
+    build output, or OS metadata such as ``.DS_Store`` — which are not part of
+    those surfaces and are not necessarily valid UTF-8.
+    """
+
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(ROOT),
+            "ls-files",
+            "-z",
+            "--",
+            search_root.relative_to(ROOT).as_posix(),
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return [ROOT / entry for entry in result.stdout.split("\0") if entry]
 
 # These are the reviewed active references at the CAK-178 implementation
 # baseline. New entries require an explicit ownership review rather than
@@ -51,7 +78,7 @@ class CakLocalAssetPathRatchetTests(unittest.TestCase):
         observed: set[tuple[str, str]] = set()
 
         for search_root in ACTIVE_SURFACE_ROOTS:
-            for path in search_root.rglob("*"):
+            for path in tracked_files(search_root):
                 if not path.is_file() or "__pycache__" in path.parts:
                     continue
                 relative = path.relative_to(ROOT).as_posix()

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3332,6 +3332,59 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(record["classification"], "blocking_unknown_other_worktree_administration")
         self.assertEqual(record["disposition"], "blocking")
 
+    def test_other_linked_worktree_git_managed_admin_creation_is_provisional(self):
+        module = load_script("claude_review_worktree_admin_creation", LAUNCHER)
+        environment = os.environ.copy()
+        linked = self.root / "provisional-admin-worktree"
+        subprocess.run(
+            ["git", "-C", str(self.candidate), "worktree", "add", "-q", "-b", "fixture-provisional", str(linked)],
+            check=True,
+        )
+        gitdir = Path(
+            subprocess.run(
+                ["git", "-C", str(linked), "rev-parse", "--absolute-git-dir"],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+            ).stdout.strip()
+        ).resolve()
+
+        # A Git-managed per-worktree administration file written mid-attempt is
+        # absent from the recorded admin_paths, so it cannot yet be attributed
+        # to that worktree's HEAD transition. It stays blocking, but must be
+        # eligible for the bounded stabilization window rather than triggering
+        # an immediate emergency stop on an intermediate observation.
+        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
+        (gitdir / "COMMIT_EDITMSG").write_text("fixture\n", encoding="utf-8")
+        changed = module.source_snapshot([self.candidate], self.candidate, environment)
+        comparison = module.snapshot_comparison(baseline, changed, live_monitoring=True)
+        record = next(
+            record
+            for record in comparison["git_admin_changes"]
+            if record["path"].endswith("COMMIT_EDITMSG")
+        )
+        self.assertEqual(record["classification"], "blocking_unattributed_other_worktree_administration")
+        self.assertEqual(record["disposition"], "blocking")
+        self.assertFalse(comparison["passed"])
+        self.assertTrue(module.provisional_attribution_only(comparison))
+
+        # An arbitrary file beside it is not Git-managed administration. Its
+        # presence must defeat the window for the whole observation, so a
+        # planted file cannot ride along with legitimate worktree activity.
+        (gitdir / "fixture-observation").write_text("planted\n", encoding="utf-8")
+        contaminated = module.source_snapshot([self.candidate], self.candidate, environment)
+        contaminated_comparison = module.snapshot_comparison(
+            baseline, contaminated, live_monitoring=True
+        )
+        planted = next(
+            record
+            for record in contaminated_comparison["git_admin_changes"]
+            if record["path"].endswith("fixture-observation")
+        )
+        self.assertEqual(planted["classification"], "blocking_unknown_other_worktree_administration")
+        self.assertEqual(planted["disposition"], "blocking")
+        self.assertFalse(module.provisional_attribution_only(contaminated_comparison))
+
     def test_other_linked_worktree_lock_is_bounded_provisional_activity(self):
         module = load_script("claude_review_other_worktree_lock", LAUNCHER)
         environment = os.environ.copy()

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3872,6 +3872,47 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(symlink_record["change_type"], "added")
         self.assertEqual(symlink_record["classification"], "blocking_lock_change")
 
+    def test_git_background_maintenance_lock_is_tolerated_and_others_stay_blocking(self):
+        module = load_script("claude_review_maintenance_lock", LAUNCHER)
+        environment = os.environ.copy()
+        git_directory = self.candidate / ".git"
+        objects_directory = git_directory / "objects"
+        objects_directory.mkdir(parents=True, exist_ok=True)
+
+        maintenance_lock = objects_directory / "maintenance.lock"
+        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
+        maintenance_lock.write_text("", encoding="utf-8")
+        changed = module.source_snapshot([self.candidate], self.candidate, environment)
+        comparison = module.snapshot_comparison(baseline, changed)
+        record = next(
+            record
+            for record in comparison["git_admin_changes"]
+            if record["path"] == "objects/maintenance.lock"
+        )
+        self.assertEqual(record["classification"], "tolerated_git_background_maintenance_lock")
+        self.assertEqual(record["disposition"], "tolerated")
+        self.assertTrue(record["evidence"]["protected_candidate_evidence_unchanged"])
+        self.assertTrue(comparison["passed"])
+        maintenance_lock.unlink()
+
+        # The admission is exact. A neighbouring lock under the same directory
+        # must remain fail-closed so this does not become a broad objects/
+        # exclusion.
+        neighbour_lock = objects_directory / "maintenance-other.lock"
+        neighbour_baseline = module.source_snapshot([self.candidate], self.candidate, environment)
+        neighbour_lock.write_text("", encoding="utf-8")
+        neighbour_changed = module.source_snapshot([self.candidate], self.candidate, environment)
+        neighbour_comparison = module.snapshot_comparison(neighbour_baseline, neighbour_changed)
+        neighbour_record = next(
+            record
+            for record in neighbour_comparison["git_admin_changes"]
+            if record["path"] == "objects/maintenance-other.lock"
+        )
+        self.assertEqual(neighbour_record["classification"], "blocking_lock_change")
+        self.assertEqual(neighbour_record["disposition"], "blocking")
+        self.assertFalse(neighbour_comparison["passed"])
+        neighbour_lock.unlink()
+
     def test_linked_worktree_common_git_admin_locks_are_detected(self):
         module = load_script("claude_review_linked_worktree_locks", LAUNCHER)
         environment = os.environ.copy()

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3335,6 +3335,14 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
     def test_other_linked_worktree_git_managed_admin_creation_is_provisional(self):
         module = load_script("claude_review_worktree_admin_creation", LAUNCHER)
         environment = os.environ.copy()
+
+        # exact_other_worktree_admin resolves any worktree present in both
+        # snapshots, because worktree_admin_identity records every
+        # WORKTREE_ADMIN_PATHS key unconditionally — absent files simply carry a
+        # None identity. Reaching the fallback therefore requires a worktree
+        # that the baseline snapshot does not know about at all, which is what
+        # adding it after the baseline produces.
+        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
         linked = self.root / "provisional-admin-worktree"
         subprocess.run(
             ["git", "-C", str(self.candidate), "worktree", "add", "-q", "-b", "fixture-provisional", str(linked)],
@@ -3348,42 +3356,55 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
                 stdout=subprocess.PIPE,
             ).stdout.strip()
         ).resolve()
-
-        # A Git-managed per-worktree administration file written mid-attempt is
-        # absent from the recorded admin_paths, so it cannot yet be attributed
-        # to that worktree's HEAD transition. It stays blocking, but must be
-        # eligible for the bounded stabilization window rather than triggering
-        # an immediate emergency stop on an intermediate observation.
-        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
         (gitdir / "COMMIT_EDITMSG").write_text("fixture\n", encoding="utf-8")
         changed = module.source_snapshot([self.candidate], self.candidate, environment)
         comparison = module.snapshot_comparison(baseline, changed, live_monitoring=True)
-        record = next(
+
+        # A Git-managed per-worktree administration file cannot yet be
+        # attributed to that worktree's HEAD transition. It stays blocking, but
+        # is eligible for the bounded window rather than triggering an
+        # immediate emergency stop on an intermediate observation.
+        admin_record = next(
             record
             for record in comparison["git_admin_changes"]
             if record["path"].endswith("COMMIT_EDITMSG")
         )
-        self.assertEqual(record["classification"], "blocking_unattributed_other_worktree_administration")
-        self.assertEqual(record["disposition"], "blocking")
-        self.assertFalse(comparison["passed"])
-        self.assertTrue(module.provisional_attribution_only(comparison))
+        self.assertEqual(
+            admin_record["classification"], "blocking_unattributed_other_worktree_administration"
+        )
+        self.assertEqual(admin_record["disposition"], "blocking")
+        self.assertEqual(
+            admin_record["evidence"]["provisional_attribution"],
+            "worktree_transition_not_yet_observed",
+        )
 
-        # An arbitrary file beside it is not Git-managed administration. Its
-        # presence must defeat the window for the whole observation, so a
-        # planted file cannot ride along with legitimate worktree activity.
+        # Adding a worktree also writes files that are not Git-managed
+        # per-worktree administration, such as gitdir and commondir. Those are
+        # not eligible, which both proves the predicate is exact and means this
+        # observation as a whole is not deferrable.
+        non_admin = [
+            record
+            for record in comparison["git_admin_changes"]
+            if record["path"].startswith("worktrees/")
+            and record["classification"] == "blocking_unknown_other_worktree_administration"
+        ]
+        self.assertTrue(non_admin)
+        self.assertFalse(module.provisional_attribution_only(comparison))
+        self.assertFalse(comparison["passed"])
+
+        # An arbitrary planted file under the same worktree is likewise never
+        # eligible, so it cannot buy itself a window.
         (gitdir / "fixture-observation").write_text("planted\n", encoding="utf-8")
         contaminated = module.source_snapshot([self.candidate], self.candidate, environment)
-        contaminated_comparison = module.snapshot_comparison(
-            baseline, contaminated, live_monitoring=True
-        )
         planted = next(
             record
-            for record in contaminated_comparison["git_admin_changes"]
+            for record in module.snapshot_comparison(
+                baseline, contaminated, live_monitoring=True
+            )["git_admin_changes"]
             if record["path"].endswith("fixture-observation")
         )
         self.assertEqual(planted["classification"], "blocking_unknown_other_worktree_administration")
         self.assertEqual(planted["disposition"], "blocking")
-        self.assertFalse(module.provisional_attribution_only(contaminated_comparison))
 
     def test_other_linked_worktree_lock_is_bounded_provisional_activity(self):
         module = load_script("claude_review_other_worktree_lock", LAUNCHER)
@@ -3946,23 +3967,27 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         objects_directory.mkdir(parents=True, exist_ok=True)
         maintenance_lock = objects_directory / "maintenance.lock"
 
-        # Admitted: bare creation of a regular file, observed live.
+        # Eligible for the bounded window, but never tolerated. The reviewer
+        # cannot establish the writing actor, so the observation stays blocking
+        # and only becomes deferrable; lifetime is what the window then tests.
         comparison, record = self._maintenance_lock_record(
             module,
             environment,
             lambda: maintenance_lock.write_text("", encoding="utf-8"),
             live_monitoring=True,
         )
-        self.assertEqual(record["classification"], "tolerated_git_background_maintenance_lock")
-        self.assertEqual(record["disposition"], "tolerated")
+        self.assertEqual(record["classification"], "blocking_unattributed_background_maintenance_lock")
+        self.assertEqual(record["disposition"], "blocking")
+        self.assertNotEqual(record["disposition"], "tolerated")
         self.assertEqual(record["evidence"]["admitted_observation_scope"], "live_monitoring_only")
         self.assertEqual(record["evidence"]["observed_kind"], "file")
-        self.assertTrue(comparison["passed"])
+        self.assertFalse(comparison["passed"])
+        self.assertTrue(module.provisional_attribution_only(comparison))
         maintenance_lock.unlink()
 
-        # Terminal postflight is unchanged by the admission. The same creation
-        # that live monitoring tolerates must still block at the terminal
-        # boundary, so a lock surviving the attempt is never masked.
+        # Terminal postflight never defers. The same creation must block there
+        # and must not be provisional, so a lock surviving the attempt is
+        # decided by the terminal boundary rather than masked.
         comparison, record = self._maintenance_lock_record(
             module,
             environment,
@@ -3972,6 +3997,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(record["classification"], "blocking_lock_change")
         self.assertEqual(record["disposition"], "blocking")
         self.assertFalse(comparison["passed"])
+        self.assertFalse(module.provisional_attribution_only(comparison))
 
         # Mutations of a pre-existing lock are not creations and stay blocking
         # even under live monitoring.

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3872,28 +3872,85 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(symlink_record["change_type"], "added")
         self.assertEqual(symlink_record["classification"], "blocking_lock_change")
 
-    def test_git_background_maintenance_lock_is_tolerated_and_others_stay_blocking(self):
-        module = load_script("claude_review_maintenance_lock", LAUNCHER)
-        environment = os.environ.copy()
-        git_directory = self.candidate / ".git"
-        objects_directory = git_directory / "objects"
-        objects_directory.mkdir(parents=True, exist_ok=True)
+    def _maintenance_lock_record(self, module, environment, mutate, *, live_monitoring):
+        """Apply one mutation under .git and return its classification record."""
 
-        maintenance_lock = objects_directory / "maintenance.lock"
         baseline = module.source_snapshot([self.candidate], self.candidate, environment)
-        maintenance_lock.write_text("", encoding="utf-8")
+        mutate()
         changed = module.source_snapshot([self.candidate], self.candidate, environment)
-        comparison = module.snapshot_comparison(baseline, changed)
+        comparison = module.snapshot_comparison(baseline, changed, live_monitoring=live_monitoring)
         record = next(
             record
             for record in comparison["git_admin_changes"]
             if record["path"] == "objects/maintenance.lock"
         )
+        return comparison, record
+
+    def test_git_background_maintenance_lock_admission_is_bounded(self):
+        module = load_script("claude_review_maintenance_lock", LAUNCHER)
+        environment = os.environ.copy()
+        objects_directory = self.candidate / ".git" / "objects"
+        objects_directory.mkdir(parents=True, exist_ok=True)
+        maintenance_lock = objects_directory / "maintenance.lock"
+
+        # Admitted: bare creation of a regular file, observed live.
+        comparison, record = self._maintenance_lock_record(
+            module,
+            environment,
+            lambda: maintenance_lock.write_text("", encoding="utf-8"),
+            live_monitoring=True,
+        )
         self.assertEqual(record["classification"], "tolerated_git_background_maintenance_lock")
         self.assertEqual(record["disposition"], "tolerated")
-        self.assertTrue(record["evidence"]["protected_candidate_evidence_unchanged"])
+        self.assertEqual(record["evidence"]["admitted_observation_scope"], "live_monitoring_only")
+        self.assertEqual(record["evidence"]["observed_kind"], "file")
         self.assertTrue(comparison["passed"])
         maintenance_lock.unlink()
+
+        # Terminal postflight is unchanged by the admission. The same creation
+        # that live monitoring tolerates must still block at the terminal
+        # boundary, so a lock surviving the attempt is never masked.
+        comparison, record = self._maintenance_lock_record(
+            module,
+            environment,
+            lambda: maintenance_lock.write_text("", encoding="utf-8"),
+            live_monitoring=False,
+        )
+        self.assertEqual(record["classification"], "blocking_lock_change")
+        self.assertEqual(record["disposition"], "blocking")
+        self.assertFalse(comparison["passed"])
+
+        # Mutations of a pre-existing lock are not creations and stay blocking
+        # even under live monitoring.
+        for label, mutate in (
+            ("content_changed", lambda: maintenance_lock.write_text("altered\n", encoding="utf-8")),
+            ("mode_changed", lambda: maintenance_lock.chmod(0o600)),
+            ("removed", maintenance_lock.unlink),
+        ):
+            with self.subTest(change=label):
+                comparison, record = self._maintenance_lock_record(
+                    module, environment, mutate, live_monitoring=True
+                )
+                self.assertEqual(record["disposition"], "blocking")
+                self.assertFalse(comparison["passed"])
+
+        # A symlink or directory at the admitted path is never admitted, so the
+        # exception cannot be used to reach outside the object store.
+        for label, mutate in (
+            ("symlink", lambda: maintenance_lock.symlink_to(self.candidate / "tracked.txt")),
+            ("directory", lambda: maintenance_lock.mkdir()),
+        ):
+            with self.subTest(created=label):
+                comparison, record = self._maintenance_lock_record(
+                    module, environment, mutate, live_monitoring=True
+                )
+                self.assertEqual(record["classification"], "blocking_lock_change")
+                self.assertEqual(record["disposition"], "blocking")
+                self.assertFalse(comparison["passed"])
+                if label == "symlink":
+                    maintenance_lock.unlink()
+                else:
+                    maintenance_lock.rmdir()
 
         # The admission is exact. A neighbouring lock under the same directory
         # must remain fail-closed so this does not become a broad objects/
@@ -3902,7 +3959,9 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         neighbour_baseline = module.source_snapshot([self.candidate], self.candidate, environment)
         neighbour_lock.write_text("", encoding="utf-8")
         neighbour_changed = module.source_snapshot([self.candidate], self.candidate, environment)
-        neighbour_comparison = module.snapshot_comparison(neighbour_baseline, neighbour_changed)
+        neighbour_comparison = module.snapshot_comparison(
+            neighbour_baseline, neighbour_changed, live_monitoring=True
+        )
         neighbour_record = next(
             record
             for record in neighbour_comparison["git_admin_changes"]

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3358,7 +3358,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         ).resolve()
         (gitdir / "COMMIT_EDITMSG").write_text("fixture\n", encoding="utf-8")
         changed = module.source_snapshot([self.candidate], self.candidate, environment)
-        comparison = module.snapshot_comparison(baseline, changed, live_monitoring=True)
+        comparison = module.snapshot_comparison(baseline, changed)
 
         # A Git-managed per-worktree administration file cannot yet be
         # attributed to that worktree's HEAD transition. It stays blocking, but
@@ -3399,7 +3399,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         planted = next(
             record
             for record in module.snapshot_comparison(
-                baseline, contaminated, live_monitoring=True
+                baseline, contaminated
             )["git_admin_changes"]
             if record["path"].endswith("fixture-observation")
         )
@@ -3945,111 +3945,6 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         )
         self.assertEqual(symlink_record["change_type"], "added")
         self.assertEqual(symlink_record["classification"], "blocking_lock_change")
-
-    def _maintenance_lock_record(self, module, environment, mutate, *, live_monitoring):
-        """Apply one mutation under .git and return its classification record."""
-
-        baseline = module.source_snapshot([self.candidate], self.candidate, environment)
-        mutate()
-        changed = module.source_snapshot([self.candidate], self.candidate, environment)
-        comparison = module.snapshot_comparison(baseline, changed, live_monitoring=live_monitoring)
-        record = next(
-            record
-            for record in comparison["git_admin_changes"]
-            if record["path"] == "objects/maintenance.lock"
-        )
-        return comparison, record
-
-    def test_git_background_maintenance_lock_admission_is_bounded(self):
-        module = load_script("claude_review_maintenance_lock", LAUNCHER)
-        environment = os.environ.copy()
-        objects_directory = self.candidate / ".git" / "objects"
-        objects_directory.mkdir(parents=True, exist_ok=True)
-        maintenance_lock = objects_directory / "maintenance.lock"
-
-        # Eligible for the bounded window, but never tolerated. The reviewer
-        # cannot establish the writing actor, so the observation stays blocking
-        # and only becomes deferrable; lifetime is what the window then tests.
-        comparison, record = self._maintenance_lock_record(
-            module,
-            environment,
-            lambda: maintenance_lock.write_text("", encoding="utf-8"),
-            live_monitoring=True,
-        )
-        self.assertEqual(record["classification"], "blocking_unattributed_background_maintenance_lock")
-        self.assertEqual(record["disposition"], "blocking")
-        self.assertNotEqual(record["disposition"], "tolerated")
-        self.assertEqual(record["evidence"]["admitted_observation_scope"], "live_monitoring_only")
-        self.assertEqual(record["evidence"]["observed_kind"], "file")
-        self.assertFalse(comparison["passed"])
-        self.assertTrue(module.provisional_attribution_only(comparison))
-        maintenance_lock.unlink()
-
-        # Terminal postflight never defers. The same creation must block there
-        # and must not be provisional, so a lock surviving the attempt is
-        # decided by the terminal boundary rather than masked.
-        comparison, record = self._maintenance_lock_record(
-            module,
-            environment,
-            lambda: maintenance_lock.write_text("", encoding="utf-8"),
-            live_monitoring=False,
-        )
-        self.assertEqual(record["classification"], "blocking_lock_change")
-        self.assertEqual(record["disposition"], "blocking")
-        self.assertFalse(comparison["passed"])
-        self.assertFalse(module.provisional_attribution_only(comparison))
-
-        # Mutations of a pre-existing lock are not creations and stay blocking
-        # even under live monitoring.
-        for label, mutate in (
-            ("content_changed", lambda: maintenance_lock.write_text("altered\n", encoding="utf-8")),
-            ("mode_changed", lambda: maintenance_lock.chmod(0o600)),
-            ("removed", maintenance_lock.unlink),
-        ):
-            with self.subTest(change=label):
-                comparison, record = self._maintenance_lock_record(
-                    module, environment, mutate, live_monitoring=True
-                )
-                self.assertEqual(record["disposition"], "blocking")
-                self.assertFalse(comparison["passed"])
-
-        # A symlink or directory at the admitted path is never admitted, so the
-        # exception cannot be used to reach outside the object store.
-        for label, mutate in (
-            ("symlink", lambda: maintenance_lock.symlink_to(self.candidate / "tracked.txt")),
-            ("directory", lambda: maintenance_lock.mkdir()),
-        ):
-            with self.subTest(created=label):
-                comparison, record = self._maintenance_lock_record(
-                    module, environment, mutate, live_monitoring=True
-                )
-                self.assertEqual(record["classification"], "blocking_lock_change")
-                self.assertEqual(record["disposition"], "blocking")
-                self.assertFalse(comparison["passed"])
-                if label == "symlink":
-                    maintenance_lock.unlink()
-                else:
-                    maintenance_lock.rmdir()
-
-        # The admission is exact. A neighbouring lock under the same directory
-        # must remain fail-closed so this does not become a broad objects/
-        # exclusion.
-        neighbour_lock = objects_directory / "maintenance-other.lock"
-        neighbour_baseline = module.source_snapshot([self.candidate], self.candidate, environment)
-        neighbour_lock.write_text("", encoding="utf-8")
-        neighbour_changed = module.source_snapshot([self.candidate], self.candidate, environment)
-        neighbour_comparison = module.snapshot_comparison(
-            neighbour_baseline, neighbour_changed, live_monitoring=True
-        )
-        neighbour_record = next(
-            record
-            for record in neighbour_comparison["git_admin_changes"]
-            if record["path"] == "objects/maintenance-other.lock"
-        )
-        self.assertEqual(neighbour_record["classification"], "blocking_lock_change")
-        self.assertEqual(neighbour_record["disposition"], "blocking")
-        self.assertFalse(neighbour_comparison["passed"])
-        neighbour_lock.unlink()
 
     def test_linked_worktree_common_git_admin_locks_are_detected(self):
         module = load_script("claude_review_linked_worktree_locks", LAUNCHER)


### PR DESCRIPTION
Two lanes in one PR at the maintainer's explicit direction. The doctrine lane implements the taxonomy half of CAK-182; the launcher lane fixes validation defects surfaced while getting that lane green.

Linear: CAK-182, CAK-175

Reviewed independently by Codex across three rounds. Final verdicts at `0e7a342`: doctrine ACCEPT, launcher ACCEPT, combined ACCEPT, no actionable findings. Disposition record is in the PR comments.

## Lane 1 — doctrine (CAK-182), `docs/core-model.md`

Two subsections under Interactive Control And Bounded Execution:

**Independent Review As A Third Role** — names the reviewer role as scoped to a run rather than to a product, vendor, model, effort setting, or thread. It deliberately does not restate what independence requires; `external-ai-reviewer.md` stays canonical owner and the text says so.

**Surface Classes** — `conversational`, `agentic-local`, `agentic-remote`, defined by repository locality alone. Initiation is a separate property, not a fourth class, so an unattended run on an agentic-local surface remains agentic-local. Executor adapters own the product mapping and `core-model.md` enumerates no products; until an adapter declares a class for a surface, the section places no obligation on it.

**Existing naming kept.** CAK-182 proposed renaming to control-plane / executor. The existing `interactive controller` / `bounded executor` terms already carry the vendor-neutral semantics, and the four existing `control plane` occurrences are one correct adapter projection (`tool-adapters/chatgpt.md:61`) plus three incidental prose references — no competing vocabulary to resolve. `surface class` appeared zero times before this change.

## Lane 2 — launcher and validation (CAK-175)

**`scripts/claude-review` — worktree attribution race.** `exact_other_worktree_admin` matches only paths already recorded in a worktree's `admin_paths`, so a Git-managed administration file created mid-attempt fell through to the non-deferrable branch even though terminal postflight attributed it correctly. This produced spurious emergency stops: the same path appeared twice in `live_observed_git_admin_changes` with opposite dispositions. The exact `WORKTREE_ADMIN_PATHS` names are now eligible for the existing bounded stabilization window when protected evidence is unchanged and the identity change is safely tolerable. Every other path under another worktree's Git directory stays non-deferrable, so a planted file cannot buy itself a window.

**`tests/test_cak_local_asset_path_ratchet.py` — walk tracked files.** It used `rglob("*")` and UTF-8-decoded every file under `scripts/`, `docs/`, `.codex/`, including untracked ones. A macOS `docs/.DS_Store` raised `UnicodeDecodeError` and failed `make check` locally while CI, with a clean checkout, never saw it. The ratchet governs committed active surfaces, so it now walks `git ls-files`.

**`Makefile` — exclude `.worktrees/` from markdownlint.** `"**/*.md"` also linted every repo-local worktree checkout: 273 files locally against 55 in CI. A markdown error on an unrelated branch's worktree could fail the current branch's `make check`, and local validation covered a different file set than CI.

**Not present: any maintenance-lock exception.** Three successive attempts to admit `objects/maintenance.lock` were rejected in review, and the handling was removed entirely rather than reformulated a fourth time. `external-ai-reviewer.md` permits stabilization only for shared-object and other-worktree attribution races, and any lock exception requires controller ownership plus exact path, actor, and lifetime. Actor is not observable from the reviewer side — the writing process is another operator's Git — so no formulation could satisfy the contract. Maintenance locks follow ordinary fail-closed lock classification. The root cause belongs to CAK-175's auto-maintenance disable, which removes the source rather than excusing the symptom.

## Materiality

**Material — trigger 3, cross-boundary contract**, confirmed in independent review. Surface Classes adds a normative obligation at a boundary among Playbook canonical owners: where an adapter has declared a class, a required contract depending on a capability that class lacks must fail closed rather than substitute a weaker route.

Trigger 1 does not apply: the reviewer subsection assigns evidence production, not authorization or decision authority. Lane 2 is non-material on its own; the combined PR inherits the doctrine lane's classification.

Per `feature-lifecycle.md` § Doctrine Promotion, governed independent review is complete. The explicit human promotion decision against this exact artifact remains separate from merge and is not granted by the reviewer verdict.

## Validation

- CI green at `0e7a342`: Markdown Lint and authoritative-source-check
- `make check` green on the maintainer's workstation, git 2.55, 291 tests
- `test_cak_local_asset_path_ratchet` has fail-before/pass-after evidence against a planted `.DS_Store` carrying the same `0x86`-at-position-23 sequence as the reported failure
- The authoring environment runs git 2.34.1 and cannot execute the launcher suite, which requires git ≥ 2.36.0 for `git worktree list --porcelain -z`. Every launcher assertion here was first executed on the maintainer's workstation and in CI, not by the author.

## Known residual, not blocking

The stabilization window is bounded — `provisional_object_change_since` anchors on the first provisional observation and is not extended by later ones — but it resets on any poll that is not provisional-only, including a poll with no changes. Alternating quiet and provisional observations therefore yield repeated fresh windows rather than one. This predates the PR and governs shared objects and unrelated refs equally; nothing is tolerated and terminal postflight stays decisive, so candidate integrity is unaffected. What is lost in that scenario is the early stop, not the verdict. Recorded on CAK-175.