### PR TITLE
CAK-195: reroute hydration on task-shape transitions

### DIFF
--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -190,6 +190,55 @@ conditional routing activates them. Do not load full maintenance,
 cross-repository, prompt-contract, or multi-agent doctrine into an ordinary
 single-repository task that does not touch those surfaces.
 
+### Task-Shape Activation Re-Routing
+
+Repository operating mode and the currently activated source set are separate
+state. Before a repository-scoped response, plan, draft, or action, determine
+whether the task shape materially changed in artifact type, interaction mode,
+workflow, authoritative-source requirements, execution locality, target
+executor, or authority boundary. An ordinary follow-up with the same needs
+reuses the still-current activated sources.
+
+When the task shape changes:
+
+1. Derive the changed task's required-source set from [Task Routing](#task-routing),
+   the repository floor, [Conditional Repository Guidance](#conditional-repository-guidance),
+   and any narrower activation rule in the owning source.
+2. Compare the changed task's required-source set with the currently activated
+   source set.
+3. Reuse still-current owners and retrieve only the newly required owners
+   before reasoning about, drafting, or acting on the affected task. This does
+   not require rereading the repository floor or other still-current owners.
+4. If a newly required owner cannot be retrieved, fail closed for the affected
+   conclusion or artifact rather than substituting memory, a summary, or a
+   convenient example from an already-loaded source.
+5. Apply the retrieved owners to the resulting behavior and validate the
+   output against their contracts.
+
+Activation and application are separate stages. Successfully retrieving an
+owner does not prove that its requirements were applied. The output must still
+conform when a later prerequisite blocks the preferred path: use the activated
+owner's failure, fallback, or presentation rules rather than degrading into an
+unconstrained response. A convenient example in an already-loaded source cannot
+substitute for a newly activated narrower owner or prove behavioral conformance.
+
+The CAK-195 cold-start regression illustrates the boundary. A fresh-memory
+repository-scoped ChatGPT interaction begins with `Let's begin CAK-194` and
+hydrates the repository floor, ChatGPT adapter, and investigation sources. The
+next request, `give me an example codex prompt to show the formatting you'd
+use`, changes the artifact, interaction mode, and target executor. Prompt
+authoring therefore newly activates `docs/prompts.md`, and the Codex target
+newly activates `docs/tool-adapters/codex.md`; the still-current repository
+floor and ChatGPT sources are reused. Both owners must be retrieved before the
+Codex prompt is produced, and their output contract remains active if a later
+delivery prerequisite becomes blocked.
+
+A nearby sibling transition follows the same rule: moving from review/audit to
+implementation reuses the still-current repository floor and newly activates
+`docs/feature-lifecycle.md` before implementation planning or mutation. These
+examples define routing and conformance checks only; the specialized prompt,
+executor, lifecycle, and failure semantics remain with their canonical owners.
+
 ### Repository Instruction Hierarchy
 
 Apply overlapping repository instructions in this order:

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -190,55 +190,6 @@ conditional routing activates them. Do not load full maintenance,
 cross-repository, prompt-contract, or multi-agent doctrine into an ordinary
 single-repository task that does not touch those surfaces.
 
-### Task-Shape Activation Re-Routing
-
-Repository operating mode and the currently activated source set are separate
-state. Before a repository-scoped response, plan, draft, or action, determine
-whether the task shape materially changed in artifact type, interaction mode,
-workflow, authoritative-source requirements, execution locality, target
-executor, or authority boundary. An ordinary follow-up with the same needs
-reuses the still-current activated sources.
-
-When the task shape changes:
-
-1. Derive the changed task's required-source set from [Task Routing](#task-routing),
-   the repository floor, [Conditional Repository Guidance](#conditional-repository-guidance),
-   and any narrower activation rule in the owning source.
-2. Compare the changed task's required-source set with the currently activated
-   source set.
-3. Reuse still-current owners and retrieve only the newly required owners
-   before reasoning about, drafting, or acting on the affected task. This does
-   not require rereading the repository floor or other still-current owners.
-4. If a newly required owner cannot be retrieved, fail closed for the affected
-   conclusion or artifact rather than substituting memory, a summary, or a
-   convenient example from an already-loaded source.
-5. Apply the retrieved owners to the resulting behavior and validate the
-   output against their contracts.
-
-Activation and application are separate stages. Successfully retrieving an
-owner does not prove that its requirements were applied. The output must still
-conform when a later prerequisite blocks the preferred path: use the activated
-owner's failure, fallback, or presentation rules rather than degrading into an
-unconstrained response. A convenient example in an already-loaded source cannot
-substitute for a newly activated narrower owner or prove behavioral conformance.
-
-The CAK-195 cold-start regression illustrates the boundary. A fresh-memory
-repository-scoped ChatGPT interaction begins with `Let's begin CAK-194` and
-hydrates the repository floor, ChatGPT adapter, and investigation sources. The
-next request, `give me an example codex prompt to show the formatting you'd
-use`, changes the artifact, interaction mode, and target executor. Prompt
-authoring therefore newly activates `docs/prompts.md`, and the Codex target
-newly activates `docs/tool-adapters/codex.md`; the still-current repository
-floor and ChatGPT sources are reused. Both owners must be retrieved before the
-Codex prompt is produced, and their output contract remains active if a later
-delivery prerequisite becomes blocked.
-
-A nearby sibling transition follows the same rule: moving from review/audit to
-implementation reuses the still-current repository floor and newly activates
-`docs/feature-lifecycle.md` before implementation planning or mutation. These
-examples define routing and conformance checks only; the specialized prompt,
-executor, lifecycle, and failure semantics remain with their canonical owners.
-
 ### Repository Instruction Hierarchy
 
 Apply overlapping repository instructions in this order:
@@ -323,13 +274,21 @@ establish sufficiency.
   leaves repository work or the human explicitly requests a different artifact
   style. Moving to another repository requires applying that repository's
   startup contract before assuming its native conventions.
-- Repository operating-mode persistence does not freeze the required source
-  set. When a task materially changes interaction mode, artifact type,
-  workflow, authoritative-source requirements, execution locality, or
-  authority boundary, re-evaluate activation routing for the current task and
-  retrieve newly required sources before answering, planning, drafting, or
-  acting. Reuse still-current verified sources; do not replay unchanged
-  doctrine or hydrate unrelated documents.
+- Repository operating-mode persistence does not freeze the task-specific
+  activated source set. When a task materially changes interaction mode,
+  artifact type, workflow, authoritative-source requirements, execution
+  locality, target executor, or authority boundary, re-evaluate activation
+  routing and compare the changed task's required-source set with the currently
+  activated set. Reuse the still-current repository floor and owners, retrieve
+  only newly required owners before answering, planning, drafting, or acting,
+  and do not blanket-rehydrate ordinary follow-ups. If a newly required owner
+  cannot be retrieved, fail closed for the affected conclusion or artifact;
+  memory, summaries, and convenient examples are not substitutes.
+- Activation and application are separate stages. Successfully retrieving an
+  owner does not prove its contract was applied. Validate the resulting
+  behavior against the activated contract, and if a later prerequisite blocks
+  the preferred path, preserve the owner's failure, fallback, or presentation
+  contract rather than degrading into unconstrained prose.
 - `docs/prompt-contracts.md` and its versioned machine-readable companions own
   shared prompt-contract meaning; implementing repositories own operational
   schemas, hydration, rendering, receipts, and validation code.

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -202,6 +202,16 @@ existing [two-block inline presentation](#prompt-presentation). If access is
 unknown, inspect or attempt it before falling back. Material prompts also apply
 the durable profile below; routine prompts do not inherit it from transport.
 
+Owner retrieval and output conformance remain separate checks. If a selected
+Dropbox or file route becomes blocked before a qualified prompt handoff is
+complete, re-run the recipient-capability selector against the observed state.
+When it permits inline presentation, preserve the two-block complete-prompt
+shape and report the blocked delivery limitation outside the copyable blocks.
+When the governing exact-byte or durable contract prohibits that fallback,
+preserve the target-shaped handoff with an explicit blocked state and stop. Do
+not degrade the required prompt or handoff into unconstrained status prose
+merely because one downstream prerequisite failed.
+
 ### Dropbox Preview And Minimal Executor Handoff
 
 When optional operator preview is selected, exact-verify the durable prompt,

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -20,6 +20,44 @@ class ChatGPTAdapterTests(unittest.TestCase):
         self.assertIn("re-evaluate activation routing", contents)
         self.assertIn("Reuse still-current verified sources", contents)
 
+    def test_start_here_re_routes_changed_task_shape_before_codex_prompt(self):
+        contents = (DOCS / "start-here.md").read_text(encoding="utf-8")
+        chatgpt = (DOCS / "tool-adapters" / "chatgpt.md").read_text(
+            encoding="utf-8"
+        )
+        normalized = " ".join(contents.split())
+        normalized_chatgpt = " ".join(chatgpt.split())
+
+        for phrase in (
+            "Task-Shape Activation Re-Routing",
+            "Compare the changed task's required-source set with the currently activated source set",
+            "retrieve only the newly required owners",
+            "target executor",
+            "A convenient example in an already-loaded source cannot substitute",
+            "fail closed for the affected conclusion or artifact",
+            "Let's begin CAK-194",
+            "give me an example codex prompt to show the formatting you'd use",
+            "docs/prompts.md",
+            "docs/tool-adapters/codex.md",
+            "review/audit to implementation",
+            "docs/feature-lifecycle.md",
+            "Activation and application are separate stages",
+            "Successfully retrieving an owner does not prove",
+        ):
+            self.assertIn(phrase, normalized)
+
+        self.assertIn(
+            "does not require rereading the repository floor or other still-current owners",
+            normalized,
+        )
+        for phrase in (
+            "blocked before a qualified prompt handoff is complete",
+            "re-run the recipient-capability selector against the observed state",
+            "preserve the two-block complete-prompt shape",
+            "Do not degrade the required prompt or handoff into unconstrained status prose",
+        ):
+            self.assertIn(phrase, normalized_chatgpt)
+
     def test_adapter_projects_boundaries_to_canonical_owners(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
 

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -17,10 +17,15 @@ class ChatGPTAdapterTests(unittest.TestCase):
         self.assertIn("docs/tool-adapters/chatgpt.md", contents)
         self.assertNotIn("ChatGPT/Work runs must read", contents)
         self.assertIn("Repository operating-mode persistence does not freeze", contents)
-        self.assertIn("re-evaluate activation routing", contents)
-        self.assertIn("Reuse still-current verified sources", contents)
+        self.assertIn("re-evaluate activation routing", normalized_start_here)
+        self.assertIn(
+            "Reuse the still-current repository floor and owners",
+            normalized_start_here,
+        )
 
-    def test_start_here_re_routes_changed_task_shape_before_codex_prompt(self):
+    def test_start_here_reroutes_material_task_shape_without_blanket_rehydration(
+        self,
+    ):
         contents = (DOCS / "start-here.md").read_text(encoding="utf-8")
         chatgpt = (DOCS / "tool-adapters" / "chatgpt.md").read_text(
             encoding="utf-8"
@@ -29,27 +34,30 @@ class ChatGPTAdapterTests(unittest.TestCase):
         normalized_chatgpt = " ".join(chatgpt.split())
 
         for phrase in (
-            "Task-Shape Activation Re-Routing",
-            "Compare the changed task's required-source set with the currently activated source set",
-            "retrieve only the newly required owners",
+            "task-specific activated source set",
+            "re-evaluate activation routing",
+            "compare the changed task's required-source set with the currently activated set",
+            "retrieve only newly required owners",
+            "Reuse the still-current repository floor and owners",
+            "do not blanket-rehydrate ordinary follow-ups",
             "target executor",
-            "A convenient example in an already-loaded source cannot substitute",
             "fail closed for the affected conclusion or artifact",
-            "Let's begin CAK-194",
-            "give me an example codex prompt to show the formatting you'd use",
-            "docs/prompts.md",
-            "docs/tool-adapters/codex.md",
-            "review/audit to implementation",
-            "docs/feature-lifecycle.md",
+            "memory, summaries, and convenient examples are not substitutes",
             "Activation and application are separate stages",
-            "Successfully retrieving an owner does not prove",
+            "Successfully retrieving an owner does not prove its contract was applied",
+            "preserve the owner's failure, fallback, or presentation contract",
+            "rather than degrading into unconstrained prose",
         ):
             self.assertIn(phrase, normalized)
 
-        self.assertIn(
-            "does not require rereading the repository floor or other still-current owners",
-            normalized,
-        )
+        for incident_text in (
+            "CAK-194",
+            "CAK-195",
+            "Let's begin CAK-194",
+            "give me an example codex prompt to show the formatting you'd use",
+        ):
+            self.assertNotIn(incident_text, contents)
+
         for phrase in (
             "blocked before a qualified prompt handoff is complete",
             "re-run the recipient-capability selector against the observed state",


### PR DESCRIPTION
## Summary\n\n- keep persistent repository mode separate from the task-specific activated source set\n- re-evaluate material task-shape changes, reuse still-current owners, retrieve only newly required owners, and fail closed when a required owner is unavailable\n- distinguish owner activation from output conformance so later blockers preserve the governing failure, fallback, or presentation contract\n- keep blocked prompt-delivery behavior in the ChatGPT adapter and regression-test the observed transition without embedding incident narrative in the canonical router\n\n## Validation\n\n- make check (308 tests passed)\n- authoritative-source-check passed in CI\n- markdownlint passed in CI\n- GitHub reports the branch cleanly mergeable with main\n\nLinear: CAK-195