### PR TITLE
docs: clarify Codex Claude handoff symmetry

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -235,7 +235,9 @@ mutation boundary explicitly and keep these three classes distinct:
    migration, destructive cleanup, production execution, provider
    reconfiguration, or other task substance assigned to a later executor or
    phase. That work requires its own bounded authority and satisfied
-   prerequisites.
+   prerequisites. In particular, producing prompt or handoff evidence does not
+   authorize repository implementation, remote-repository mutation, or
+   unrelated planning-system mutation.
 3. **Human-gated transitions remain separately human-gated.** Architecture or
    operational adoption, destructive approval, merge, release, publication,
    scientific adoption, and any task-specific human decision gate require the

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -380,9 +380,10 @@ qualified capability, independently of prompt materiality:
 
 This selector is symmetric: a Codex-produced prompt for Claude and a
 Claude-produced prompt for Codex are each complete prompts governed by this
-same shared presentation and handoff contract. After a successful
-Dropbox-backed presentation, provide the target-shaped retrieval handoff
-without reproducing the complete prompt in the thin handoff.
+same shared presentation and handoff contract. When the selector places the
+prompt in a Dropbox-backed file, immediately provide the target-shaped
+[thin semantic handoff](#thin-semantic-handoff-envelope) without reproducing
+the complete prompt.
 
 Preview is not raw-byte verification, approval, a send gate, delivery evidence,
 executor acknowledgement, a coordination state, or authority. A connector

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -378,6 +378,12 @@ qualified capability, independently of prompt materiality:
   [connector-availability rule](start-here.md#connector-availability-is-runtime-evidence)
   before choosing this fallback.
 
+This selector is symmetric: a Codex-produced prompt for Claude and a
+Claude-produced prompt for Codex are each complete prompts governed by this
+same shared presentation and handoff contract. After a successful
+Dropbox-backed presentation, provide the target-shaped retrieval handoff
+without reproducing the complete prompt in the thin handoff.
+
 Preview is not raw-byte verification, approval, a send gate, delivery evidence,
 executor acknowledgement, a coordination state, or authority. A connector
 confirmation needed to create or preview the file authorizes only that

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -363,12 +363,12 @@ Reason:
 
 ## Cross-Executor Prompt Presentation
 
-For any complete prompt, select presentation by the recipient's currently
-qualified capability, independently of prompt materiality:
-
 This selector applies symmetrically when one executor produces a complete
 prompt for another: each direction is governed by the same shared presentation
 and handoff contract.
+
+For any complete prompt, select presentation by the recipient's currently
+qualified capability, independently of prompt materiality:
 
 - When the recipient has a qualified Dropbox retrieval route and the current
   storage contract supplies a permitted destination, place the prompt in a

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -366,9 +366,9 @@ Reason:
 For any complete prompt, select presentation by the recipient's currently
 qualified capability, independently of prompt materiality:
 
-This selector is symmetric: a Codex-produced prompt for Claude and a
-Claude-produced prompt for Codex are each complete prompts governed by this
-same shared presentation and handoff contract.
+This selector applies symmetrically when one executor produces a complete
+prompt for another: each direction is governed by the same shared presentation
+and handoff contract.
 
 - When the recipient has a qualified Dropbox retrieval route and the current
   storage contract supplies a permitted destination, place the prompt in a

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -366,24 +366,23 @@ Reason:
 For any complete prompt, select presentation by the recipient's currently
 qualified capability, independently of prompt materiality:
 
+This selector is symmetric: a Codex-produced prompt for Claude and a
+Claude-produced prompt for Codex are each complete prompts governed by this
+same shared presentation and handoff contract.
+
 - When the recipient has a qualified Dropbox retrieval route and the current
   storage contract supplies a permitted destination, place the prompt in a
   Dropbox-backed file, present the file surface produced by that operation, and
-  immediately provide the target-shaped retrieval handoff. A separate preview
-  or open action is optional under the matching client adapter and does not
-  block the handoff or require prompt approval.
+  immediately provide the target-shaped
+  [thin semantic handoff](#thin-semantic-handoff-envelope) without reproducing
+  the complete prompt. A separate preview or open action is optional under the
+  matching client adapter and does not block the handoff or require prompt
+  approval.
 - For a human recipient, or when the receiving system has no qualified Dropbox
   route, present the complete prompt inline through the matching client
   adapter. When access is unknown, apply the
   [connector-availability rule](start-here.md#connector-availability-is-runtime-evidence)
   before choosing this fallback.
-
-This selector is symmetric: a Codex-produced prompt for Claude and a
-Claude-produced prompt for Codex are each complete prompts governed by this
-same shared presentation and handoff contract. When the selector places the
-prompt in a Dropbox-backed file, immediately provide the target-shaped
-[thin semantic handoff](#thin-semantic-handoff-envelope) without reproducing
-the complete prompt.
 
 Preview is not raw-byte verification, approval, a send gate, delivery evidence,
 executor acknowledgement, a coordination state, or authority. A connector

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -190,13 +190,12 @@ Apply the shared
 [`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation)
 selector. For a machine recipient with qualified Dropbox retrieval and a
 permitted destination, use the authorized file route, present the card produced
-by the write when available, and immediately provide the target-shaped
-[thin semantic handoff](../prompts.md#thin-semantic-handoff-envelope) without
-reproducing the complete prompt. A separate preview or open action remains
-optional under the connected-app rules above. Do not wait for prompt approval
-or require the operator to open a preview; connector confirmation authorizes
-only its file operation. File-card and preview behavior is product-dependent
-runtime evidence, so recheck the relevant action.
+by the write when available, and immediately provide the target-shaped handoff.
+A separate preview or open action remains optional under the connected-app
+rules above. Do not wait for prompt approval or require the operator to open a
+preview; connector confirmation authorizes only its file operation. File-card
+and preview behavior is product-dependent runtime evidence, so recheck the
+relevant action.
 
 For a human recipient or a system without a qualified Dropbox route, use the
 existing [two-block inline presentation](#prompt-presentation). If access is

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -190,12 +190,13 @@ Apply the shared
 [`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation)
 selector. For a machine recipient with qualified Dropbox retrieval and a
 permitted destination, use the authorized file route, present the card produced
-by the write when available, and immediately provide the target-shaped handoff.
-A separate preview or open action remains optional under the connected-app
-rules above. Do not wait for prompt approval or require the operator to open a
-preview; connector confirmation authorizes only its file operation. File-card
-and preview behavior is product-dependent runtime evidence, so recheck the
-relevant action.
+by the write when available, and immediately provide the target-shaped
+[thin semantic handoff](../prompts.md#thin-semantic-handoff-envelope) without
+reproducing the complete prompt. A separate preview or open action remains
+optional under the connected-app rules above. Do not wait for prompt approval
+or require the operator to open a preview; connector confirmation authorizes
+only its file operation. File-card and preview behavior is product-dependent
+runtime evidence, so recheck the relevant action.
 
 For a human recipient or a system without a qualified Dropbox route, use the
 existing [two-block inline presentation](#prompt-presentation). If access is

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -518,8 +518,9 @@ and byte verification require only the minimum read capability needed to
 inspect the prompt. Record whether Claude computed the digest itself or relied
 on controller-bound digest evidence plus exact read evidence. A direct Claude
 provider limitation does not block this profile when the exact attempt-local
-route succeeds. Do not use a synchronized local provider mount as durable
-identity, retain the attempt-local copy as durable, or create an exchange root.
+route succeeds. Do not use a locally synchronized provider mount as provider or
+durable identity, retain the attempt-local copy as durable, or create an
+exchange root.
 
 After prompt acceptance, choose Claude's tools and permission mode from the
 bounded task's authorized execution requirements. Read-only tools are mandatory

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -518,7 +518,8 @@ and byte verification require only the minimum read capability needed to
 inspect the prompt. Record whether Claude computed the digest itself or relied
 on controller-bound digest evidence plus exact read evidence. A direct Claude
 provider limitation does not block this profile when the exact attempt-local
-route succeeds.
+route succeeds. Do not use a synchronized local provider mount as durable
+identity, retain the attempt-local copy as durable, or create an exchange root.
 
 After prompt acceptance, choose Claude's tools and permission mode from the
 bounded task's authorized execution requirements. Read-only tools are mandatory

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -311,8 +311,8 @@ may download the raw provider object once into a private OS-managed
 attempt-local directory, verify the provider identity and raw bytes, and pass
 Codex the exact local path plus expected size and SHA-256. Codex verifies the
 consumed local bytes and declared text format before acceptance. Do not use a
-locally synchronized provider mount as provider identity, treat the local
-retrieval as durable, or create an exchange root.
+locally synchronized provider mount as provider or durable identity, treat the
+local retrieval as durable, or create an exchange root.
 
 Record the delivery operation and Codex attempt separately from the durable
 prompt. Distinguish `DELIVERED`, `ACCEPTED`, `STARTED`, and the terminal

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -259,21 +259,21 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertIn("a Codex-produced prompt for Claude", presentation)
         self.assertIn("a Claude-produced prompt for Codex", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
+        self.assertIn("immediately provide the target-shaped", presentation)
         self.assertIn(
-            "without reproducing the complete prompt in the thin handoff",
-            presentation,
+            "[thin semantic handoff](#thin-semantic-handoff-envelope)",
+            self.presentation,
+        )
+        self.assertIn(
+            "without reproducing the complete prompt", presentation
         )
 
-        for adapter in self.adapter_profiles[:2]:
-            self.assertIn(
-                "prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile",
-                adapter,
-            )
-            self.assertIn("attempt-local", adapter)
-            self.assertIn("fail closed", adapter)
-        self.assertIn("Prefer direct retrieval", self.adapter_profiles[0])
+        codex, claude = (" ".join(profile.split()) for profile in self.adapter_profiles[:2])
+        self.assertIn("when Codex receives an exact issue-owned prompt", codex)
+        self.assertIn("when Claude Code receives an exact issue-owned prompt", claude)
+        self.assertIn("Prefer direct retrieval", codex)
         self.assertIn(
-            "Direct provider consumption", " ".join(self.adapter_profiles[1].split())
+            "Direct provider consumption", claude
         )
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -24,6 +24,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.contract = normalized(DOCS / "prompt-contracts.md")
+        cls.core = normalized(DOCS / "core-model.md")
         cls.evidence = normalized(DOCS / "evidence-lifecycle.md")
         cls.prompts = normalized(DOCS / "prompts.md")
         cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
@@ -46,6 +47,10 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         cls.delivery_envelope = markdown_section(
             DOCS / "prompts.md",
             "## Issue-Owned Durable Prompt Delivery Envelope Add-On",
+        )
+        cls.kickoff_boundary = markdown_section(
+            DOCS / "core-model.md",
+            "## Kickoff Mutation Boundaries",
         )
         cls.complete_prompt_shape = markdown_section(
             DOCS / "prompts.md",
@@ -264,6 +269,26 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             "(#thin-semantic-handoff-envelope) without reproducing the complete prompt",
             presentation,
         )
+        for phrase in (
+            "one private OS-managed executor-owned attempt-local retrieval",
+            "Fallback changes delivery only",
+        ):
+            self.assertIn(phrase, self.contract)
+        for phrase in (
+            "Exact durable identity: [immutable human locator, provider locator, "
+            "object identity, size, SHA-256",
+            "Verify raw or attempt-local bytes, size, SHA-256, UTF-8, no BOM, LF "
+            "endings, and the declared final-newline rule before acceptance.",
+            "Fail closed on collision, mismatch, missing identity, prohibited "
+            "retention, unsupported required capability, or ambiguous authority.",
+            "Prohibited delivery: no exchange root, mutable alias, shadow durable "
+            "copy, or copy/paste claim of byte identity",
+        ):
+            self.assertIn(phrase, delivery_envelope)
+        self.assertIn(
+            "Do not reproduce the complete durable artifact in chat merely for transport.",
+            self.evidence,
+        )
 
         codex, claude = (" ".join(profile.split()) for profile in self.adapter_profiles[:2])
         directions = (
@@ -278,8 +303,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
                 "Otherwise use one private OS-managed executor-attempt copy",
                 "Bind the launch to its exact path, expected size, SHA-256, and "
                 "declared text format",
-                "Do not infer that qualification from connector presence, extracted "
-                "text, a synced folder",
+                "Do not use a synchronized local provider mount as durable identity, "
+                "retain the attempt-local copy as durable, or create an exchange root",
             ),
             (
                 "Claude",
@@ -311,35 +336,41 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
                 self.assertIn(fallback, recipient_profile)
                 self.assertIn(verification, recipient_profile)
                 self.assertIn(prohibited_local_substitute, recipient_profile)
-                self.assertIn(
-                    "one private OS-managed executor-owned attempt-local retrieval",
-                    self.contract,
+                self.assertIn("fail closed on the shared cleanup conditions", recipient_profile)
+                self.assertLess(
+                    recipient_profile.index(direct_route),
+                    recipient_profile.index(fallback),
                 )
-                self.assertIn("Fallback changes delivery only", self.contract)
+
+    def test_cross_executor_prompt_handoffs_keep_the_kickoff_mutation_boundary(self):
+        kickoff_boundary = " ".join(self.kickoff_boundary.split())
+        presentation = " ".join(self.presentation.split())
+        for phrase in (
+            "Task-owned orchestration and evidence mutations may be permitted",
+            "produce and preserve a decision package or exact downstream prompt and "
+            "its receipt",
+            "producing prompt or handoff evidence does not authorize repository "
+            "implementation, remote-repository mutation, or unrelated planning-system "
+            "mutation",
+            "pull request creates zero authority",
+        ):
+            self.assertIn(phrase, kickoff_boundary)
+
+        directions = (("Codex", "Claude"), ("Claude", "Codex"))
+        for producer, recipient in directions:
+            with self.subTest(producer=producer, recipient=recipient):
+                self.assertIn("selector applies symmetrically", presentation)
                 self.assertIn(
-                    "Exact durable identity: [immutable human locator, provider "
-                    "locator, object identity, size, SHA-256",
-                    delivery_envelope,
-                )
-                self.assertIn(
-                    "Verify raw or attempt-local bytes, size, SHA-256, UTF-8, no BOM, "
-                    "LF endings, and the declared final-newline rule before acceptance.",
-                    delivery_envelope,
-                )
-                self.assertIn(
-                    "Fail closed on collision, mismatch, missing identity, prohibited "
-                    "retention, unsupported required capability, or ambiguous authority.",
-                    delivery_envelope,
-                )
-                self.assertIn(
-                    "Prohibited delivery: no exchange root, mutable alias, shadow "
-                    "durable copy, or copy/paste claim of byte identity",
-                    delivery_envelope,
-                )
-                self.assertIn(
-                    "without reproducing the complete prompt",
+                    "same shared presentation and handoff contract",
                     presentation,
                 )
+
+        chatgpt_presentation = " ".join(self.chatgpt_presentation.split())
+        self.assertIn(
+            "[thin semantic handoff](../prompts.md#thin-semantic-handoff-envelope) "
+            "without reproducing the complete prompt",
+            chatgpt_presentation,
+        )
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -250,7 +250,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         )
         route = presentation.index("qualified Dropbox retrieval route")
         file = presentation.index("Dropbox-backed file")
-        handoff = presentation.index("target-shaped retrieval handoff")
+        handoff = presentation.index("target-shaped [thin semantic handoff]")
         self.assertLess(route, file)
         self.assertLess(file, handoff)
 
@@ -259,13 +259,10 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertIn("a Codex-produced prompt for Claude", presentation)
         self.assertIn("a Claude-produced prompt for Codex", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
-        self.assertIn("immediately provide the target-shaped", presentation)
         self.assertIn(
-            "[thin semantic handoff](#thin-semantic-handoff-envelope)",
-            self.presentation,
-        )
-        self.assertIn(
-            "without reproducing the complete prompt", presentation
+            "immediately provide the target-shaped [thin semantic handoff]"
+            "(#thin-semantic-handoff-envelope) without reproducing the complete prompt",
+            presentation,
         )
 
         codex, claude = (" ".join(profile.split()) for profile in self.adapter_profiles[:2])

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -365,13 +365,6 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
                     presentation,
                 )
 
-        chatgpt_presentation = " ".join(self.chatgpt_presentation.split())
-        self.assertIn(
-            "[thin semantic handoff](../prompts.md#thin-semantic-handoff-envelope) "
-            "without reproducing the complete prompt",
-            chatgpt_presentation,
-        )
-
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())
         chatgpt_prompt = " ".join(self.chatgpt_prompt_presentation.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -256,8 +256,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_codex_and_claude_handoffs_use_the_same_shared_selector(self):
         presentation = " ".join(self.presentation.split())
-        self.assertIn("a Codex-produced prompt for Claude", presentation)
-        self.assertIn("a Claude-produced prompt for Codex", presentation)
+        self.assertIn("selector applies symmetrically", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
         self.assertIn(
             "immediately provide the target-shaped [thin semantic handoff]"
@@ -266,12 +265,14 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         )
 
         codex, claude = (" ".join(profile.split()) for profile in self.adapter_profiles[:2])
-        self.assertIn("when Codex receives an exact issue-owned prompt", codex)
-        self.assertIn("when Claude Code receives an exact issue-owned prompt", claude)
-        self.assertIn("Prefer direct retrieval", codex)
-        self.assertIn(
-            "Direct provider consumption", claude
+        directions = (
+            ("Codex", "Claude", claude, "when Claude Code receives", "Direct provider consumption"),
+            ("Claude", "Codex", codex, "when Codex receives", "Prefer direct retrieval"),
         )
+        for producer, recipient, recipient_profile, receipt, direct_route in directions:
+            with self.subTest(producer=producer, recipient=recipient):
+                self.assertIn(receipt, recipient_profile)
+                self.assertIn(direct_route, recipient_profile)
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -24,7 +24,6 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.contract = normalized(DOCS / "prompt-contracts.md")
-        cls.core = normalized(DOCS / "core-model.md")
         cls.evidence = normalized(DOCS / "evidence-lifecycle.md")
         cls.prompts = normalized(DOCS / "prompts.md")
         cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
@@ -220,7 +219,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_adapters_project_actual_route_without_provider_configuration(self):
         self.assertIn(
-            "Do not use a locally synchronized provider mount as provider identity",
+            "Do not use a locally synchronized provider mount as provider or durable "
+            "identity",
             self.codex,
         )
         self.assertIn("controller-bound digest evidence plus exact read evidence", self.claude)
@@ -303,8 +303,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
                 "Otherwise use one private OS-managed executor-attempt copy",
                 "Bind the launch to its exact path, expected size, SHA-256, and "
                 "declared text format",
-                "Do not use a synchronized local provider mount as durable identity, "
-                "retain the attempt-local copy as durable, or create an exchange root",
+                "Do not use a locally synchronized provider mount as provider or "
+                "durable identity",
             ),
             (
                 "Claude",
@@ -317,7 +317,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
                 "attempt-local directory",
                 "verify the provider identity and raw bytes, and pass Codex the exact "
                 "local path plus expected size and SHA-256",
-                "Do not use a locally synchronized provider mount as provider identity",
+                "Do not use a locally synchronized provider mount as provider or "
+                "durable identity",
             ),
         )
         for (
@@ -345,25 +346,14 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
     def test_cross_executor_prompt_handoffs_keep_the_kickoff_mutation_boundary(self):
         kickoff_boundary = " ".join(self.kickoff_boundary.split())
         presentation = " ".join(self.presentation.split())
-        for phrase in (
-            "Task-owned orchestration and evidence mutations may be permitted",
-            "produce and preserve a decision package or exact downstream prompt and "
-            "its receipt",
+        self.assertIn(
             "producing prompt or handoff evidence does not authorize repository "
             "implementation, remote-repository mutation, or unrelated planning-system "
             "mutation",
-            "pull request creates zero authority",
-        ):
-            self.assertIn(phrase, kickoff_boundary)
-
-        directions = (("Codex", "Claude"), ("Claude", "Codex"))
-        for producer, recipient in directions:
-            with self.subTest(producer=producer, recipient=recipient):
-                self.assertIn("selector applies symmetrically", presentation)
-                self.assertIn(
-                    "same shared presentation and handoff contract",
-                    presentation,
-                )
+            kickoff_boundary,
+        )
+        self.assertIn("selector applies symmetrically", presentation)
+        self.assertIn("same shared presentation and handoff contract", presentation)
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -256,6 +256,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_codex_and_claude_handoffs_use_the_same_shared_selector(self):
         presentation = " ".join(self.presentation.split())
+        delivery_envelope = " ".join(self.delivery_envelope.split())
         self.assertIn("selector applies symmetrically", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
         self.assertIn(
@@ -266,13 +267,79 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
         codex, claude = (" ".join(profile.split()) for profile in self.adapter_profiles[:2])
         directions = (
-            ("Codex", "Claude", claude, "when Claude Code receives", "Direct provider consumption"),
-            ("Claude", "Codex", codex, "when Codex receives", "Prefer direct retrieval"),
+            (
+                "Codex",
+                "Claude",
+                claude,
+                "when Claude Code receives",
+                "Direct provider consumption is qualified only when the current "
+                "Claude surface can retrieve raw bytes and the required provider "
+                "identity metadata",
+                "Otherwise use one private OS-managed executor-attempt copy",
+                "Bind the launch to its exact path, expected size, SHA-256, and "
+                "declared text format",
+                "Do not infer that qualification from connector presence, extracted "
+                "text, a synced folder",
+            ),
+            (
+                "Claude",
+                "Codex",
+                codex,
+                "when Codex receives",
+                "Prefer direct retrieval only when the current connector or provider "
+                "route exposes raw bytes and the required provider identity metadata",
+                "download the raw provider object once into a private OS-managed "
+                "attempt-local directory",
+                "verify the provider identity and raw bytes, and pass Codex the exact "
+                "local path plus expected size and SHA-256",
+                "Do not use a locally synchronized provider mount as provider identity",
+            ),
         )
-        for producer, recipient, recipient_profile, receipt, direct_route in directions:
+        for (
+            producer,
+            recipient,
+            recipient_profile,
+            receipt,
+            direct_route,
+            fallback,
+            verification,
+            prohibited_local_substitute,
+        ) in directions:
             with self.subTest(producer=producer, recipient=recipient):
                 self.assertIn(receipt, recipient_profile)
                 self.assertIn(direct_route, recipient_profile)
+                self.assertIn(fallback, recipient_profile)
+                self.assertIn(verification, recipient_profile)
+                self.assertIn(prohibited_local_substitute, recipient_profile)
+                self.assertIn(
+                    "one private OS-managed executor-owned attempt-local retrieval",
+                    self.contract,
+                )
+                self.assertIn("Fallback changes delivery only", self.contract)
+                self.assertIn(
+                    "Exact durable identity: [immutable human locator, provider "
+                    "locator, object identity, size, SHA-256",
+                    delivery_envelope,
+                )
+                self.assertIn(
+                    "Verify raw or attempt-local bytes, size, SHA-256, UTF-8, no BOM, "
+                    "LF endings, and the declared final-newline rule before acceptance.",
+                    delivery_envelope,
+                )
+                self.assertIn(
+                    "Fail closed on collision, mismatch, missing identity, prohibited "
+                    "retention, unsupported required capability, or ambiguous authority.",
+                    delivery_envelope,
+                )
+                self.assertIn(
+                    "Prohibited delivery: no exchange root, mutable alias, shadow "
+                    "durable copy, or copy/paste claim of byte identity",
+                    delivery_envelope,
+                )
+                self.assertIn(
+                    "without reproducing the complete prompt",
+                    presentation,
+                )
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -254,6 +254,28 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertLess(route, file)
         self.assertLess(file, handoff)
 
+    def test_codex_and_claude_handoffs_use_the_same_shared_selector(self):
+        presentation = " ".join(self.presentation.split())
+        self.assertIn("a Codex-produced prompt for Claude", presentation)
+        self.assertIn("a Claude-produced prompt for Codex", presentation)
+        self.assertIn("same shared presentation and handoff contract", presentation)
+        self.assertIn(
+            "without reproducing the complete prompt in the thin handoff",
+            presentation,
+        )
+
+        for adapter in self.adapter_profiles[:2]:
+            self.assertIn(
+                "prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile",
+                adapter,
+            )
+            self.assertIn("attempt-local", adapter)
+            self.assertIn("fail closed", adapter)
+        self.assertIn("Prefer direct retrieval", self.adapter_profiles[0])
+        self.assertIn(
+            "Direct provider consumption", " ".join(self.adapter_profiles[1].split())
+        )
+
     def test_two_block_format_is_conditional_on_inline_presentation(self):
         complete_shape = " ".join(self.complete_prompt_shape.split())
         chatgpt_prompt = " ".join(self.chatgpt_prompt_presentation.split())


### PR DESCRIPTION
## Summary
- state that Codex→Claude and Claude→Codex prompts use the same recipient-capability selector
- require a thin retrieval handoff after successful Dropbox-backed presentation
- add directional regression coverage for shared contract, direct retrieval, exact fallback, and fail-closed behavior

## Validation
- make check

CAK-192