### PR TITLE
CAK-196: select recipient capability before inline rendering

### DIFF
--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -336,8 +336,13 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-When the shared recipient-capability selector chooses inline presentation for
-a complete, copy-ready prompt or downstream handoff prepared in ChatGPT,
+Before rendering a complete, copy-ready prompt or downstream handoff inline,
+apply the shared [recipient-capability selector](../prompts.md#cross-executor-prompt-presentation).
+Do not begin either inline block until that selector has established the
+recipient's qualified Dropbox route and permitted destination, or has inspected
+or attempted an unknown capability and selected the inline fallback. When the
+shared recipient-capability selector chooses inline presentation for a complete,
+copy-ready prompt or downstream handoff,
 present the shared operator-metadata block followed immediately by the complete
 executable block as consecutive copyable code blocks, with no intervening
 prose. Immediately after the executable block, outside both code blocks, emit

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -177,3 +177,22 @@ class ChatGPTAdapterTests(unittest.TestCase):
         self.assertIn("does not ask ChatGPT to rename itself or report a naming limitation", normalized)
         self.assertNotIn("currently, that means an applicable Codex-targeted handoff", contents)
         self.assertIn("normal `SAME THREAD` or `CHILD TASK`", normalized)
+
+    def test_cold_start_codex_prompt_selects_capability_before_inline_rendering(self):
+        contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
+        prompt_presentation = " ".join(
+            contents[contents.index("### Prompt presentation") :].split()
+        )
+
+        selector = prompt_presentation.index("Before rendering a complete, copy-ready prompt")
+        capability = prompt_presentation.index(
+            "has inspected or attempted an unknown capability"
+        )
+        inline = prompt_presentation.index("present the shared operator-metadata block")
+
+        self.assertLess(selector, capability)
+        self.assertLess(capability, inline)
+        self.assertIn(
+            "[recipient-capability selector](../prompts.md#cross-executor-prompt-presentation)",
+            prompt_presentation,
+        )


### PR DESCRIPTION
## Summary
- require ChatGPT to apply recipient-capability selection before beginning inline prompt blocks
- require inspection or attempt of unknown capability before inline fallback
- add an order-sensitive cold-start Codex prompt regression

## Validation
- make check