### PR TITLE
CAK-199 lock inline prompt rendering

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -345,11 +345,16 @@ interpreted as inline HTML by Markdown tooling.
 
 ## Complete Prompt Shape
 
-When inline presentation is selected for a complete generated prompt, emit one
-shared operator-metadata block and one complete executable block consecutively.
-The executable block must remain complete and actionable without the metadata,
-so the operator can copy only that block. Matching executor adapters own
-concrete metadata fields and client presentation mechanics.
+When inline presentation is selected for a complete generated prompt, that
+selection controls the final response surface. Emit exactly two consecutive
+fenced code blocks: one shared operator-metadata block, then one complete
+executable block. Do not emit assistant-authored prose, headings, labels,
+separators, or postambles before, between, or after those blocks. Preserve
+ordinary line breaks inside both blocks; do not introduce Markdown
+line-continuation backslashes or equivalent escaping artifacts. The executable
+block must remain complete and actionable without the metadata, so the operator
+can copy only that block. Matching executor adapters own concrete metadata
+fields and client presentation mechanics.
 
 ```text
 Operator metadata (do not include in prompt)

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -353,28 +353,19 @@ shared recipient-capability selector chooses inline presentation for a complete,
 copy-ready prompt or downstream handoff,
 present the shared operator-metadata block followed immediately by the complete
 executable block as consecutive copyable code blocks, with no intervening
-prose. Immediately after the executable block, outside both code blocks, emit
-this separate line exactly:
-
-`ChatGPT thread: [exact canonical title]`
-
-Keep the executable block complete without metadata or the breadcrumb so the
-operator can copy only that block. The breadcrumb is human navigation only: it
-is not task authority, execution identity, durable continuity, source
-evidence, or part of the downstream executable prompt. Do not add it to quoted
-prompts, source excerpts, incomplete fragments, or conceptual discussion that
-does not deliver a copy-ready prompt.
-
-When no canonical title exists for the current ChatGPT workstream, establish a
-concise one; reuse that exact title in later complete prompts from the same
-conversation. The emitted value is a canonical navigation title, not verified
-or changed ChatGPT UI state when the UI title is not observable. The breadcrumb
-title may also be selected as a downstream visible name only when the
-downstream target executor adapter explicitly supports executor-applied naming.
-ChatGPT-targeted prompts resolve the shared naming placeholder to nothing. This
-adapter does not ask ChatGPT to rename itself or report a naming limitation,
-and it does not change the normal `SAME THREAD` or `CHILD TASK` routing behavior in
-[`prompts.md`](../prompts.md#executor-applied-visible-thread-names).
+prose. The shared canonical renderer controls the entire response surface:
+emit no assistant-authored material before, between, or after the two blocks.
+Do not add a copy instruction, navigation breadcrumb, Markdown separator,
+prose label, or line-continuation escaping artifact. Keep the executable block
+complete without metadata so the operator can copy only that block. This rule
+applies only after the shared selector has legitimately selected inline
+presentation; it does not change recipient-capability selection, Dropbox-backed
+routing, or the treatment of quoted prompts, source excerpts, incomplete
+fragments, and conceptual discussion. ChatGPT-targeted prompts resolve the
+shared naming placeholder to nothing. This adapter does not ask ChatGPT to
+rename itself or report a naming limitation. A downstream visible name may be
+selected only when the downstream target executor adapter explicitly supports
+executor-applied naming.
 
 Do not nest Markdown code fences inside the executable block; represent any
 embedded example with indentation or plain text. Optimize this client rendering

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import unittest
 
 
@@ -150,33 +151,72 @@ class ChatGPTAdapterTests(unittest.TestCase):
         ):
             self.assertIn(owner, contents)
 
-    def test_copy_ready_prompt_breadcrumb_stays_outside_both_code_blocks(self):
+    def test_inline_complete_prompt_renderer_owns_the_entire_response_surface(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
+        prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
         normalized = " ".join(contents.split())
+        complete_prompt_shape = " ".join(
+            prompts[
+                prompts.index("## Complete Prompt Shape") : prompts.index(
+                    "## Produced-Artifact Classification"
+                )
+            ].split()
+        )
 
         self.assertIn("complete, copy-ready prompt or downstream handoff", contents)
         self.assertIn("with no intervening prose", normalized)
-        self.assertIn(
-            "`ChatGPT thread: [exact canonical title]`",
-            contents,
+        self.assertIn("shared canonical renderer controls the entire response surface", normalized)
+        self.assertIn("no assistant-authored material before, between, or after", normalized)
+        self.assertIn("copy instruction, navigation breadcrumb, Markdown separator", normalized)
+        self.assertIn("prose label, or line-continuation escaping artifact", normalized)
+        self.assertNotIn("ChatGPT thread: [exact canonical title]", contents)
+
+        for phrase in (
+            "exactly two consecutive fenced code blocks",
+            "Do not emit assistant-authored prose, headings, labels, separators, or postambles",
+            "Markdown line-continuation backslashes or equivalent escaping artifacts",
+        ):
+            self.assertIn(phrase, complete_prompt_shape)
+
+        def is_canonical_inline_response(rendered):
+            match = re.fullmatch(
+                r"```[^\n]*\n(?P<metadata>.*?)```\n```[^\n]*\n(?P<prompt>.*?)```\n?",
+                rendered,
+                flags=re.DOTALL,
+            )
+            if not match:
+                return False
+            if not match.group("metadata").startswith("Thread routing:"):
+                return False
+            if not match.group("prompt").startswith("Outcome:"):
+                return False
+            return not any(
+                prohibited in rendered
+                for prohibited in (
+                    "Here’s the drop-in Codex handoff.",
+                    "---",
+                    "Copy the block as-is",
+                    "Reason:\\",
+                    "Outcome:\\",
+                    "Regression coverage:\\",
+                    "Final report:\\",
+                )
+            )
+
+        canonical_rendering = (
+            "```text\nThread routing: FRESH THREAD\nReason:\nFocused implementation.\n```\n"
+            "```text\nOutcome:\nImplement the bounded change.\n```\n"
         )
-        self.assertIn("outside both code blocks", contents)
-        self.assertIn(
-            "not task authority, execution identity, durable continuity, source evidence",
-            normalized,
-        )
-        self.assertIn("or part of the downstream executable prompt", normalized)
-        self.assertIn(
-            "quoted prompts, source excerpts, incomplete fragments, or conceptual discussion",
-            normalized,
-        )
-        self.assertIn("reuse that exact title in later complete prompts", normalized)
-        self.assertIn("not verified or changed ChatGPT UI state", normalized)
-        self.assertIn("downstream target executor adapter explicitly supports", normalized)
-        self.assertIn("ChatGPT-targeted prompts resolve the shared naming placeholder to nothing", normalized)
-        self.assertIn("does not ask ChatGPT to rename itself or report a naming limitation", normalized)
-        self.assertNotIn("currently, that means an applicable Codex-targeted handoff", contents)
-        self.assertIn("normal `SAME THREAD` or `CHILD TASK`", normalized)
+        self.assertTrue(is_canonical_inline_response(canonical_rendering))
+
+        for malformed_rendering in (
+            "Here’s the drop-in Codex handoff.\n" + canonical_rendering,
+            canonical_rendering.replace("\n```\n```text", "\n```\n---\n```text"),
+            canonical_rendering + "Copy the block as-is into a fresh Codex thread.\n",
+            canonical_rendering.replace("Reason:\n", "Reason:\\\n"),
+            canonical_rendering.replace("Outcome:\n", "Outcome:\\\n"),
+        ):
+            self.assertFalse(is_canonical_inline_response(malformed_rendering))
 
     def test_cold_start_codex_prompt_selects_capability_before_inline_rendering(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Make inline complete-prompt selection own the full two-code-block response surface.
- Remove the ChatGPT inline-rendering breadcrumb and prohibit rendering decorations and escape artifacts.
- Add deterministic regression coverage for the canonical and malformed response shapes.

## Validation
- make check

Linear: CAK-199