### PR TITLE
CAK-197 classify executable prompt artifacts

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -361,6 +361,32 @@ Reason:
 [one concise task-specific explanation]
 ```
 
+## Produced-Artifact Classification
+
+Classify the artifact actually produced before choosing its presentation. The
+user's request framing can describe the desired level of detail, but words such
+as `example`, `sample`, `roughly`, `formatting`, `preview`, or `demo` do not
+make a produced artifact conceptual when it is complete or substantially
+executable for a downstream executor. This includes framing such as `show me
+the format`, `sample prompt`, or `example implementation prompt`.
+
+A produced artifact is substantially executable when it gives a downstream
+executor enough concrete task, scope, constraint, source, validation, and stop
+information to act as a prompt rather than merely illustrating a phrase or
+layout. Resolve known repository, task, and other required prompt-local values;
+do not retain a known-value placeholder to avoid this classification.
+
+Classify a complete or substantially executable artifact as a complete prompt
+for presentation and transport, then apply the recipient-capability selector
+before emitting any inline prompt block. This preserves the matching adapter's
+concrete model and reasoning metadata and the inline two-block shape when
+inline presentation is the selected route.
+
+Keep genuinely conceptual discussion, quoted source material, isolated
+snippets, and incomplete fragments lightweight. They are not complete prompts
+solely because they concern prompt design, and do not require file-backed
+transport.
+
 ## Cross-Executor Prompt Presentation
 
 This selector applies symmetrically when one executor produces a complete

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -336,8 +336,16 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-Before rendering a complete, copy-ready prompt or downstream handoff inline,
-apply the shared [recipient-capability selector](../prompts.md#cross-executor-prompt-presentation).
+Before choosing presentation, classify the artifact ChatGPT is about to
+produce under the shared
+[produced-artifact classification](../prompts.md#produced-artifact-classification)
+rule. Request framing such as `example`, `sample`, `roughly`, `formatting`,
+`preview`, or `demo` does not bypass complete-prompt handling when the produced
+artifact is complete or substantially executable for its downstream recipient.
+Keep genuinely conceptual fragments and incomplete snippets lightweight.
+
+After that classification, before rendering a complete, copy-ready prompt or downstream handoff inline, apply the shared
+[recipient-capability selector](../prompts.md#cross-executor-prompt-presentation).
 Do not begin either inline block until that selector has established the
 recipient's qualified Dropbox route and permitted destination, or has inspected
 or attempted an unknown capability and selected the inline fallback. When the

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -184,15 +184,58 @@ class ChatGPTAdapterTests(unittest.TestCase):
             contents[contents.index("### Prompt presentation") :].split()
         )
 
-        selector = prompt_presentation.index("Before rendering a complete, copy-ready prompt")
+        classification = prompt_presentation.index(
+            "Before choosing presentation, classify the artifact ChatGPT is about to produce"
+        )
+        executable = prompt_presentation.index(
+            "does not bypass complete-prompt handling when the produced artifact is complete or substantially executable"
+        )
+        selector = prompt_presentation.index(
+            "After that classification, before rendering a complete, copy-ready prompt"
+        )
         capability = prompt_presentation.index(
             "has inspected or attempted an unknown capability"
         )
         inline = prompt_presentation.index("present the shared operator-metadata block")
 
+        self.assertLess(classification, executable)
+        self.assertLess(executable, selector)
         self.assertLess(selector, capability)
         self.assertLess(capability, inline)
         self.assertIn(
             "[recipient-capability selector](../prompts.md#cross-executor-prompt-presentation)",
             prompt_presentation,
         )
+
+    def test_executable_examples_use_complete_prompt_presentation(self):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        codex = (DOCS / "tool-adapters" / "codex.md").read_text(encoding="utf-8")
+        classification = " ".join(
+            prompts[
+                prompts.index("## Produced-Artifact Classification") : prompts.index(
+                    "## Cross-Executor Prompt Presentation"
+                )
+            ].split()
+        )
+
+        for framing in (
+            "`example`",
+            "`sample`",
+            "`roughly`",
+            "`formatting`",
+            "`preview`",
+            "`demo`",
+            "`show me the format`",
+            "`sample prompt`",
+            "`example implementation prompt`",
+        ):
+            self.assertIn(framing, classification)
+        self.assertIn("complete or substantially executable", classification)
+        self.assertIn("before emitting any inline prompt block", classification)
+        self.assertIn("qualified capability", prompts)
+        self.assertIn("Dropbox-backed file", prompts)
+        self.assertIn("two-block shape", classification)
+        self.assertIn("known-value placeholder", classification)
+        self.assertIn("genuinely conceptual discussion", classification)
+        self.assertIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", codex)
+        self.assertNotIn("Recommended model: Codex", codex)


### PR DESCRIPTION
## Summary
- classify produced prompt artifacts by executability rather than request framing
- require recipient-capability selection before inline complete-prompt rendering
- cover executable examples, concrete Codex metadata, resolved values, and conceptual-fragment fallback

## Validation
- make check (310 tests; Markdown lint) 

Linear: CAK-197