### PR TITLE
CAK-198 honor ready-to-run prompt classification

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -363,6 +363,17 @@ Reason:
 
 ## Produced-Artifact Classification
 
+Explicit human readiness or classification language is authoritative input to
+this classification. When the human requests an exact, complete, executable,
+ready to run, final, ready to paste, ready to execute, or complete runnable
+prompt or handoff, do not weaken that classification with assistant-authored
+framing such as `illustrative`, `sample-only`, `conceptual`, `provisional`,
+`rough`, or `not finalized`. Apply the complete-prompt presentation and
+transport contract unless a stronger safety, authority, or capability
+constraint requires refusal or an explicit blocked result. If unresolved facts
+prevent a truthful ready-to-run artifact, resolve them from their owners or
+return that explicit blocked result; do not silently downgrade the artifact.
+
 Classify the artifact actually produced before choosing its presentation. The
 user's request framing can describe the desired level of detail, but words such
 as `example`, `sample`, `roughly`, `formatting`, `preview`, or `demo` do not

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -239,3 +239,64 @@ class ChatGPTAdapterTests(unittest.TestCase):
         self.assertIn("genuinely conceptual discussion", classification)
         self.assertIn("GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol", codex)
         self.assertNotIn("Recommended model: Codex", codex)
+
+    def test_explicit_ready_to_run_request_cannot_be_downgraded_before_routing(
+        self,
+    ):
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
+        chatgpt = (DOCS / "tool-adapters" / "chatgpt.md").read_text(
+            encoding="utf-8"
+        )
+        classification = " ".join(
+            prompts[
+                prompts.index("## Produced-Artifact Classification") : prompts.index(
+                    "## Cross-Executor Prompt Presentation"
+                )
+            ].split()
+        )
+        presentation = " ".join(
+            prompts[
+                prompts.index("## Cross-Executor Prompt Presentation") : prompts.index(
+                    "## Quick Navigation"
+                )
+            ].split()
+        )
+        chatgpt_presentation = " ".join(
+            chatgpt[chatgpt.index("### Prompt presentation") :].split()
+        )
+
+        cold_start_request = (
+            "Show me the exact Codex handoff you would use for CAK-194, "
+            "including the operator metadata and the complete executable prompt. "
+            "Treat it as ready to run, not as a conceptual example."
+        )
+        self.assertIn("exact Codex handoff", cold_start_request)
+        self.assertIn("complete executable prompt", cold_start_request)
+        self.assertIn("ready to run", cold_start_request)
+
+        for phrase in (
+            "authoritative input to this classification",
+            "exact, complete, executable, ready to run, final, ready to paste, "
+            "ready to execute, or complete runnable",
+            "do not weaken that classification with assistant-authored framing",
+            "`illustrative`",
+            "`sample-only`",
+            "`conceptual`",
+            "`provisional`",
+            "`rough`",
+            "`not finalized`",
+            "stronger safety, authority, or capability constraint",
+            "explicit blocked result",
+            "do not silently downgrade the artifact",
+        ):
+            self.assertIn(phrase, classification)
+
+        self.assertLess(
+            classification.index("authoritative input to this classification"),
+            classification.index("Classify the artifact actually produced"),
+        )
+        self.assertIn("qualified Dropbox retrieval route", presentation)
+        self.assertIn("Dropbox-backed file", presentation)
+        self.assertIn("without reproducing the complete prompt", presentation)
+        self.assertIn("present the complete prompt inline", presentation)
+        self.assertIn("consecutive copyable code blocks", chatgpt_presentation)


### PR DESCRIPTION
## Summary
- Make explicit human ready-to-run wording authoritative in prompt-artifact classification.
- Add regression coverage for the CAK-194 cold-start request and preserved routing behavior.

## Validation
- make check