### PR TITLE
docs: route Claude Chat and Cowork hydration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,8 @@
 # CLAUDE.md
 
-This file routes Claude Code sessions to the canonical instruction sources.
-It is not an authority layer and contains no doctrine of its own.
+This file routes Claude Code and desktop Cowork sessions with repository
+locality to the canonical instruction sources. It is not an authority layer
+and contains no doctrine of its own.
 
 Read these routing sources in startup order:
 

--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -47,13 +47,23 @@ provider surfaces:
 
 - **Claude Code user-global instructions:** place it in
   `~/.claude/CLAUDE.md` between the same managed markers.
-- **Claude profile instructions:** click the account initials, open
-  **Settings**, and install and verify the body under **Instructions for
-  Claude** when ordinary Claude Chat conversations may start CAK repository
-  work.
-- **Claude Cowork global instructions:** install and verify the body through
-  **Settings > Cowork > Global instructions** when Cowork sessions may start
-  CAK repository work.
+- **Claude account instructions:** Anthropic currently documents
+  **Instructions for Claude** as an account-wide setting reached from the
+  account initials and **Settings**. Install and verify the body there when
+  Claude conversations may start CAK repository work; do not classify this
+  account surface as Chat-only.
+- **Claude runtime account preferences:** when a current session exposes one
+  or more `user_preferences` blocks, audit them as a separate observed
+  instruction transport until their owning hosted setting and precedence are
+  established. Remove or reconcile stale CAK directives such as unconditional
+  "before answering" wording; do not assume an edit to another visible field
+  changed these injected blocks.
+- **Claude Cowork global instructions:** Anthropic currently documents
+  **Settings > Cowork**, then **Global instructions**, for standing Cowork
+  instructions. Verify that destination in the current account and product
+  build before installation. If the route is not exposed, record the observed
+  capability gap instead of substituting account instructions or installing a
+  duplicate in another field.
 - **ChatGPT account custom instructions:** install and verify the body through
   the hosted Personalization surface.
 - **ChatGPT CAK project instructions:** install and verify the body through the
@@ -65,20 +75,24 @@ them separately; do not collapse them into one ambiguous "project/custom"
 surface. They are manual hosted projections, not prerequisites for the
 immediate Codex desktop repair.
 
-Claude profile and Cowork global instructions are also distinct hosted/manual
-configuration surfaces. They are not read or changed by this distribution or
-its local-file validator. Reconcile older unconditional wording such as
-"always fetch before answering" to the canonical timing and fail-closed
-retrieval semantics; do not claim local validator coverage for either surface.
-Use Claude project or Cowork folder instructions for project-specific context,
-not as another copy of the global router when the corresponding account-level
-surface already covers the run.
+Claude account instructions, runtime account preferences, and Cowork global
+instructions are independently audited hosted transports. They are not read or
+changed by this distribution or its local-file validator. Reconcile older
+unconditional wording such as "always fetch before answering" to the canonical
+timing and fail-closed retrieval semantics; do not claim local validator
+coverage for any hosted surface. Use Claude project or Cowork folder
+instructions for project-specific context, not as another copy of the global
+router when the corresponding account-level surface already covers the run.
 
-Anthropic documents **Instructions for Claude** as account-wide and Cowork
-Global instructions as applying to every Cowork session, but does not publish
-their combined precedence or deduplication behavior. Verify them separately and
-do not infer that the profile setting alone covers Cowork. If a runtime presents
-the same canonical router through both, treat the copies as one idempotent
+Anthropic documents
+[**Instructions for Claude**](https://support.claude.com/en/articles/10185728-understanding-claude-s-personalization-features)
+as account-wide for conversations and
+[Cowork Global instructions](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork)
+as applying to every Cowork session, but does not publish their combined
+precedence, their relationship to runtime `user_preferences` blocks, or
+deduplication behavior. Verify them separately and do not infer that account
+instructions alone cover Cowork. If a runtime presents the same canonical
+router through more than one transport, treat the copies as one idempotent
 bootstrap trigger under the persistence rule, not as separate doctrine or a
 reason to retrieve once per copy.
 
@@ -130,12 +144,14 @@ python3 scripts/check_global_bootstrap.py \
   --require-claude
 ```
 
-The Claude profile, Claude Cowork global, ChatGPT account, and ChatGPT CAK
+Claude account instructions, observed runtime account preferences, Claude
+Cowork global instructions, ChatGPT account instructions, and ChatGPT CAK
 project instructions are each validated by direct comparison during manual
-installation because the providers do not expose those hosted surfaces as
-local files. That is a capability gap, not equivalent to the local byte check:
-record the surface, canonical router commit, and verification time in the
-owning rollout issue so later drift checks have an explicit baseline.
+installation or runtime audit because the providers do not expose those hosted
+surfaces as local files. That is a capability gap, not equivalent to the local
+byte check: record the surface, observed owner or unresolved provenance,
+canonical router commit, and verification time in the owning rollout issue so
+later drift checks have an explicit baseline.
 
 ## Local Reconciliation
 

--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -47,6 +47,12 @@ provider surfaces:
 
 - **Claude Code user-global instructions:** place it in
   `~/.claude/CLAUDE.md` between the same managed markers.
+- **Claude profile instructions:** install and verify the body through the
+  hosted profile-instructions surface when ordinary Claude Chat conversations
+  may start CAK repository work.
+- **Claude Cowork global instructions:** install and verify the body through
+  **Settings > Cowork > Global instructions** when Cowork sessions may start
+  CAK repository work.
 - **ChatGPT account custom instructions:** install and verify the body through
   the hosted Personalization surface.
 - **ChatGPT CAK project instructions:** install and verify the body through the
@@ -58,12 +64,14 @@ them separately; do not collapse them into one ambiguous "project/custom"
 surface. They are manual hosted projections, not prerequisites for the
 immediate Codex desktop repair.
 
-Claude Cowork Settings preferences are another hosted/manual instruction
-surface. They are not read or changed by this distribution or its local-file
-validator. If that surface contains older unconditional wording such as
-"always fetch before answering," reconcile it manually to the same
-first-action/material-change timing and fail-closed retrieval semantics; do not
-claim local validator coverage for it.
+Claude profile and Cowork global instructions are also distinct hosted/manual
+configuration surfaces. They are not read or changed by this distribution or
+its local-file validator. Reconcile older unconditional wording such as
+"always fetch before answering" to the canonical timing and fail-closed
+retrieval semantics; do not claim local validator coverage for either surface.
+Use Claude project or Cowork folder instructions for project-specific context,
+not as another copy of the global router when the corresponding account-level
+surface already covers the run.
 
 Use these markers around the exact router body in the Codex and Claude local
 files:
@@ -113,11 +121,12 @@ python3 scripts/check_global_bootstrap.py \
   --require-claude
 ```
 
-The ChatGPT account and CAK project instructions are each validated by direct
-comparison during manual installation because the provider does not expose
-either hosted surface as a local file. That is a capability gap, not equivalent
-to the local byte check: record the canonical router commit and verification
-time in the owning rollout issue so later drift checks have an explicit baseline.
+The Claude profile, Claude Cowork global, ChatGPT account, and ChatGPT CAK
+project instructions are each validated by direct comparison during manual
+installation because the providers do not expose those hosted surfaces as
+local files. That is a capability gap, not equivalent to the local byte check:
+record the surface, canonical router commit, and verification time in the
+owning rollout issue so later drift checks have an explicit baseline.
 
 ## Local Reconciliation
 

--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -57,7 +57,9 @@ provider surfaces:
   instruction transport until their owning hosted setting and precedence are
   established. Remove or reconcile stale CAK directives such as unconditional
   "before answering" wording; do not assume an edit to another visible field
-  changed these injected blocks.
+  changed these injected blocks. When the owner cannot be established, record
+  unresolved provenance and continue treating the stale directive as active;
+  do not claim that it was repaired.
 - **Claude Cowork global instructions:** Anthropic currently documents
   **Settings > Cowork**, then **Global instructions**, for standing Cowork
   instructions. Verify that destination in the current account and product
@@ -81,8 +83,10 @@ changed by this distribution or its local-file validator. Reconcile older
 unconditional wording such as "always fetch before answering" to the canonical
 timing and fail-closed retrieval semantics; do not claim local validator
 coverage for any hosted surface. Use Claude project or Cowork folder
-instructions for project-specific context, not as another copy of the global
-router when the corresponding account-level surface already covers the run.
+instructions for project-specific context, never as another copy of the global
+router. When no verified global transport covers a run, record the gap and use
+an explicit qualified current-source route for that run; do not fill the gap by
+duplicating the router in a project or folder field.
 
 Anthropic documents
 [**Instructions for Claude**](https://support.claude.com/en/articles/10185728-understanding-claude-s-personalization-features)

--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -47,9 +47,10 @@ provider surfaces:
 
 - **Claude Code user-global instructions:** place it in
   `~/.claude/CLAUDE.md` between the same managed markers.
-- **Claude profile instructions:** install and verify the body through the
-  hosted profile-instructions surface when ordinary Claude Chat conversations
-  may start CAK repository work.
+- **Claude profile instructions:** click the account initials, open
+  **Settings**, and install and verify the body under **Instructions for
+  Claude** when ordinary Claude Chat conversations may start CAK repository
+  work.
 - **Claude Cowork global instructions:** install and verify the body through
   **Settings > Cowork > Global instructions** when Cowork sessions may start
   CAK repository work.
@@ -72,6 +73,14 @@ retrieval semantics; do not claim local validator coverage for either surface.
 Use Claude project or Cowork folder instructions for project-specific context,
 not as another copy of the global router when the corresponding account-level
 surface already covers the run.
+
+Anthropic documents **Instructions for Claude** as account-wide and Cowork
+Global instructions as applying to every Cowork session, but does not publish
+their combined precedence or deduplication behavior. Verify them separately and
+do not infer that the profile setting alone covers Cowork. If a runtime presents
+the same canonical router through both, treat the copies as one idempotent
+bootstrap trigger under the persistence rule, not as separate doctrine or a
+reason to retrieve once per copy.
 
 Use these markers around the exact router body in the Codex and Claude local
 files:

--- a/docs/codex-preflight.md
+++ b/docs/codex-preflight.md
@@ -30,7 +30,7 @@ delegating workers or touching repositories:
 ```text
 Before starting repository work, run:
 
-cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
+cd /ABSOLUTE/PATH/TO/ai-workflow-playbook
 ./scripts/codex-preflight
 
 If it exits non-zero, stop and report the failing check and remediation.

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -1,11 +1,110 @@
 # Claude Adapter
 
-Claude Code-specific deltas on top of the core playbook. Use with
+This adapter maps Claude Chat, Claude Cowork, and Claude Code onto the shared
+Playbook. Use it with
 [`start-here.md`](../start-here.md), [`core-model.md`](../core-model.md),
 [`source-first-retrieval.md`](../source-first-retrieval.md),
 [`repo-readiness.md`](../repo-readiness.md), and the target repo's `AGENTS.md`.
-Record only what differs for Claude Code here; shared rules stay in their
-canonical docs.
+Record only Claude-specific deltas here; shared rules stay in their canonical
+docs.
+
+## Surface And Invocation Routing
+
+Classify the concrete run from its observed repository locality, not only from
+the Claude product label. Apply the
+[`Surface Classes`](../core-model.md#surface-classes) vocabulary as follows:
+
+- **Claude Chat** is conversational. It has no repository filesystem. Profile
+  instructions apply account-wide, while project instructions apply only
+  inside that project. Repository files arrive through explicitly selected
+  GitHub content or project knowledge, so current source retrieval is
+  best-effort per thread rather than guaranteed by the instruction surface.
+- **Claude Cowork** is agentic-remote by default because its agent loop and
+  code execution run in Anthropic's cloud environment. A concrete Cowork
+  session with an active desktop-connected local folder has repository
+  locality for that connected folder and can satisfy the agentic-local startup
+  contract while the connection remains available. A cloud-only or scheduled
+  session without current repository access remains agentic-remote.
+- **Claude Code** is agentic-local when a CLI or desktop Code session has the
+  repository filesystem. A remote Code session is agentic-remote until its
+  current repository source and repo-local instructions are available through
+  the execution environment.
+
+Initiation is a separate axis. Chat is normally human-initiated. Cowork can be
+human-initiated or unattended through scheduled tasks and Dispatch. Claude
+Code can be human-interactive or controller-launched. Human-interactive Code
+uses the ordinary repository sections below. A controller-launched independent
+review additionally uses
+[`Governed read-only reviewer launch`](#governed-read-only-reviewer-launch)
+and the controller-side adapter for the invoking executor; each adapter governs
+its own run boundary.
+
+## Hydration Transport By Surface
+
+Persistent instructions trigger hydration; they do not prove that hydration
+succeeded or that a repository snapshot is current. Apply the shared
+[`global bootstrap router`](../../distributions/global-bootstrap/bootstrap-router.md)
+at each independently starting hosted surface that must enter CAK repository
+work, then use these source routes:
+
+### Claude Chat
+
+- Put the canonical global router in Claude profile instructions when ordinary
+  Chat conversations may start CAK work. A bare repository URL is context, not
+  an instruction to retrieve and apply it.
+- Use project instructions for project-specific context; do not copy shared
+  Playbook doctrine or another router body there when the account-level router
+  already covers the session.
+- Retrieve repository files through explicitly selected GitHub content. In a
+  Claude project, GitHub content is a selected, synchronized knowledge source;
+  refresh it before relying on mutable repository state. A successful prior
+  sync does not prove the current branch or file version.
+- If the current `docs/start-here.md`, repo-local `AGENTS.md`, or another
+  required source cannot be retrieved, report the exact capability gap and
+  stop the repository-dependent task. Do not proceed from project memory,
+  chat history, or a stale synchronized copy while claiming current hydration.
+
+Chat hydration is therefore best-effort per thread. Profile or project
+instructions can reliably present the routing request, but they cannot create
+filesystem locality or guarantee that the selected GitHub source is current.
+
+### Claude Cowork
+
+- Put the canonical global router in **Settings > Cowork > Global
+  instructions** when Cowork sessions may start CAK work. This is a distinct
+  hosted/manual surface from Claude profile instructions and from
+  `~/.claude/CLAUDE.md`.
+- Folder instructions provide project-specific context when a local folder is
+  selected on desktop. Cowork project instructions and context apply only
+  within that project. Keep either layer thin and point it to the repository's
+  current `CLAUDE.md`/`AGENTS.md` route instead of copying shared doctrine.
+- With a connected local repository folder, read the current
+  `docs/start-here.md`, root `CLAUDE.md`, and repo-local `AGENTS.md` from that
+  folder before repository work. If the desktop bridge or folder is
+  unavailable, use a currently observed connector or synchronized project
+  source and preserve its freshness limitation.
+- Scheduled and other unattended Cowork tasks run without a human available
+  at startup. Their task definition must name a qualified current-source route
+  and stop when it is unavailable; remembered context and a prior successful
+  run are not substitutes.
+
+Cowork's product-native global and folder instructions are the portable
+instruction surfaces across Cowork sessions. Claude Code's memory guidance
+also documents `~/.claude/CLAUDE.md` behavior in desktop Cowork sessions, but
+that file is not the sole Cowork route: outside-working-directory imports and
+linked user files are skipped there, and cloud/web/mobile Cowork execution must
+not infer coverage from a workstation file.
+
+### Claude Code
+
+Claude Code uses its file-backed `CLAUDE.md` discovery described below. Local
+file-backed hydration is deterministic when the required files are current and
+readable. Remote Code runs must establish equivalent current repository access
+before claiming the same result.
+
+The remaining execution, permission, worktree, context, connector, model, and
+delivery sections are Claude Code-specific unless a section explicitly says
+otherwise.
 
 ## Instruction Discovery And Precedence
 
@@ -41,9 +140,10 @@ canonical repository execution layer the startup contract requires. Therefore:
   repository.
 - Do not implement the user-global router as an import that resolves outside a
   Cowork session's working directory, or as a symlink or hard link. Claude Code
-  documents that Cowork desktop skips those user-scope imports and skips a
-  linked `~/.claude/CLAUDE.md`. The inline managed block remains available in
-  Cowork without either indirection.
+  documents that desktop Cowork sessions skip those user-scope imports and a
+  linked `~/.claude/CLAUDE.md`. A regular inline managed block avoids those
+  two failure modes, but it does not replace Cowork Global instructions or
+  establish coverage for cloud, web, or mobile Cowork sessions.
 - Keep the managed HTML markers around the inline router. Claude Code strips
   block-level HTML comments before injecting `CLAUDE.md` content into context,
   so the markers remain available to the drift validator without consuming
@@ -539,7 +639,7 @@ repository automation or worker fan-out, run it first and stop on a non-zero
 exit:
 
 ```text
-cd /Users/keith/src/ctrl-alt-keith/ai-workflow-playbook
+cd /ABSOLUTE/PATH/TO/ai-workflow-playbook
 ./scripts/codex-preflight
 ```
 
@@ -559,12 +659,18 @@ permissions-sensitive.
 ## References
 
 Behavioral claims above are grounded in official Anthropic documentation,
-including [memory](https://docs.claude.com/en/docs/claude-code/memory),
+including [Claude Code memory](https://code.claude.com/docs/en/memory),
 [permissions](https://code.claude.com/docs/en/permissions),
 [the tools reference](https://code.claude.com/docs/en/tools-reference),
 [subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
-[worktrees](https://code.claude.com/docs/en/worktrees). Model-routing claims
-above are additionally derived from Anthropic's official [Claude Code model
+[worktrees](https://code.claude.com/docs/en/worktrees). Surface and hydration
+claims are additionally grounded in Anthropic's official
+[Cowork introduction](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork),
+[Cowork surface guide](https://support.claude.com/en/articles/15520349-use-claude-cowork-on-web-desktop-and-mobile),
+[personalization guide](https://support.claude.com/en/articles/10185728-understanding-claude-s-personalization-features),
+and [GitHub integration guide](https://support.claude.com/en/articles/10167454-use-the-github-integration),
+checked 2026-08-29. Model-routing claims above are additionally derived from
+Anthropic's official [Claude Code model
 configuration](https://code.claude.com/docs/en/model-config), [model-selection
 guide](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model),
 [models overview](https://platform.claude.com/docs/en/about-claude/models/overview),

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -19,12 +19,12 @@ the Claude product label. Apply the
   inside that project. Repository files arrive through explicitly selected
   GitHub content or project knowledge, so current source retrieval is
   best-effort per thread rather than guaranteed by the instruction surface.
-- **Claude Cowork** is agentic-remote by default because its agent loop and
-  code execution run in Anthropic's cloud environment. A concrete Cowork
-  session with an active desktop-connected local folder has repository
-  locality for that connected folder and can satisfy the agentic-local startup
-  contract while the connection remains available. A cloud-only or scheduled
-  session without current repository access remains agentic-remote.
+- **Claude Cowork** is agentic-remote by default because a session has no
+  guaranteed repository locality. A concrete Cowork session with an active
+  desktop-connected local folder has repository locality for that connected
+  folder and can satisfy the agentic-local startup contract while the
+  connection remains available. A cloud-only or scheduled session without
+  current repository access remains agentic-remote.
 - **Claude Code** is agentic-local when a CLI or desktop Code session has the
   repository filesystem. A remote Code session is agentic-remote until its
   current repository source and repo-local instructions are available through
@@ -45,7 +45,11 @@ Persistent instructions trigger hydration; they do not prove that hydration
 succeeded or that a repository snapshot is current. Apply the shared
 [`global bootstrap router`](../../distributions/global-bootstrap/bootstrap-router.md)
 at each independently starting hosted surface that must enter CAK repository
-work, then use these source routes:
+work. Its
+[`global bootstrap persistence`](../start-here.md#global-bootstrap-persistence)
+boundary applies unchanged: hydrate before the first project action and again
+only when the task or repository materially changes, never merely because a
+new turn or tool call occurs. Then use these source routes:
 
 ### Claude Chat
 
@@ -55,14 +59,21 @@ work, then use these source routes:
 - Use project instructions for project-specific context; do not copy shared
   Playbook doctrine or another router body there when the account-level router
   already covers the session.
-- Retrieve repository files through explicitly selected GitHub content. In a
-  Claude project, GitHub content is a selected, synchronized knowledge source;
-  refresh it before relying on mutable repository state. A successful prior
-  sync does not prove the current branch or file version.
+- Prefer explicitly selected GitHub content for repository files. In a Claude
+  project, GitHub content is a selected, synchronized knowledge source;
+  refresh it when the task materially changes or before relying on mutable
+  repository state whose freshness has not been established. A successful
+  prior sync does not prove the current branch or file version. Another
+  currently observed retrieval route is valid when it returns the current
+  required source.
 - If the current `docs/start-here.md`, repo-local `AGENTS.md`, or another
-  required source cannot be retrieved, report the exact capability gap and
-  stop the repository-dependent task. Do not proceed from project memory,
-  chat history, or a stale synchronized copy while claiming current hydration.
+  required source cannot be retrieved after inspecting or attempting the
+  relevant route, report the exact capability gap and stop the
+  repository-dependent task. Apply the
+  [`runtime-evidence rule`](../start-here.md#connector-availability-is-runtime-evidence)
+  before claiming a connector or retrieval capability is unavailable. Do not
+  proceed from project memory, chat history, or a stale synchronized copy while
+  claiming current hydration.
 
 Chat hydration is therefore best-effort per thread. Profile or project
 instructions can reliably present the routing request, but they cannot create
@@ -80,9 +91,9 @@ filesystem locality or guarantee that the selected GitHub source is current.
   current `CLAUDE.md`/`AGENTS.md` route instead of copying shared doctrine.
 - With a connected local repository folder, read the current
   `docs/start-here.md`, root `CLAUDE.md`, and repo-local `AGENTS.md` from that
-  folder before repository work. If the desktop bridge or folder is
-  unavailable, use a currently observed connector or synchronized project
-  source and preserve its freshness limitation.
+  folder at the first-action/material-change boundary. If the desktop bridge
+  or folder is unavailable, use a currently observed connector or synchronized
+  project source and preserve its freshness limitation.
 - Scheduled and other unattended Cowork tasks run without a human available
   at startup. Their task definition must name a qualified current-source route
   and stop when it is unavailable; remembered context and a prior successful
@@ -95,12 +106,22 @@ that file is not the sole Cowork route: outside-working-directory imports and
 linked user files are skipped there, and cloud/web/mobile Cowork execution must
 not infer coverage from a workstation file.
 
+Anthropic documents **Instructions for Claude** as account-wide and Cowork
+Global instructions as applying to every Cowork session, but does not publish
+cross-surface precedence or deduplication semantics for those two settings.
+Treat them as independently verified transports and do not infer that profile
+instructions alone cover Cowork. If one runtime presents the exact canonical
+router through more than one surface, the duplicate transport is idempotent:
+apply the first-action/material-change trigger once, not once per copy.
+
 ### Claude Code
 
 Claude Code uses its file-backed `CLAUDE.md` discovery described below. Local
 file-backed hydration is deterministic when the required files are current and
-readable. Remote Code runs must establish equivalent current repository access
-before claiming the same result.
+readable. In a remote Code workspace, the repo-local root `CLAUDE.md` is the
+bootstrap route to `docs/start-here.md` and repo-local `AGENTS.md`. If neither a
+user-global projection nor those repository files are readable, report the
+capability gap and stop before repository-dependent work.
 
 The remaining execution, permission, worktree, context, connector, model, and
 delivery sections are Claude Code-specific unless a section explicitly says
@@ -667,6 +688,7 @@ including [Claude Code memory](https://code.claude.com/docs/en/memory),
 claims are additionally grounded in Anthropic's official
 [Cowork introduction](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork),
 [Cowork surface guide](https://support.claude.com/en/articles/15520349-use-claude-cowork-on-web-desktop-and-mobile),
+[Dispatch guide](https://support.claude.com/en/articles/13947068-assign-tasks-from-anywhere-in-claude-cowork),
 [personalization guide](https://support.claude.com/en/articles/10185728-understanding-claude-s-personalization-features),
 and [GitHub integration guide](https://support.claude.com/en/articles/10167454-use-the-github-integration),
 checked 2026-08-29. Model-routing claims above are additionally derived from

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -17,8 +17,9 @@ the Claude product label. Apply the
 - **Claude Chat** is conversational. It has no repository filesystem. Profile
   instructions apply account-wide, while project instructions apply only
   inside that project. Repository files arrive through explicitly selected
-  GitHub content or project knowledge, so current source retrieval is
-  best-effort per thread rather than guaranteed by the instruction surface.
+  GitHub content, project knowledge, or another currently observed retrieval
+  route, so current source retrieval is best-effort per thread rather than
+  guaranteed by the instruction surface.
 - **Claude Cowork** is agentic-remote by default because a session has no
   guaranteed repository locality. A concrete Cowork session with an active
   desktop-connected local folder has repository locality for that connected
@@ -30,11 +31,12 @@ the Claude product label. Apply the
   current repository source and repo-local instructions are available through
   the execution environment.
 
-Initiation is a separate axis. Chat is normally human-initiated. Cowork can be
-human-initiated or unattended through scheduled tasks and Dispatch. Claude
-Code can be human-interactive or controller-launched. Human-interactive Code
-uses the ordinary repository sections below. A controller-launched independent
-review additionally uses
+Initiation is a separate axis. Chat is normally human-initiated. Scheduled
+Cowork tasks are unattended; Dispatch tasks are human-initiated assignments
+whose execution does not require the initiating human to remain present.
+Claude Code can be human-interactive or controller-launched. Human-interactive
+Code uses the ordinary repository sections below. A controller-launched
+independent review additionally uses
 [`Governed read-only reviewer launch`](#governed-read-only-reviewer-launch)
 and the controller-side adapter for the invoking executor; each adapter governs
 its own run boundary.
@@ -118,9 +120,12 @@ apply the first-action/material-change trigger once, not once per copy.
 
 Claude Code uses its file-backed `CLAUDE.md` discovery described below. Local
 file-backed hydration is deterministic when the required files are current and
-readable. In a remote Code workspace, the repo-local root `CLAUDE.md` is the
-bootstrap route to `docs/start-here.md` and repo-local `AGENTS.md`. If neither a
-user-global projection nor those repository files are readable, report the
+readable. In a remote Code workspace, use a repo-local root `CLAUDE.md`, when
+present, as a thin bootstrap pointer to the current `docs/start-here.md` and
+repo-local `AGENTS.md`; otherwise retrieve those two required sources directly
+through a currently observed route. User-global or project `CLAUDE.md` content
+triggers this hydration but does not substitute for either required source. If
+the current required sources are not readable or retrievable, report the
 capability gap and stop before repository-dependent work.
 
 The remaining execution, permission, worktree, context, connector, model, and

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -14,12 +14,12 @@ Classify the concrete run from its observed repository locality, not only from
 the Claude product label. Apply the
 [`Surface Classes`](../core-model.md#surface-classes) vocabulary as follows:
 
-- **Claude Chat** is conversational. It has no repository filesystem. Profile
-  instructions apply account-wide, while project instructions apply only
-  inside that project. Repository files arrive through explicitly selected
-  GitHub content, project knowledge, or another currently observed retrieval
-  route, so current source retrieval is best-effort per thread rather than
-  guaranteed by the instruction surface.
+- **Claude Chat** is conversational. It has no repository filesystem.
+  **Instructions for Claude** apply account-wide to conversations, while
+  project instructions apply only inside that project. Repository files arrive
+  through explicitly selected GitHub content, project knowledge, or another
+  currently observed retrieval route, so current source retrieval is
+  best-effort per thread rather than guaranteed by the instruction surface.
 - **Claude Cowork** is agentic-remote by default because a session has no
   guaranteed repository locality. A concrete Cowork session with an active
   desktop-connected local folder has repository locality for that connected
@@ -62,7 +62,9 @@ new turn or tool call occurs. Then use these source routes:
   as independently observed runtime instruction transports until the owning
   hosted setting and precedence are established. Audit each block for stale
   unconditional hydration wording. An edit to **Instructions for Claude** does
-  not prove that a separately presented runtime block changed.
+  not prove that a separately presented runtime block changed. If its owner
+  remains unknown, record unresolved provenance, continue treating the stale
+  block as active, and do not claim reconciliation.
 - Anthropic separately documents Cowork Global instructions as standing
   instructions for every Cowork session. The published route is **Settings >
   Cowork**, then **Global instructions**; current UI exposure is runtime
@@ -104,6 +106,11 @@ filesystem locality or guarantee that the selected GitHub source is current.
   hosted/manual surface from account instructions, observed runtime account
   preferences, and `~/.claude/CLAUDE.md`. The published menu route does not
   prove that a particular account or product build currently exposes it.
+- When no verified global transport is exposed, an interactive Cowork run may
+  proceed only when its current task or a verified project/folder instruction
+  explicitly triggers hydration and the required current sources are obtained.
+  Record the global coverage gap; do not substitute a duplicate router in a
+  project or folder field.
 - Folder instructions provide project-specific context when a local folder is
   selected on desktop. Cowork project instructions and context apply only
   within that project. Keep either layer thin and point it to the repository's
@@ -145,8 +152,8 @@ triggers this hydration but does not substitute for either required source. If
 the current required sources are not readable or retrievable, report the
 capability gap and stop before repository-dependent work.
 
-The remaining execution, permission, worktree, context, connector, model, and
-delivery sections are Claude Code-specific unless a section explicitly says
+The remaining execution, permission, worktree, context, model, and delivery
+sections are Claude Code-specific unless a section explicitly says
 otherwise.
 
 ## Instruction Discovery And Precedence
@@ -484,7 +491,8 @@ file state before relying on it, per
 
 ## Connectors
 
-Claude reaches remote services, including GitHub, through MCP servers. Apply the
+This section applies across Claude surfaces that expose connectors. Claude
+reaches remote services, including GitHub, through MCP servers. Apply the
 [runtime-evidence rule](../start-here.md#connector-availability-is-runtime-evidence):
 inspect available connector actions or attempt the operation before claiming a
 capability is unavailable, and treat a successful call as evidence it remains
@@ -705,7 +713,7 @@ Behavioral claims above are grounded in official Anthropic documentation,
 including [Claude Code memory](https://code.claude.com/docs/en/memory),
 [permissions](https://code.claude.com/docs/en/permissions),
 [the tools reference](https://code.claude.com/docs/en/tools-reference),
-[subagents](https://docs.claude.com/en/docs/claude-code/sub-agents), and
+[subagents](https://code.claude.com/docs/en/sub-agents), and
 [worktrees](https://code.claude.com/docs/en/worktrees). Surface and hydration
 claims are additionally grounded in Anthropic's official
 [Cowork introduction](https://support.claude.com/en/articles/13345190-get-started-with-claude-cowork),

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -53,11 +53,27 @@ boundary applies unchanged: hydrate before the first project action and again
 only when the task or repository materially changes, never merely because a
 new turn or tool call occurs. Then use these source routes:
 
+### Account-Level Hosted Transports
+
+- Anthropic documents **Instructions for Claude** as an account-wide setting
+  that applies to conversations. Because it is account-level, do not frame it
+  as a Chat-only transport or infer that project instructions replace it.
+- When a current run exposes one or more `user_preferences` blocks, treat them
+  as independently observed runtime instruction transports until the owning
+  hosted setting and precedence are established. Audit each block for stale
+  unconditional hydration wording. An edit to **Instructions for Claude** does
+  not prove that a separately presented runtime block changed.
+- Anthropic separately documents Cowork Global instructions as standing
+  instructions for every Cowork session. The published route is **Settings >
+  Cowork**, then **Global instructions**; current UI exposure is runtime
+  evidence. If an account or build does not expose that route, record the gap
+  instead of assuming another account field owns the same transport.
+
 ### Claude Chat
 
-- Put the canonical global router in Claude profile instructions when ordinary
-  Chat conversations may start CAK work. A bare repository URL is context, not
-  an instruction to retrieve and apply it.
+- Put the canonical global router in the verified account instruction
+  transport when ordinary Chat conversations may start CAK work. A bare
+  repository URL is context, not an instruction to retrieve and apply it.
 - Use project instructions for project-specific context; do not copy shared
   Playbook doctrine or another router body there when the account-level router
   already covers the session.
@@ -77,16 +93,17 @@ new turn or tool call occurs. Then use these source routes:
   proceed from project memory, chat history, or a stale synchronized copy while
   claiming current hydration.
 
-Chat hydration is therefore best-effort per thread. Profile or project
+Chat hydration is therefore best-effort per thread. Account or project
 instructions can reliably present the routing request, but they cannot create
 filesystem locality or guarantee that the selected GitHub source is current.
 
 ### Claude Cowork
 
-- Put the canonical global router in **Settings > Cowork > Global
-  instructions** when Cowork sessions may start CAK work. This is a distinct
-  hosted/manual surface from Claude profile instructions and from
-  `~/.claude/CLAUDE.md`.
+- Put the canonical global router in the verified Cowork Global instructions
+  transport when Cowork sessions may start CAK work. This is a distinct
+  hosted/manual surface from account instructions, observed runtime account
+  preferences, and `~/.claude/CLAUDE.md`. The published menu route does not
+  prove that a particular account or product build currently exposes it.
 - Folder instructions provide project-specific context when a local folder is
   selected on desktop. Cowork project instructions and context apply only
   within that project. Keep either layer thin and point it to the repository's
@@ -108,13 +125,13 @@ that file is not the sole Cowork route: outside-working-directory imports and
 linked user files are skipped there, and cloud/web/mobile Cowork execution must
 not infer coverage from a workstation file.
 
-Anthropic documents **Instructions for Claude** as account-wide and Cowork
-Global instructions as applying to every Cowork session, but does not publish
-cross-surface precedence or deduplication semantics for those two settings.
-Treat them as independently verified transports and do not infer that profile
-instructions alone cover Cowork. If one runtime presents the exact canonical
-router through more than one surface, the duplicate transport is idempotent:
-apply the first-action/material-change trigger once, not once per copy.
+Anthropic does not publish cross-surface precedence or deduplication semantics
+for account instructions, runtime `user_preferences` blocks, and Cowork Global
+instructions. Treat them as independently verified transports and do not infer
+that account instructions alone cover Cowork. If one runtime presents the exact
+canonical router through more than one surface, the duplicate transport is
+idempotent: apply the first-action/material-change trigger once, not once per
+copy.
 
 ### Claude Code
 

--- a/tests/test_cak_local_asset_path_ratchet.py
+++ b/tests/test_cak_local_asset_path_ratchet.py
@@ -72,6 +72,13 @@ EXPECTED_LOCAL_REFERENCES = {
 # placement-ownership guarantee.
 ACTIVE_SURFACE_ROOTS = (ROOT / "scripts", ROOT / "docs", ROOT / ".codex")
 
+OPERATOR_PATH_SURFACES = ACTIVE_SURFACE_ROOTS + (
+    ROOT / "distributions",
+    ROOT / "AGENTS.md",
+    ROOT / "CLAUDE.md",
+    ROOT / "README.md",
+)
+
 
 class CakLocalAssetPathRatchetTests(unittest.TestCase):
     def test_active_code_policy_and_guidance_local_references_do_not_expand(self) -> None:
@@ -88,18 +95,19 @@ class CakLocalAssetPathRatchetTests(unittest.TestCase):
 
         self.assertEqual(EXPECTED_LOCAL_REFERENCES, observed)
 
-    def test_active_docs_do_not_hardcode_the_operator_home(self) -> None:
+    def test_active_surfaces_do_not_hardcode_the_operator_home(self) -> None:
         observed: list[tuple[str, int]] = []
 
-        for path in tracked_files(ROOT / "docs"):
-            if not path.is_file():
-                continue
-            relative = path.relative_to(ROOT).as_posix()
-            for line_number, line in enumerate(
-                path.read_text(encoding="utf-8").splitlines(), start=1
-            ):
-                if "/Users/keith/" in line:
-                    observed.append((relative, line_number))
+        for search_root in OPERATOR_PATH_SURFACES:
+            for path in tracked_files(search_root):
+                if not path.is_file() or "__pycache__" in path.parts:
+                    continue
+                relative = path.relative_to(ROOT).as_posix()
+                for line_number, line in enumerate(
+                    path.read_text(encoding="utf-8").splitlines(), start=1
+                ):
+                    if "/Users/keith" in line:
+                        observed.append((relative, line_number))
 
         self.assertEqual([], observed)
 

--- a/tests/test_cak_local_asset_path_ratchet.py
+++ b/tests/test_cak_local_asset_path_ratchet.py
@@ -88,6 +88,21 @@ class CakLocalAssetPathRatchetTests(unittest.TestCase):
 
         self.assertEqual(EXPECTED_LOCAL_REFERENCES, observed)
 
+    def test_active_docs_do_not_hardcode_the_operator_home(self) -> None:
+        observed: list[tuple[str, int]] = []
+
+        for path in tracked_files(ROOT / "docs"):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(ROOT).as_posix()
+            for line_number, line in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if "/Users/keith/" in line:
+                    observed.append((relative, line_number))
+
+        self.assertEqual([], observed)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cak_local_asset_path_ratchet.py
+++ b/tests/test_cak_local_asset_path_ratchet.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 import unittest
 from pathlib import Path
@@ -79,6 +80,8 @@ OPERATOR_PATH_SURFACES = ACTIVE_SURFACE_ROOTS + (
     ROOT / "README.md",
 )
 
+OPERATOR_HOME_PATTERN = re.compile(r"/(?:Users|home)/[^/\s`\"']+")
+
 
 class CakLocalAssetPathRatchetTests(unittest.TestCase):
     def test_active_code_policy_and_guidance_local_references_do_not_expand(self) -> None:
@@ -99,14 +102,17 @@ class CakLocalAssetPathRatchetTests(unittest.TestCase):
         observed: list[tuple[str, int]] = []
 
         for search_root in OPERATOR_PATH_SURFACES:
-            for path in tracked_files(search_root):
+            self.assertTrue(search_root.exists(), f"missing surface: {search_root}")
+            paths = tracked_files(search_root)
+            self.assertTrue(paths, f"no tracked files for surface: {search_root}")
+            for path in paths:
                 if not path.is_file() or "__pycache__" in path.parts:
                     continue
                 relative = path.relative_to(ROOT).as_posix()
                 for line_number, line in enumerate(
                     path.read_text(encoding="utf-8").splitlines(), start=1
                 ):
-                    if "/Users/keith" in line:
+                    if OPERATOR_HOME_PATTERN.search(line):
                         observed.append((relative, line_number))
 
         self.assertEqual([], observed)

--- a/tests/test_global_bootstrap.py
+++ b/tests/test_global_bootstrap.py
@@ -73,13 +73,15 @@ class GlobalBootstrapTests(unittest.TestCase):
         ):
             self.assertFalse((PROJECTIONS / removed_copy).exists())
 
-    def test_distribution_names_both_hosted_chatgpt_destinations(self) -> None:
+    def test_distribution_names_each_hosted_provider_destination(self) -> None:
         readme = (PROJECTIONS / "README.md").read_text(encoding="utf-8")
         normalized = " ".join(readme.split())
         self.assertIn("immediate Codex desktop repair has exactly one", readme)
         self.assertIn("does not require a Codex project setting", readme)
         self.assertIn("ChatGPT account custom instructions", readme)
         self.assertIn("ChatGPT CAK project instructions", readme)
+        self.assertIn("Claude profile instructions", readme)
+        self.assertIn("Claude Cowork global instructions", readme)
         self.assertIn("distinct hosted configuration surfaces", readme)
         self.assertIn(
             "capability gap, not equivalent to the local byte check", normalized
@@ -88,7 +90,7 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn(
             "python3 scripts/check_global_bootstrap.py --require-claude", readme
         )
-        self.assertIn("Claude Cowork Settings preferences", readme)
+        self.assertIn("Settings > Cowork > Global instructions", readme)
 
     def test_claude_adapter_preserves_scope_order_and_cowork_caveats(self) -> None:
         adapter = (ROOT / "docs" / "tool-adapters" / "claude.md").read_text(
@@ -100,9 +102,30 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn("./CLAUDE.md` or `./.claude/CLAUDE.md", normalized)
         self.assertIn("broader CAK-187 provider rollout", normalized)
         self.assertIn("--require-claude", normalized)
-        self.assertIn("Cowork desktop skips those user-scope imports", normalized)
+        self.assertIn("desktop Cowork sessions skip those user-scope imports", normalized)
         self.assertIn("symlink or hard link", normalized)
         self.assertIn("strips block-level HTML comments", normalized)
+
+    def test_claude_adapter_routes_chat_cowork_and_code_surfaces(self) -> None:
+        adapter = (ROOT / "docs" / "tool-adapters" / "claude.md").read_text(
+            encoding="utf-8"
+        )
+        normalized = " ".join(adapter.split())
+        for heading in (
+            "## Surface And Invocation Routing",
+            "### Claude Chat",
+            "### Claude Cowork",
+            "### Claude Code",
+        ):
+            self.assertIn(heading, adapter)
+        self.assertIn("Claude Chat** is conversational", normalized)
+        self.assertIn("Claude Cowork** is agentic-remote by default", normalized)
+        self.assertIn("active desktop-connected local folder", normalized)
+        self.assertIn("Profile instructions apply account-wide", normalized)
+        self.assertIn("Settings > Cowork > Global instructions", normalized)
+        self.assertIn("Scheduled and other unattended Cowork tasks", normalized)
+        self.assertIn("best-effort per thread", normalized)
+        self.assertNotIn("/Users/keith/", adapter)
 
     def test_validator_accepts_exact_blocks_with_unrelated_local_content(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_global_bootstrap.py
+++ b/tests/test_global_bootstrap.py
@@ -112,11 +112,6 @@ class GlobalBootstrapTests(unittest.TestCase):
             encoding="utf-8"
         )
         normalized = " ".join(adapter.split())
-        chat = adapter.split("### Claude Chat", 1)[1].split("### Claude Cowork", 1)[0]
-        cowork = adapter.split("### Claude Cowork", 1)[1].split("### Claude Code", 1)[0]
-        code = adapter.split("### Claude Code", 1)[1].split(
-            "## Instruction Discovery And Precedence", 1
-        )[0]
         for heading in (
             "## Surface And Invocation Routing",
             "### Claude Chat",
@@ -124,6 +119,11 @@ class GlobalBootstrapTests(unittest.TestCase):
             "### Claude Code",
         ):
             self.assertIn(heading, adapter)
+        chat = adapter.split("### Claude Chat", 1)[1].split("### Claude Cowork", 1)[0]
+        cowork = adapter.split("### Claude Cowork", 1)[1].split("### Claude Code", 1)[0]
+        code = adapter.split("### Claude Code", 1)[1].split(
+            "## Instruction Discovery And Precedence", 1
+        )[0]
         self.assertIn("../core-model.md#surface-classes", adapter)
         self.assertIn("agentic-remote", normalized)
         self.assertIn("agentic-local", normalized)

--- a/tests/test_global_bootstrap.py
+++ b/tests/test_global_bootstrap.py
@@ -118,14 +118,11 @@ class GlobalBootstrapTests(unittest.TestCase):
             "### Claude Code",
         ):
             self.assertIn(heading, adapter)
-        self.assertIn("Claude Chat** is conversational", normalized)
-        self.assertIn("Claude Cowork** is agentic-remote by default", normalized)
-        self.assertIn("active desktop-connected local folder", normalized)
-        self.assertIn("Profile instructions apply account-wide", normalized)
+        self.assertIn("../core-model.md#surface-classes", adapter)
+        self.assertIn("agentic-remote", normalized)
+        self.assertIn("agentic-local", normalized)
         self.assertIn("Settings > Cowork > Global instructions", normalized)
-        self.assertIn("Scheduled and other unattended Cowork tasks", normalized)
-        self.assertIn("best-effort per thread", normalized)
-        self.assertNotIn("/Users/keith/", adapter)
+        self.assertIn("#global-bootstrap-persistence", adapter)
 
     def test_validator_accepts_exact_blocks_with_unrelated_local_content(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_global_bootstrap.py
+++ b/tests/test_global_bootstrap.py
@@ -80,7 +80,8 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn("does not require a Codex project setting", readme)
         self.assertIn("ChatGPT account custom instructions", readme)
         self.assertIn("ChatGPT CAK project instructions", readme)
-        self.assertIn("Claude profile instructions", readme)
+        self.assertIn("Claude account instructions", readme)
+        self.assertIn("Claude runtime account preferences", readme)
         self.assertIn("Claude Cowork global instructions", readme)
         self.assertIn("distinct hosted configuration surfaces", readme)
         self.assertIn(
@@ -90,7 +91,6 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn(
             "python3 scripts/check_global_bootstrap.py --require-claude", readme
         )
-        self.assertIn("Settings > Cowork > Global instructions", readme)
 
     def test_claude_adapter_preserves_scope_order_and_cowork_caveats(self) -> None:
         adapter = (ROOT / "docs" / "tool-adapters" / "claude.md").read_text(
@@ -127,7 +127,6 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn("../core-model.md#surface-classes", adapter)
         self.assertIn("agentic-remote", normalized)
         self.assertIn("agentic-local", normalized)
-        self.assertIn("Settings > Cowork > Global instructions", normalized)
         self.assertIn("#global-bootstrap-persistence", adapter)
         self.assertIn("#connector-availability-is-runtime-evidence", chat)
         self.assertIn("new turn or tool call", normalized)

--- a/tests/test_global_bootstrap.py
+++ b/tests/test_global_bootstrap.py
@@ -102,7 +102,8 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn("./CLAUDE.md` or `./.claude/CLAUDE.md", normalized)
         self.assertIn("broader CAK-187 provider rollout", normalized)
         self.assertIn("--require-claude", normalized)
-        self.assertIn("desktop Cowork sessions skip those user-scope imports", normalized)
+        self.assertIn("outside-working-directory imports", normalized)
+        self.assertIn("desktop Cowork sessions", normalized)
         self.assertIn("symlink or hard link", normalized)
         self.assertIn("strips block-level HTML comments", normalized)
 
@@ -111,6 +112,11 @@ class GlobalBootstrapTests(unittest.TestCase):
             encoding="utf-8"
         )
         normalized = " ".join(adapter.split())
+        chat = adapter.split("### Claude Chat", 1)[1].split("### Claude Cowork", 1)[0]
+        cowork = adapter.split("### Claude Cowork", 1)[1].split("### Claude Code", 1)[0]
+        code = adapter.split("### Claude Code", 1)[1].split(
+            "## Instruction Discovery And Precedence", 1
+        )[0]
         for heading in (
             "## Surface And Invocation Routing",
             "### Claude Chat",
@@ -123,6 +129,20 @@ class GlobalBootstrapTests(unittest.TestCase):
         self.assertIn("agentic-local", normalized)
         self.assertIn("Settings > Cowork > Global instructions", normalized)
         self.assertIn("#global-bootstrap-persistence", adapter)
+        self.assertIn("#connector-availability-is-runtime-evidence", chat)
+        self.assertIn("new turn or tool call", normalized)
+        self.assertIn(
+            "report the exact capability gap and stop", " ".join(chat.split())
+        )
+        self.assertIn(
+            "task definition must name a qualified current-source route",
+            " ".join(cowork.split()),
+        )
+        self.assertIn("duplicate transport is idempotent", " ".join(cowork.split()))
+        self.assertIn(
+            "does not substitute for either required source", " ".join(code.split())
+        )
+        self.assertIn("capability gap and stop", " ".join(code.split()))
 
     def test_validator_accepts_exact_blocks_with_unrelated_local_content(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Summary

- map Claude Chat, Cowork, and Code to the shared surface and invocation model
- document current-source hydration routes, hosted instruction surfaces, persistence boundaries, and fail-closed behavior
- enumerate observed runtime user-preferences injection separately from documented account and Cowork settings
- distinguish officially documented destinations from current UI exposure without inventing precedence
- prohibit duplicate router installation when a hosted transport is unavailable
- add semantic coverage for each Claude surface and broaden the operator-path ratchet

## Validation

- make check (305 tests)
- make authoritative-source-check
- governed Claude review on the initial implementation
- focused governed Claude re-review after fixes
- final governed Claude transport review; all findings reconciled

## Sources

Current Claude product claims are grounded in the official Claude Code memory, Cowork, Dispatch, personalization, and GitHub integration documentation linked from the adapter. Runtime user-preferences injection and current UI exposure are recorded as observed evidence where provider ownership is not documented.

Linear: https://linear.app/ctrl-alt-keith/issue/CAK-181/claude-adapter-covers-claude-code-only-no-hydration-route-for-chat-and