### PR TITLE
fix: name the Git capability requirement and stop self-inflicted maintenance locks

### DIFF
--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -167,9 +167,10 @@ under a nested host sandbox showed that it can make every granted Bash command
 unusable. Instead, the controller independently executes each configured
 command before review under a safe environment that disables system Git
 and user Git configuration, repository hooks and filesystem monitors, external
-diffs, optional Git locks, pagers, Python bytecode writes, Claude instruction
-memory loading, and Claude auto memory, with the provider working directory and
-temporary state redirected to fresh attempt-local scratch through the qualified
+diffs, optional Git locks, background auto-maintenance, pagers, Python bytecode
+writes, Claude instruction memory loading, and Claude auto memory, with the
+provider working directory and temporary state redirected to fresh
+attempt-local scratch through the qualified
 macOS or Linux route in
 [`repo-readiness.md`](../repo-readiness.md#repo-local-workflow-state).
 It accepts only the exact Git status, diff, log, and revision forms needed by
@@ -178,6 +179,21 @@ revision grammar prevents unresolved operands from falling through to Git's
 filesystem comparison behavior. Explicit or inferred `diff --no-index`, path
 operands, traversal, unadmitted pathspec magic, shell forms, configuration
 overrides, text conversion, and external diff fail before provider launch.
+
+Disabling background auto-maintenance removes the controller as a source of
+`objects/maintenance.lock` in the candidate repository. It does not remove
+another operator's Git, which does not share this environment. A lock created
+by that actor remains reviewer side-effect contamination and still fails
+closed, because the reviewer cannot establish the writing actor and
+[`external-ai-reviewer.md`](../external-ai-reviewer.md) admits only a
+controller-owned transient lock identified by exact path, actor, and lifetime.
+
+Linked-worktree modelling requires `git worktree list --porcelain -z`, which
+Git introduced in 2.36.0. The launcher probes that exact capability before
+taking its first snapshot and fails closed naming the requirement and the
+observed version, because the unsupported switch would otherwise surface from
+inside snapshot collection and be reported as a review contract failure that
+names neither Git nor the version.
 
 The first configured exact command is also an in-provider capability canary.
 The system prompt requires it before substantive analysis, and the controller

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -2436,22 +2436,48 @@ def trusted_system_executable(name: str, environment: dict[str, str]) -> Path:
     return path
 
 
-GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL = "2.36.0"
+GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL = (2, 36, 0)
 
 
-def git_worktree_capability_error(candidate: Path, environment: dict[str, str]) -> str | None:
-    """Return a named cause when Git cannot support linked-worktree modelling.
+def parsed_git_version(reported: str | None) -> tuple[int, int, int] | None:
+    """Extract a comparable version from ``git --version`` output, if present."""
+
+    if not reported:
+        return None
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", reported)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3) or 0)
+
+
+def git_worktree_capability_error(
+    candidate: Path,
+    environment: dict[str, str],
+) -> tuple[str, str] | None:
+    """Return ``(failure_classification, cause)`` when the required Git command cannot run.
 
     Attribution depends on ``git worktree list --porcelain -z``, which Git
     introduced in 2.36.0. Without this probe the unsupported switch surfaces
     from inside snapshot collection, and the attempt is reported as a review
     contract failure that names neither Git nor the version requirement.
+
+    A nonzero exit is not by itself evidence of an unsupported switch. The
+    command also fails when the candidate is not a repository, is unreadable,
+    or has damaged administration, and config loading only requires the
+    candidate to be an existing directory. The observed version is therefore
+    the discriminator: a Git at or above the minimum cannot be lacking the
+    capability, so that failure keeps the ordinary command-preflight
+    classification and its underlying cause. Only a Git below the minimum is
+    reported as a capability gap, and every branch preserves the cause so the
+    operator is not sent toward the wrong remediation.
     """
 
     try:
         executable = trusted_system_executable("git", environment)
     except (OSError, RuntimeError) as error:
-        return f"git is unavailable or is not trusted system code: {error}"
+        return "access_or_command_preflight_failure", (
+            f"git is unavailable or is not trusted system code: {error}"
+        )
     try:
         result = subprocess.run(
             [str(executable), "-C", str(candidate), "worktree", "list", "--porcelain", "-z"],
@@ -2460,16 +2486,31 @@ def git_worktree_capability_error(candidate: Path, environment: dict[str, str]) 
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            text=True,
         )
     except OSError as error:
-        return f"git could not be executed: {error}"
+        return "access_or_command_preflight_failure", f"git could not be executed: {error}"
     if result.returncode == 0:
         return None
-    observed = version_of(str(executable), environment, cwd=str(candidate))
-    return (
-        "git does not support 'worktree list --porcelain -z', which governed review "
-        f"requires for linked-worktree attribution: minimum "
-        f"{GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL}, observed {observed or 'unknown'}"
+    detail = bounded_redacted(result.stderr.strip()) or f"exit status {result.returncode}"
+    minimum = ".".join(str(part) for part in GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL)
+    reported = version_of(str(executable), environment, cwd=str(candidate))
+    observed = parsed_git_version(reported)
+    if observed is not None and observed >= GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL:
+        return "access_or_command_preflight_failure", (
+            "'git worktree list --porcelain -z' failed against the candidate, and the "
+            f"observed git {reported} is at or above the {minimum} required for that "
+            f"command, so this is not a capability gap: {detail}"
+        )
+    if observed is not None:
+        return "git_capability_preflight_failure", (
+            "git does not support 'worktree list --porcelain -z', which governed review "
+            f"requires for linked-worktree attribution: minimum {minimum}, observed "
+            f"{reported}: {detail}"
+        )
+    return "access_or_command_preflight_failure", (
+        "'git worktree list --porcelain -z' failed and the git version could not be "
+        f"determined, so no capability claim is made: {detail}"
     )
 
 
@@ -2939,18 +2980,19 @@ def run_governed_review(
     with AttemptScratch.allocate(child_environment, "claude-review-controller-") as scratch:
         controller_environment = safe_command_environment(child_environment, scratch)
         environment = controller_environment
-        git_capability_error = git_worktree_capability_error(config.candidate, environment)
-        if git_capability_error is not None:
+        git_capability_failure = git_worktree_capability_error(config.candidate, environment)
+        if git_capability_failure is not None:
+            git_failure_classification, git_failure_cause = git_capability_failure
             record = {
                 "kind": "claude_governed_review",
                 "review_id": config.body["review_id"],
                 "contract_id": config.body["contract_id"],
                 "controller_id": controller_id,
                 "contract_identity": contract_identity,
-                "failure_classification": "git_capability_preflight_failure",
+                "failure_classification": git_failure_classification,
                 "candidate_verdict": "not_produced",
                 "substantive_review_started": False,
-                "error": git_capability_error,
+                "error": git_failure_cause,
             }
             emit_diagnostics(record, diagnostics_destination)
             return REVIEWER_FAILURE_EXIT

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -2146,13 +2146,23 @@ def safe_command_environment(base: dict[str, str], scratch: Path) -> dict[str, s
             "GIT_ATTR_NOSYSTEM": "1",
             "GIT_CONFIG_GLOBAL": "/dev/null",
             "GIT_CONFIG_NOSYSTEM": "1",
-            "GIT_CONFIG_COUNT": "3",
+            "GIT_CONFIG_COUNT": "5",
             "GIT_CONFIG_KEY_0": "core.hooksPath",
             "GIT_CONFIG_VALUE_0": str(hooks),
             "GIT_CONFIG_KEY_1": "core.fsmonitor",
             "GIT_CONFIG_VALUE_1": "false",
             "GIT_CONFIG_KEY_2": "core.untrackedCache",
             "GIT_CONFIG_VALUE_2": "false",
+            # Background auto-maintenance writes objects/maintenance.lock into the
+            # candidate repository, which the classifier then correctly reports as
+            # lock contamination. Disabling it here removes the controller as a
+            # source of that contamination. It cannot remove another operator's
+            # Git, which does not share this environment; that case still fails
+            # closed, which is the contract in external-ai-reviewer.md.
+            "GIT_CONFIG_KEY_3": "maintenance.auto",
+            "GIT_CONFIG_VALUE_3": "false",
+            "GIT_CONFIG_KEY_4": "gc.auto",
+            "GIT_CONFIG_VALUE_4": "0",
             "GIT_EXTERNAL_DIFF": "/usr/bin/false",
             "GIT_OPTIONAL_LOCKS": "0",
             "GIT_PAGER": "cat",
@@ -2424,6 +2434,43 @@ def trusted_system_executable(name: str, environment: dict[str, str]) -> Path:
     if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0 or stat.S_IMODE(metadata.st_mode) & 0o022:
         raise RuntimeError(f"observational command executable is not trusted system code: {path}")
     return path
+
+
+GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL = "2.36.0"
+
+
+def git_worktree_capability_error(candidate: Path, environment: dict[str, str]) -> str | None:
+    """Return a named cause when Git cannot support linked-worktree modelling.
+
+    Attribution depends on ``git worktree list --porcelain -z``, which Git
+    introduced in 2.36.0. Without this probe the unsupported switch surfaces
+    from inside snapshot collection, and the attempt is reported as a review
+    contract failure that names neither Git nor the version requirement.
+    """
+
+    try:
+        executable = trusted_system_executable("git", environment)
+    except (OSError, RuntimeError) as error:
+        return f"git is unavailable or is not trusted system code: {error}"
+    try:
+        result = subprocess.run(
+            [str(executable), "-C", str(candidate), "worktree", "list", "--porcelain", "-z"],
+            check=False,
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except OSError as error:
+        return f"git could not be executed: {error}"
+    if result.returncode == 0:
+        return None
+    observed = version_of(str(executable), environment, cwd=str(candidate))
+    return (
+        "git does not support 'worktree list --porcelain -z', which governed review "
+        f"requires for linked-worktree attribution: minimum "
+        f"{GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL}, observed {observed or 'unknown'}"
+    )
 
 
 def preflight_review(config: GovernedReviewConfig, environment: dict[str, str]) -> dict[str, object]:
@@ -2892,6 +2939,21 @@ def run_governed_review(
     with AttemptScratch.allocate(child_environment, "claude-review-controller-") as scratch:
         controller_environment = safe_command_environment(child_environment, scratch)
         environment = controller_environment
+        git_capability_error = git_worktree_capability_error(config.candidate, environment)
+        if git_capability_error is not None:
+            record = {
+                "kind": "claude_governed_review",
+                "review_id": config.body["review_id"],
+                "contract_id": config.body["contract_id"],
+                "controller_id": controller_id,
+                "contract_identity": contract_identity,
+                "failure_classification": "git_capability_preflight_failure",
+                "candidate_verdict": "not_produced",
+                "substantive_review_started": False,
+                "error": git_capability_error,
+            }
+            emit_diagnostics(record, diagnostics_destination)
+            return REVIEWER_FAILURE_EXIT
         initial_snapshot = source_snapshot(
             list(config.guard_roots), config.candidate, environment, config.allowed_commands, config.candidate_head
         )

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3297,6 +3297,38 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertFalse(comparison["passed"])
         self.assertIn(f"git-admin:objects/{object_id[:2]}/{object_id[2:]}", comparison["blocking_paths"])
 
+    def test_safe_command_environment_disables_background_maintenance(self):
+        module = load_script("claude_review_maintenance_env", LAUNCHER)
+        environment = module.safe_command_environment(os.environ.copy(), self.root)
+        declared = int(environment["GIT_CONFIG_COUNT"])
+        pairs = {
+            environment[f"GIT_CONFIG_KEY_{index}"]: environment[f"GIT_CONFIG_VALUE_{index}"]
+            for index in range(declared)
+        }
+        # Git silently ignores pairs beyond GIT_CONFIG_COUNT, so a stale count
+        # would disable these settings without producing any error.
+        self.assertEqual(len(pairs), declared)
+        self.assertEqual(pairs["maintenance.auto"], "false")
+        self.assertEqual(pairs["gc.auto"], "0")
+
+    def test_git_worktree_capability_probe_reports_named_causes(self):
+        module = load_script("claude_review_git_capability", LAUNCHER)
+        environment = os.environ.copy()
+        environment["PATH"] = "/usr/bin:/bin"
+
+        # A Git supporting the required switch clears the probe.
+        self.assertIsNone(module.git_worktree_capability_error(self.candidate, environment))
+
+        # The caller has no exception handling around this probe, so an absent
+        # or untrusted Git must return a named cause rather than raise.
+        # Reporting an unsupported Git beats a review contract failure that
+        # names neither Git nor the requirement.
+        absent = module.git_worktree_capability_error(
+            self.candidate, {"PATH": str(self.root / "absent")}
+        )
+        self.assertIsInstance(absent, str)
+        self.assertIn("git", absent)
+
     def test_arbitrary_other_linked_worktree_administration_is_blocking(self):
         module = load_script("claude_review_other_worktree_admin", LAUNCHER)
         environment = os.environ.copy()

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3320,14 +3320,47 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertIsNone(module.git_worktree_capability_error(self.candidate, environment))
 
         # The caller has no exception handling around this probe, so an absent
-        # or untrusted Git must return a named cause rather than raise.
-        # Reporting an unsupported Git beats a review contract failure that
-        # names neither Git nor the requirement.
+        # or untrusted Git must return a named cause rather than raise. It is
+        # also not a capability gap, so it keeps the ordinary command-preflight
+        # classification.
         absent = module.git_worktree_capability_error(
             self.candidate, {"PATH": str(self.root / "absent")}
         )
-        self.assertIsInstance(absent, str)
-        self.assertIn("git", absent)
+        self.assertIsNotNone(absent)
+        classification, cause = absent
+        self.assertEqual(classification, "access_or_command_preflight_failure")
+        self.assertIn("git", cause)
+
+    def test_git_probe_does_not_blame_the_git_version_for_other_failures(self):
+        # A nonzero exit is not evidence of an unsupported switch. Config
+        # loading only requires the candidate to be an existing directory, so a
+        # non-repository reaches this probe and previously produced the
+        # self-contradicting claim that a supported Git was too old.
+        module = load_script("claude_review_git_non_repository", LAUNCHER)
+        environment = os.environ.copy()
+        environment["PATH"] = "/usr/bin:/bin"
+        non_repository = self.root / "not-a-repository"
+        non_repository.mkdir()
+
+        failure = module.git_worktree_capability_error(non_repository, environment)
+        self.assertIsNotNone(failure)
+        classification, cause = failure
+        self.assertEqual(classification, "access_or_command_preflight_failure")
+        self.assertNotIn("does not support", cause)
+        self.assertIn("is not a capability gap", cause)
+
+    def test_parsed_git_version_extracts_comparable_versions(self):
+        module = load_script("claude_review_git_version", LAUNCHER)
+        self.assertEqual(module.parsed_git_version("git version 2.50.1 (Apple Git-155)"), (2, 50, 1))
+        self.assertEqual(module.parsed_git_version("git version 2.36"), (2, 36, 0))
+        self.assertIsNone(module.parsed_git_version("git version unknown"))
+        self.assertIsNone(module.parsed_git_version(None))
+        # The comparison must order by component, not lexically: "2.9" is older
+        # than "2.36" but sorts after it as text.
+        self.assertLess(
+            module.parsed_git_version("git version 2.9.5"),
+            module.GIT_MINIMUM_VERSION_FOR_WORKTREE_NUL,
+        )
 
     def test_arbitrary_other_linked_worktree_administration_is_blocking(self):
         module = load_script("claude_review_other_worktree_admin", LAUNCHER)


### PR DESCRIPTION
Two of the three items left open on CAK-175 after #361.

Linear: CAK-175

Reviewed independently by Codex across two rounds. Final verdict at `6e57d1c`: no new findings, ready to merge. Disposition record is in the PR comments.

## Git capability preflight

Linked-worktree attribution depends on `git worktree list --porcelain -z`, which Git introduced in **2.36.0**. That minimum was undocumented, and the failure mode hid it: the first source snapshot runs *before* `preflight_review`, so an older Git surfaced the unsupported switch from inside snapshot collection and the attempt was reported as `review_contract_failure` with `candidate_verdict: not_produced` — naming neither Git nor the requirement.

The launcher now probes that exact capability immediately after building the controller environment and before the first snapshot, failing closed with a classification and a cause.

**The observed version is the discriminator, not the exit code.** A nonzero exit is not by itself evidence of an unsupported switch: the command also fails when the candidate is not a repository, is unreadable, or has damaged administration, and config loading only requires the candidate to be an existing directory. So a Git at or above the minimum keeps `access_or_command_preflight_failure` and carries the underlying stderr; only a Git below the minimum is reported as `git_capability_preflight_failure`; an unparseable version makes no capability claim at all. Every branch preserves the cause, so the operator is not sent toward the wrong remediation.

The probe returns a cause rather than raising, because its caller has no exception handling around it.

## Background auto-maintenance

`safe_command_environment` already disables hooks, filesystem monitors, external diffs, optional locks, and system and user Git configuration — but not `maintenance.auto` or `gc.auto`. The controller's own Git commands against the candidate could therefore create the `objects/maintenance.lock` that the classifier then correctly reported as contamination. Both are now disabled, removing the controller as a source.

**This does not remove another operator's Git**, which does not share this environment. A lock created by that actor remains reviewer side-effect contamination and still fails closed — the contract #361 restored by deleting the admission attempt. The scope limit is stated in the adapter rather than left implied.

## Tests

- The `GIT_CONFIG_COUNT`/pair-count invariant, since a stale count makes Git silently ignore the tail and would disable both new settings with no error.
- A non-repository candidate produces `access_or_command_preflight_failure` and never claims a version gap.
- Version parsing, including the lexical trap where `"2.9"` sorts after `"2.36"` as text but is older.
- The probe returns causes rather than raising.

## Documentation

`docs/tool-adapters/claude.md` records the 2.36.0 minimum, that the launcher probes it before the first snapshot, and the auto-maintenance scope limit above.

## Validation

- CI green at `6e57d1c`: Markdown Lint and authoritative-source-check
- `make check` green on the maintainer's workstation, **295 tests** — the first execution of both the probe's success path and the non-repository regression, since each requires a root-owned Git
- Full suite delta in the authoring environment: no new failures beyond tests requiring that root-owned Git. That environment runs Git 2.34.1 and its `/usr/bin/git` is not root-owned, so the launcher suite cannot execute there.
- The version parser and the probe's failure paths were verified directly in that environment.

## Not included

CAK-175's third open item, the stabilization-window reset. On examination it is likely not a defect: a quiet poll means the provisional change reverted entirely, so resetting the anchor is correct, and exploiting it would require creating and fully removing a file repeatedly — leaving nothing at terminal postflight to mask. Recorded on CAK-175 with that reasoning rather than fixed.