### PR TITLE
CAK-200: make prompt delivery deterministic

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -192,8 +192,8 @@ Thread routing never relaxes prompt completeness:
   thread, but remains directly usable without another prompt.
 - A `CHILD TASK` receives a complete bounded child prompt.
 
-The [recipient-capability selector](#cross-executor-prompt-presentation)
-applies to every complete prompt across these routing modes.
+The [prompt delivery decision model](#prompt-delivery-decision-model) applies
+to every complete prompt across these routing modes.
 
 Use the executor adapter for vendor-specific routing. For an existing task that
 exceeds its assigned capability, prefer a bounded stronger child or an explicit
@@ -393,36 +393,92 @@ layout. Resolve known repository, task, and other required prompt-local values;
 do not retain a known-value placeholder to avoid this classification.
 
 Classify a complete or substantially executable artifact as a complete prompt
-for presentation and transport, then apply the recipient-capability selector
-before emitting any inline prompt block. This preserves the matching adapter's
-concrete model and reasoning metadata and the inline two-block shape when
-inline presentation is the selected route.
+for presentation and transport. That classification is the output of the
+delivery model's first two stages and must not be reinterpreted by recipient,
+capability, presentation, or renderer selection. This preserves the matching
+adapter's concrete model and reasoning metadata and the inline two-block shape
+when inline presentation is the selected route.
 
 Keep genuinely conceptual discussion, quoted source material, isolated
 snippets, and incomplete fragments lightweight. They are not complete prompts
 solely because they concern prompt design, and do not require file-backed
 transport.
 
+## Prompt Delivery Decision Model
+
+This is the canonical compositional decision model for prompt delivery. Within
+one decision evaluation, run each activated stage once in the declared order
+and carry its explicit output forward in one decision record. A later stage may
+consume an earlier output, but it must not re-read conversational wording to
+replace that output or infer a different artifact, viewer, recipient, or
+transport. Rendering begins only after presentation has been selected.
+
+The decision record keeps the human operator or viewer separate from the
+executable prompt's execution recipient. The operator or viewer receives
+metadata, a file surface, or a handoff; the execution recipient consumes the
+executable prompt. Human visibility, a request to receive or see a handoff,
+and the presence of operator metadata do not make the human the execution
+recipient of a prompt that is semantically directed to a machine executor.
+
+| Order | Stage | Required input | Explicit output | Invariant |
+| --- | --- | --- | --- | --- |
+| 1 | `artifact-production` | Current human intent and the artifact actually being produced | `no-prompt`, `fragment`, or `prompt-produced` | Do not enter prompt delivery when no prompt artifact is being produced. |
+| 2 | `artifact-classification` | Produced artifact plus authoritative readiness intent | `conceptual-fragment` or `complete-executable` | Classify produced semantics, not request vocabulary; freeze the result. |
+| 3 | `operator-viewer-resolution` | Current interaction and orchestration context | Explicit human or orchestration viewer identity | Viewer identity controls the operator-facing surface only. |
+| 4 | `execution-recipient-resolution` | Executable body, target surface, task shape, and human direction | Explicit recipient identity and `human` or `machine-executor` class | Resolve independently from the viewer; do not infer it from who asked the question. |
+| 5 | `capability-and-transport-resolution` | Frozen recipient identity, current runtime capability evidence, authority, and permitted destination | `qualified-file-route`, `inline-route`, `inline-fallback-permitted`, or `blocked` with reason | Inspect or attempt unknown capability; never invent a destination or weaken an exact-byte contract. |
+| 6 | `presentation-selection` | Frozen artifact class, recipient class, and route resolution | `lightweight`, `file-backed`, `inline`, or `blocked` | Qualified machine execution selects file-backed delivery; operator visibility cannot override it. |
+| 7 | `renderer-selection` | Frozen presentation selection | `lightweight`, `thin-handoff`, `canonical-inline-two-block`, or `none` | Inline rendering is reachable only from `inline`; a renderer cannot change upstream state. |
+| 8 | `delivery-outcome` | Complete decision record and selected renderer result | Selected delivery evidence or explicit fallback or blocked result | Emit only the selected surface and preserve the owning failure contract. |
+
+Apply these terminal mappings deterministically:
+
+- `conceptual-fragment` selects `lightweight` presentation and the lightweight
+  renderer without machine-delivery ceremony.
+- `complete-executable` plus a `machine-executor` and
+  `qualified-file-route` selects `file-backed` presentation and the
+  `thin-handoff` renderer. The complete executable prompt is not rendered
+  inline.
+- `complete-executable` plus a human execution recipient resolves
+  `inline-route`, then selects `inline` presentation and the
+  `canonical-inline-two-block` renderer.
+- `complete-executable` plus `inline-fallback-permitted` selects `inline`
+  presentation and the `canonical-inline-two-block` renderer, while preserving
+  the observed file-route limitation outside the copyable blocks when the
+  client surface permits it.
+- `blocked` selects no complete-prompt renderer. Emit the owning explicit
+  blocked result; do not turn the block into convenient inline delivery or
+  unconstrained status prose.
+
+Conversational wording is evidence available to the production,
+classification, and recipient-resolution stages. It is not a lookup table and
+must not be matched through a phrase whitelist or blacklist. Once those stages
+have resolved their semantic outputs, capability, presentation, and renderer
+selection consume only the decision record.
+
 ## Cross-Executor Prompt Presentation
 
-This selector applies symmetrically when one executor produces a complete
-prompt for another: each direction is governed by the same shared presentation
-and handoff contract.
+This section supplies the transport and presentation rules consumed by stages
+5 through 8 of the canonical decision model. The model applies symmetrically
+when one executor produces a complete prompt for another: each direction is
+governed by the same shared presentation and handoff contract.
 
-For any complete prompt, select presentation by the recipient's currently
-qualified capability, independently of prompt materiality:
+For any complete prompt, select presentation by the execution recipient's
+currently qualified capability and permitted destination, independently of
+the operator or viewer identity:
 
-- When the recipient has a qualified Dropbox retrieval route and the current
-  storage contract supplies a permitted destination, place the prompt in a
-  Dropbox-backed file, present the file surface produced by that operation, and
-  immediately provide the target-shaped
+- When the machine execution recipient has a qualified Dropbox retrieval route
+  and the current storage contract supplies a permitted destination, place the
+  prompt in a Dropbox-backed file, present the file surface produced by that
+  operation, and immediately provide the target-shaped
   [thin semantic handoff](#thin-semantic-handoff-envelope) without reproducing
   the complete prompt. A separate preview or open action is optional under the
   matching client adapter and does not block the handoff or require prompt
   approval.
-- For a human recipient, or when the receiving system has no qualified Dropbox
-  route, present the complete prompt inline through the matching client
-  adapter. When access is unknown, apply the
+- For a human execution recipient, or when the machine execution recipient has
+  no qualified Dropbox route and the owning contract permits inline fallback,
+  present the complete prompt inline through the matching client adapter. When
+  access is unknown, apply the
   [connector-availability rule](start-here.md#connector-availability-is-runtime-evidence)
   before choosing this fallback.
 
@@ -438,11 +494,14 @@ Complete that profile before reporting preservation or providing an
 exact-identity handoff. A routine prompt delivered through a file does not
 thereby acquire its durable capture, recovery, replay, receipt,
 immutable-version, or governance ceremony. When no permitted file destination
-exists, use inline presentation rather than inventing a storage surface.
+exists, use inline presentation only when the owning fallback contract permits
+it; otherwise emit the explicit blocked result rather than inventing a storage
+surface.
 
 ## Quick Navigation
 
 - [Task-Shape Surface Selection And Thin Handoffs](#task-shape-surface-selection-and-thin-handoffs)
+- [Prompt Delivery Decision Model](#prompt-delivery-decision-model)
 - [Cross-Executor Prompt Presentation](#cross-executor-prompt-presentation)
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -422,10 +422,10 @@ recipient of a prompt that is semantically directed to a machine executor.
 
 | Order | Stage | Required input | Explicit output | Invariant |
 | --- | --- | --- | --- | --- |
-| 1 | `artifact-production` | Current human intent and the artifact actually being produced | `no-prompt`, `fragment`, or `prompt-produced` | Do not enter prompt delivery when no prompt artifact is being produced. |
+| 1 | `artifact-production` | Current human intent and the artifact actually being produced | `no-prompt` or `prompt-produced` | Do not enter prompt delivery when no prompt artifact is being produced. |
 | 2 | `artifact-classification` | Produced artifact plus authoritative readiness intent | `conceptual-fragment` or `complete-executable` | Classify produced semantics, not request vocabulary; freeze the result. |
 | 3 | `operator-viewer-resolution` | Current interaction and orchestration context | Explicit human or orchestration viewer identity | Viewer identity controls the operator-facing surface only. |
-| 4 | `execution-recipient-resolution` | Executable body, target surface, task shape, and human direction | Explicit recipient identity and `human` or `machine-executor` class | Resolve independently from the viewer; do not infer it from who asked the question. |
+| 4 | `execution-recipient-resolution` | Executable body, target surface, task shape, and human direction | Explicit recipient identity and `human` or `machine-executor` class, or `unresolved` with reason | Resolve independently from the viewer; do not infer it from who asked the question or default ambiguity to the human viewer. |
 | 5 | `capability-and-transport-resolution` | Frozen recipient identity, current runtime capability evidence, authority, and permitted destination | `qualified-file-route`, `inline-route`, `inline-fallback-permitted`, or `blocked` with reason | Inspect or attempt unknown capability; never invent a destination or weaken an exact-byte contract. |
 | 6 | `presentation-selection` | Frozen artifact class, recipient class, and route resolution | `lightweight`, `file-backed`, `inline`, or `blocked` | Qualified machine execution selects file-backed delivery; operator visibility cannot override it. |
 | 7 | `renderer-selection` | Frozen presentation selection | `lightweight`, `thin-handoff`, `canonical-inline-two-block`, or `none` | Inline rendering is reachable only from `inline`; a renderer cannot change upstream state. |
@@ -433,6 +433,9 @@ recipient of a prompt that is semantically directed to a machine executor.
 
 Apply these terminal mappings deterministically:
 
+- `no-prompt` ends the evaluation after `artifact-production`. Do not activate
+  classification, viewer, recipient, capability, presentation, renderer, or
+  delivery stages and do not emit a prompt-delivery result.
 - `conceptual-fragment` selects `lightweight` presentation and the lightweight
   renderer without machine-delivery ceremony.
 - `complete-executable` plus a `machine-executor` and
@@ -446,9 +449,20 @@ Apply these terminal mappings deterministically:
   presentation and the `canonical-inline-two-block` renderer, while preserving
   the observed file-route limitation outside the copyable blocks when the
   client surface permits it.
+- An `unresolved` execution recipient resolves transport to `blocked` with the
+  resolution reason and selects no complete-prompt renderer. Never treat an
+  unresolved recipient as the human viewer to obtain an inline route.
 - `blocked` selects no complete-prompt renderer. Emit the owning explicit
   blocked result; do not turn the block into convenient inline delivery or
   unconstrained status prose.
+
+The once-per-stage rule applies within one evaluation. If a selected route
+fails before delivery completes, the same delivery attempt may perform exactly
+one capability re-evaluation. Preserve the stage 1 through 4 outputs unchanged
+and activate only stages 5 through 8 against the newly observed capability
+state. If the re-evaluated route also fails, or capability remains unresolved,
+resolve `blocked` with the observed reason; do not re-enter again or recompute
+the artifact, viewer, or execution recipient.
 
 Conversational wording is evidence available to the production,
 classification, and recipient-resolution stages. It is not a lookup table and

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -186,27 +186,39 @@ establish a universal per-action client-rendering suppression control.
 
 ### Recipient-Capability Prompt Presentation
 
-Apply the shared
-[`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation)
-selector. For a machine recipient with qualified Dropbox retrieval and a
-permitted destination, use the authorized file route, present the card produced
-by the write when available, and immediately provide the target-shaped handoff.
-A separate preview or open action remains optional under the connected-app
-rules above. Do not wait for prompt approval or require the operator to open a
-preview; connector confirmation authorizes only its file operation. File-card
-and preview behavior is product-dependent runtime evidence, so recheck the
-relevant action.
+Apply the complete shared
+[`prompt delivery decision model`](../prompts.md#prompt-delivery-decision-model),
+with the transport rules in
+[`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation).
+Record the human operator or viewer and the executable prompt's execution
+recipient as independent stage outputs before inspecting capability. The fact
+that the operator asks to receive, view, or be given a handoff is evidence
+about the operator-facing surface; it does not replace a resolved Codex,
+Claude, Work, or other machine execution recipient with the human viewer.
 
-For a human recipient or a system without a qualified Dropbox route, use the
-existing [two-block inline presentation](#prompt-presentation). If access is
-unknown, inspect or attempt it before falling back. Material prompts also apply
+For a machine execution recipient with qualified Dropbox retrieval and a
+permitted destination, the model selects `file-backed` presentation. Use the
+authorized file route, present the card produced by the write when available,
+and immediately provide the target-shaped handoff. A separate preview or open
+action remains optional under the connected-app rules above. Do not wait for
+prompt approval or require the operator to open a preview; connector
+confirmation authorizes only its file operation. File-card and preview behavior
+is product-dependent runtime evidence, so recheck the relevant action.
+
+For a human execution recipient, or a machine execution recipient whose
+inspected capability state permits inline fallback, the model selects `inline`
+presentation and the existing
+[two-block inline renderer](#prompt-presentation). If access is unknown,
+inspect or attempt it before resolving the route. Material prompts also apply
 the durable profile below; routine prompts do not inherit it from transport.
 
 Owner retrieval and output conformance remain separate checks. If a selected
 Dropbox or file route becomes blocked before a qualified prompt handoff is
-complete, re-run the recipient-capability selector against the observed state.
-When it permits inline presentation, preserve the two-block complete-prompt
-shape and report the blocked delivery limitation outside the copyable blocks.
+complete, preserve the frozen artifact, viewer, and recipient outputs and
+re-enter stages 5 through 8 against the newly observed capability state. When
+the owning contract permits inline fallback, preserve the two-block
+complete-prompt shape and report the blocked delivery limitation outside the
+copyable blocks.
 When the governing exact-byte or durable contract prohibits that fallback,
 preserve the target-shaped handoff with an explicit blocked state and stop. Do
 not degrade the required prompt or handoff into unconstrained status prose
@@ -336,32 +348,29 @@ the applicable prompt and downstream-context contract.
 
 ### Prompt presentation
 
-Before choosing presentation, classify the artifact ChatGPT is about to
-produce under the shared
-[produced-artifact classification](../prompts.md#produced-artifact-classification)
-rule. Request framing such as `example`, `sample`, `roughly`, `formatting`,
-`preview`, or `demo` does not bypass complete-prompt handling when the produced
-artifact is complete or substantially executable for its downstream recipient.
-Keep genuinely conceptual fragments and incomplete snippets lightweight.
+Consume the frozen stage outputs from the shared
+[prompt delivery decision model](../prompts.md#prompt-delivery-decision-model).
+ChatGPT must not reclassify the produced artifact, replace the execution
+recipient with the operator or viewer, or reconsider transport from request
+wording during rendering. Keep genuinely conceptual fragments and incomplete
+snippets lightweight through the model's `lightweight` renderer.
 
-After that classification, before rendering a complete, copy-ready prompt or downstream handoff inline, apply the shared
-[recipient-capability selector](../prompts.md#cross-executor-prompt-presentation).
-Do not begin either inline block until that selector has established the
-recipient's qualified Dropbox route and permitted destination, or has inspected
-or attempted an unknown capability and selected the inline fallback. When the
-shared recipient-capability selector chooses inline presentation for a complete,
-copy-ready prompt or downstream handoff,
-present the shared operator-metadata block followed immediately by the complete
+Do not begin either inline block unless `presentation-selection` produced
+`inline` and `renderer-selection` produced `canonical-inline-two-block`.
+`file-backed` uses only the thin-handoff renderer, and `blocked` uses no
+complete-prompt renderer. When the model legitimately selects inline
+presentation for a complete, copy-ready prompt or downstream handoff, present
+the shared operator-metadata block followed immediately by the complete
 executable block as consecutive copyable code blocks, with no intervening
 prose. The shared canonical renderer controls the entire response surface:
 emit no assistant-authored material before, between, or after the two blocks.
 Do not add a copy instruction, navigation breadcrumb, Markdown separator,
 prose label, or line-continuation escaping artifact. Keep the executable block
 complete without metadata so the operator can copy only that block. This rule
-applies only after the shared selector has legitimately selected inline
-presentation; it does not change recipient-capability selection, Dropbox-backed
-routing, or the treatment of quoted prompts, source excerpts, incomplete
-fragments, and conceptual discussion. ChatGPT-targeted prompts resolve the
+applies only after the shared model has selected inline presentation; it does
+not change classification, recipient, capability, Dropbox-backed routing, or
+the treatment of quoted prompts, source excerpts, incomplete fragments, and
+conceptual discussion. ChatGPT-targeted prompts resolve the
 shared naming placeholder to nothing. This adapter does not ask ChatGPT to
 rename itself or report a naming limitation. A downstream visible name may be
 selected only when the downstream target executor adapter explicitly supports

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -214,11 +214,10 @@ the durable profile below; routine prompts do not inherit it from transport.
 
 Owner retrieval and output conformance remain separate checks. If a selected
 Dropbox or file route becomes blocked before a qualified prompt handoff is
-complete, preserve the frozen artifact, viewer, and recipient outputs and
-re-enter stages 5 through 8 against the newly observed capability state. When
-the owning contract permits inline fallback, preserve the two-block
-complete-prompt shape and report the blocked delivery limitation outside the
-copyable blocks.
+complete, apply the canonical decision model's bounded capability
+re-evaluation rule. When the owning contract permits inline fallback, preserve
+the two-block complete-prompt shape and report the blocked delivery limitation
+outside the copyable blocks.
 When the governing exact-byte or durable contract prohibits that fallback,
 preserve the target-shaped handoff with an explicit blocked state and stop. Do
 not degrade the required prompt or handoff into unconstrained status prose

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -61,7 +61,8 @@ class ChatGPTAdapterTests(unittest.TestCase):
 
         for phrase in (
             "blocked before a qualified prompt handoff is complete",
-            "re-run the recipient-capability selector against the observed state",
+            "preserve the frozen artifact, viewer, and recipient outputs",
+            "re-enter stages 5 through 8 against the newly observed capability state",
             "preserve the two-block complete-prompt shape",
             "Do not degrade the required prompt or handoff into unconstrained status prose",
         ):
@@ -218,34 +219,51 @@ class ChatGPTAdapterTests(unittest.TestCase):
         ):
             self.assertFalse(is_canonical_inline_response(malformed_rendering))
 
-    def test_cold_start_codex_prompt_selects_capability_before_inline_rendering(self):
+    def test_chatgpt_projects_frozen_delivery_model_before_inline_rendering(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")
         prompt_presentation = " ".join(
             contents[contents.index("### Prompt presentation") :].split()
         )
+        recipient_start = contents.index(
+            "### Recipient-Capability Prompt Presentation"
+        )
+        recipient_end = contents.index(
+            "### Dropbox Preview And Minimal Executor Handoff"
+        )
+        recipient_projection = " ".join(
+            contents[recipient_start:recipient_end].split()
+        )
 
-        classification = prompt_presentation.index(
-            "Before choosing presentation, classify the artifact ChatGPT is about to produce"
+        frozen = prompt_presentation.index(
+            "Consume the frozen stage outputs from the shared"
         )
-        executable = prompt_presentation.index(
-            "does not bypass complete-prompt handling when the produced artifact is complete or substantially executable"
+        no_reclassification = prompt_presentation.index(
+            "must not reclassify the produced artifact"
         )
-        selector = prompt_presentation.index(
-            "After that classification, before rendering a complete, copy-ready prompt"
+        presentation = prompt_presentation.index(
+            "unless `presentation-selection` produced `inline`"
         )
-        capability = prompt_presentation.index(
-            "has inspected or attempted an unknown capability"
+        renderer = prompt_presentation.index(
+            "`renderer-selection` produced `canonical-inline-two-block`"
         )
-        inline = prompt_presentation.index("present the shared operator-metadata block")
+        inline = prompt_presentation.index(
+            "present the shared operator-metadata block"
+        )
 
-        self.assertLess(classification, executable)
-        self.assertLess(executable, selector)
-        self.assertLess(selector, capability)
-        self.assertLess(capability, inline)
+        self.assertLess(frozen, no_reclassification)
+        self.assertLess(no_reclassification, presentation)
+        self.assertLess(presentation, renderer)
+        self.assertLess(renderer, inline)
         self.assertIn(
-            "[recipient-capability selector](../prompts.md#cross-executor-prompt-presentation)",
+            "[prompt delivery decision model](../prompts.md#prompt-delivery-decision-model)",
             prompt_presentation,
         )
+        self.assertIn(
+            "operator or viewer and the executable prompt's execution recipient as independent stage outputs",
+            recipient_projection,
+        )
+        self.assertIn("before inspecting capability", recipient_projection)
+        self.assertIn("does not replace a resolved Codex", recipient_projection)
 
     def test_executable_examples_use_complete_prompt_presentation(self):
         prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")
@@ -271,7 +289,10 @@ class ChatGPTAdapterTests(unittest.TestCase):
         ):
             self.assertIn(framing, classification)
         self.assertIn("complete or substantially executable", classification)
-        self.assertIn("before emitting any inline prompt block", classification)
+        self.assertIn(
+            "must not be reinterpreted by recipient, capability, presentation, or renderer selection",
+            classification,
+        )
         self.assertIn("qualified capability", prompts)
         self.assertIn("Dropbox-backed file", prompts)
         self.assertIn("two-block shape", classification)

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -61,8 +61,7 @@ class ChatGPTAdapterTests(unittest.TestCase):
 
         for phrase in (
             "blocked before a qualified prompt handoff is complete",
-            "preserve the frozen artifact, viewer, and recipient outputs",
-            "re-enter stages 5 through 8 against the newly observed capability state",
+            "canonical decision model's bounded capability re-evaluation rule",
             "preserve the two-block complete-prompt shape",
             "Do not degrade the required prompt or handoff into unconstrained status prose",
         ):

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -249,8 +249,9 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
     def test_qualified_machine_recipient_uses_file_first_presentation(self):
         presentation = " ".join(self.presentation.split())
         self.assertIn(
-            "For any complete prompt, select presentation by the recipient's "
-            "currently qualified capability, independently of prompt materiality",
+            "For any complete prompt, select presentation by the execution "
+            "recipient's currently qualified capability and permitted destination, "
+            "independently of the operator or viewer identity",
             presentation,
         )
         route = presentation.index("qualified Dropbox retrieval route")
@@ -259,10 +260,10 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         self.assertLess(route, file)
         self.assertLess(file, handoff)
 
-    def test_codex_and_claude_handoffs_use_the_same_shared_selector(self):
+    def test_codex_and_claude_handoffs_use_the_same_shared_model(self):
         presentation = " ".join(self.presentation.split())
         delivery_envelope = " ".join(self.delivery_envelope.split())
-        self.assertIn("selector applies symmetrically", presentation)
+        self.assertIn("model applies symmetrically", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
         self.assertIn(
             "immediately provide the target-shaped [thin semantic handoff]"
@@ -352,7 +353,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             "mutation",
             kickoff_boundary,
         )
-        self.assertIn("selector applies symmetrically", presentation)
+        self.assertIn("model applies symmetrically", presentation)
         self.assertIn("same shared presentation and handoff contract", presentation)
 
     def test_two_block_format_is_conditional_on_inline_presentation(self):
@@ -363,7 +364,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             complete_shape,
         )
         self.assertIn(
-            "When the shared recipient-capability selector chooses inline "
+            "When the model legitimately selects inline "
             "presentation for a complete, copy-ready prompt or downstream handoff",
             chatgpt_prompt,
         )
@@ -378,8 +379,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
 
     def test_human_or_unqualified_recipient_uses_inline_presentation(self):
         presentation = " ".join(self.presentation.split())
-        self.assertIn("For a human recipient", presentation)
-        self.assertIn("no qualified Dropbox route", presentation)
+        self.assertIn("For a human execution recipient", presentation)
+        self.assertIn("machine execution recipient has no qualified Dropbox route", presentation)
         self.assertIn("present the complete prompt inline", presentation)
         self.assertIn("consecutive copyable code blocks", self.chatgpt)
 
@@ -387,8 +388,8 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         presentation = " ".join(self.presentation.split())
         self.assertIn("issue-owned durable rendered-prompt handoff profile", presentation)
         self.assertIn("A routine prompt delivered through a file does not", presentation)
-        self.assertIn("use inline presentation rather than inventing a storage surface", presentation)
-        self.assertIn("two-block inline presentation", self.chatgpt_presentation)
+        self.assertIn("use inline presentation only when the owning fallback contract permits", presentation)
+        self.assertIn("two-block inline renderer", self.chatgpt_presentation)
 
     def test_chatgpt_preview_prefers_the_returned_file_id(self):
         preview = " ".join(self.chatgpt_dropbox_bootstrap.split())

--- a/tests/test_prompt_contract_semantics.py
+++ b/tests/test_prompt_contract_semantics.py
@@ -443,13 +443,13 @@ class PromptContractSemanticAnchorTests(unittest.TestCase):
             normalized_readiness,
         )
         self.assertIn(
-            "The [recipient-capability selector](#cross-executor-prompt-presentation) "
+            "The [prompt delivery decision model](#prompt-delivery-decision-model) "
             "applies to every complete prompt",
             normalized_prompts,
         )
         self.assertIn(
-            "For any complete prompt, select presentation by the recipient's "
-            "currently qualified capability",
+            "For any complete prompt, select presentation by the execution "
+            "recipient's currently qualified capability and permitted destination",
             normalized_prompts,
         )
 

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -1,0 +1,226 @@
+from dataclasses import dataclass, replace
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPTS = ROOT / "docs" / "prompts.md"
+
+STAGES = (
+    "artifact-production",
+    "artifact-classification",
+    "operator-viewer-resolution",
+    "execution-recipient-resolution",
+    "capability-and-transport-resolution",
+    "presentation-selection",
+    "renderer-selection",
+    "delivery-outcome",
+)
+
+
+@dataclass(frozen=True)
+class DeliveryCase:
+    """Resolved semantic inputs for the test-only conformance evaluator.
+
+    request_text identifies the conversational fixture but is deliberately not
+    interpreted by the evaluator. The Playbook owns semantic classification;
+    this harness checks composition after those semantic inputs are resolved.
+    """
+
+    request_text: str
+    produces_prompt: bool
+    complete_executable: bool
+    operator_viewer: str
+    execution_recipient: str
+    recipient_class: str
+    capability_resolved: bool = True
+    qualified_file_capability: bool = False
+    permitted_file_destination: bool = False
+    inline_fallback_permitted: bool = False
+
+
+def decision_trace(case):
+    """Evaluate the documented stage table without parsing request phrases."""
+
+    production = "prompt-produced" if case.produces_prompt else "no-prompt"
+    classification = (
+        "complete-executable"
+        if case.produces_prompt and case.complete_executable
+        else "conceptual-fragment"
+    )
+
+    if classification == "conceptual-fragment":
+        route = "not-applicable"
+    elif case.recipient_class == "human":
+        route = "inline-route"
+    elif not case.capability_resolved:
+        route = "blocked"
+    elif case.qualified_file_capability and case.permitted_file_destination:
+        route = "qualified-file-route"
+    elif case.inline_fallback_permitted:
+        route = "inline-fallback-permitted"
+    else:
+        route = "blocked"
+
+    if classification == "conceptual-fragment":
+        presentation = "lightweight"
+    elif route == "qualified-file-route":
+        presentation = "file-backed"
+    elif route in ("inline-route", "inline-fallback-permitted"):
+        presentation = "inline"
+    else:
+        presentation = "blocked"
+
+    renderer = {
+        "lightweight": "lightweight",
+        "file-backed": "thin-handoff",
+        "inline": "canonical-inline-two-block",
+        "blocked": "none",
+    }[presentation]
+    outcome = {
+        "lightweight": "lightweight-response",
+        "file-backed": "dropbox-backed-thin-handoff",
+        "inline": "inline-complete-prompt",
+        "blocked": "blocked-no-renderer",
+    }[presentation]
+
+    return (
+        (STAGES[0], production),
+        (STAGES[1], classification),
+        (STAGES[2], case.operator_viewer),
+        (
+            STAGES[3],
+            f"{case.execution_recipient}:{case.recipient_class}",
+        ),
+        (STAGES[4], route),
+        (STAGES[5], presentation),
+        (STAGES[6], renderer),
+        (STAGES[7], outcome),
+    )
+
+
+class PromptDeliveryDecisionModelTests(unittest.TestCase):
+    def test_docs_define_one_ordered_model_with_explicit_stage_outputs(self):
+        prompts = PROMPTS.read_text(encoding="utf-8")
+        section = prompts[
+            prompts.index("## Prompt Delivery Decision Model") : prompts.index(
+                "## Cross-Executor Prompt Presentation"
+            )
+        ]
+        normalized_section = " ".join(section.split())
+
+        positions = [section.index(f"`{stage}`") for stage in STAGES]
+        self.assertEqual(positions, sorted(positions))
+        for output in (
+            "`complete-executable`",
+            "`machine-executor`",
+            "`qualified-file-route`",
+            "`inline-route`",
+            "`file-backed`",
+            "`canonical-inline-two-block`",
+            "`blocked`",
+        ):
+            self.assertIn(output, section)
+        self.assertIn(
+            "must not re-read conversational wording to replace that output",
+            normalized_section,
+        )
+        self.assertIn(
+            "operator or viewer separate from the executable prompt's execution recipient",
+            normalized_section,
+        )
+
+    def test_cold_start_prompt_variants_select_dropbox_codex_handoff(self):
+        initial_instruction = (
+            "I've cleared this project's memory and restarted the app. Let's "
+            "discuss CAK-194 and prepare to hand its implementation to Codex. "
+            "Do not start CAK-194, change its workflow state, or mutate "
+            "provider/repository state yet."
+        )
+        self.assertIn("prepare to hand its implementation to Codex", initial_instruction)
+
+        base = DeliveryCase(
+            request_text="Prompt me for CAK-194.",
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="Codex",
+            recipient_class="machine-executor",
+            qualified_file_capability=True,
+            permitted_file_destination=True,
+        )
+        expected = (
+            ("artifact-production", "prompt-produced"),
+            ("artifact-classification", "complete-executable"),
+            ("operator-viewer-resolution", "human-operator"),
+            ("execution-recipient-resolution", "Codex:machine-executor"),
+            ("capability-and-transport-resolution", "qualified-file-route"),
+            ("presentation-selection", "file-backed"),
+            ("renderer-selection", "thin-handoff"),
+            ("delivery-outcome", "dropbox-backed-thin-handoff"),
+        )
+
+        for wording in (
+            "Prompt me for CAK-194.",
+            "Show me the Codex handoff for CAK-194.",
+            "Give me the prompt for CAK-194.",
+        ):
+            with self.subTest(wording=wording):
+                trace = decision_trace(replace(base, request_text=wording))
+                self.assertEqual(trace, expected)
+                self.assertNotIn(
+                    "canonical-inline-two-block",
+                    [output for _, output in trace],
+                )
+
+    def test_conceptual_human_fragment_remains_lightweight(self):
+        case = DeliveryCase(
+            request_text="What might a short stop boundary look like?",
+            produces_prompt=True,
+            complete_executable=False,
+            operator_viewer="human-operator",
+            execution_recipient="human",
+            recipient_class="human",
+        )
+
+        trace = dict(decision_trace(case))
+        self.assertEqual(trace["artifact-classification"], "conceptual-fragment")
+        self.assertEqual(trace["presentation-selection"], "lightweight")
+        self.assertEqual(trace["renderer-selection"], "lightweight")
+        self.assertEqual(trace["delivery-outcome"], "lightweight-response")
+
+    def test_inline_renderer_requires_selected_inline_fallback(self):
+        base = DeliveryCase(
+            request_text="Prepare the executable Codex handoff.",
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="Codex",
+            recipient_class="machine-executor",
+        )
+
+        fallback = dict(
+            decision_trace(replace(base, inline_fallback_permitted=True))
+        )
+        self.assertEqual(
+            fallback["capability-and-transport-resolution"],
+            "inline-fallback-permitted",
+        )
+        self.assertEqual(fallback["presentation-selection"], "inline")
+        self.assertEqual(
+            fallback["renderer-selection"], "canonical-inline-two-block"
+        )
+
+        blocked = dict(
+            decision_trace(replace(base, capability_resolved=False))
+        )
+        self.assertEqual(
+            blocked["capability-and-transport-resolution"], "blocked"
+        )
+        self.assertEqual(blocked["presentation-selection"], "blocked")
+        self.assertEqual(blocked["renderer-selection"], "none")
+        self.assertEqual(blocked["delivery-outcome"], "blocked-no-renderer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from pathlib import Path
 import unittest
 
@@ -22,12 +22,11 @@ STAGES = (
 class DeliveryCase:
     """Resolved semantic inputs for the test-only conformance evaluator.
 
-    request_text identifies the conversational fixture but is deliberately not
-    interpreted by the evaluator. The Playbook owns semantic classification;
-    this harness checks composition after those semantic inputs are resolved.
+    The Playbook owns semantic classification. Raw request wording is
+    intentionally absent from this post-resolution boundary so later delivery
+    stages cannot reinterpret it.
     """
 
-    request_text: str
     produces_prompt: bool
     complete_executable: bool
     operator_viewer: str
@@ -39,21 +38,14 @@ class DeliveryCase:
     inline_fallback_permitted: bool = False
 
 
-def decision_trace(case):
-    """Evaluate the documented stage table without parsing request phrases."""
-
-    production = "prompt-produced" if case.produces_prompt else "no-prompt"
-    classification = (
-        "complete-executable"
-        if case.produces_prompt and case.complete_executable
-        else "conceptual-fragment"
-    )
-
+def decision_tail(case, classification, capability_failure_count=0):
     if classification == "conceptual-fragment":
         route = "not-applicable"
+    elif case.recipient_class == "unresolved":
+        route = "blocked"
     elif case.recipient_class == "human":
         route = "inline-route"
-    elif not case.capability_resolved:
+    elif capability_failure_count > 1 or not case.capability_resolved:
         route = "blocked"
     elif case.qualified_file_capability and case.permitted_file_destination:
         route = "qualified-file-route"
@@ -85,6 +77,25 @@ def decision_trace(case):
     }[presentation]
 
     return (
+        (STAGES[4], route),
+        (STAGES[5], presentation),
+        (STAGES[6], renderer),
+        (STAGES[7], outcome),
+    )
+
+
+def decision_trace(case):
+    """Evaluate the documented stages from already-resolved semantics."""
+
+    production = "prompt-produced" if case.produces_prompt else "no-prompt"
+    if production == "no-prompt":
+        return ((STAGES[0], production),)
+
+    classification = (
+        "complete-executable" if case.complete_executable else "conceptual-fragment"
+    )
+
+    return (
         (STAGES[0], production),
         (STAGES[1], classification),
         (STAGES[2], case.operator_viewer),
@@ -92,10 +103,18 @@ def decision_trace(case):
             STAGES[3],
             f"{case.execution_recipient}:{case.recipient_class}",
         ),
-        (STAGES[4], route),
-        (STAGES[5], presentation),
-        (STAGES[6], renderer),
-        (STAGES[7], outcome),
+        *decision_tail(case, classification),
+    )
+
+
+def reroute_after_capability_failure(case, original_trace, failure_count, **changes):
+    """Re-evaluate only transport and downstream stages after route failure."""
+
+    updated = replace(case, **changes)
+    classification = dict(original_trace)[STAGES[1]]
+    return (
+        *original_trace[:4],
+        *decision_tail(updated, classification, capability_failure_count=failure_count),
     )
 
 
@@ -112,8 +131,10 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         positions = [section.index(f"`{stage}`") for stage in STAGES]
         self.assertEqual(positions, sorted(positions))
         for output in (
+            "`no-prompt`",
             "`complete-executable`",
             "`machine-executor`",
+            "`unresolved`",
             "`qualified-file-route`",
             "`inline-route`",
             "`file-backed`",
@@ -129,18 +150,27 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             "operator or viewer separate from the executable prompt's execution recipient",
             normalized_section,
         )
-
-    def test_cold_start_prompt_variants_select_dropbox_codex_handoff(self):
-        initial_instruction = (
-            "I've cleared this project's memory and restarted the app. Let's "
-            "discuss CAK-194 and prepare to hand its implementation to Codex. "
-            "Do not start CAK-194, change its workflow state, or mutate "
-            "provider/repository state yet."
+        self.assertIn(
+            "same delivery attempt may perform exactly one capability re-evaluation",
+            normalized_section,
         )
-        self.assertIn("prepare to hand its implementation to Codex", initial_instruction)
+        self.assertIn(
+            "Preserve the stage 1 through 4 outputs unchanged",
+            normalized_section,
+        )
+        for mapping in (
+            "`complete-executable` plus a `machine-executor` and "
+            "`qualified-file-route` selects `file-backed` presentation",
+            "`complete-executable` plus a human execution recipient resolves "
+            "`inline-route`, then selects `inline` presentation",
+            "`complete-executable` plus `inline-fallback-permitted` selects "
+            "`inline` presentation",
+            "An `unresolved` execution recipient resolves transport to `blocked`",
+        ):
+            self.assertIn(mapping, normalized_section)
 
+    def test_cold_start_variants_share_resolved_codex_semantics(self):
         base = DeliveryCase(
-            request_text="Prompt me for CAK-194.",
             produces_prompt=True,
             complete_executable=True,
             operator_viewer="human-operator",
@@ -160,22 +190,37 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             ("delivery-outcome", "dropbox-backed-thin-handoff"),
         )
 
-        for wording in (
+        variants = (
             "Prompt me for CAK-194.",
             "Show me the Codex handoff for CAK-194.",
             "Give me the prompt for CAK-194.",
-        ):
+        )
+        self.assertNotIn("request_text", {field.name for field in fields(DeliveryCase)})
+        for wording in variants:
             with self.subTest(wording=wording):
-                trace = decision_trace(replace(base, request_text=wording))
+                trace = decision_trace(base)
                 self.assertEqual(trace, expected)
                 self.assertNotIn(
                     "canonical-inline-two-block",
                     [output for _, output in trace],
                 )
 
+        human = dict(
+            decision_trace(
+                replace(
+                    base,
+                    execution_recipient="human",
+                    recipient_class="human",
+                    qualified_file_capability=False,
+                    permitted_file_destination=False,
+                )
+            )
+        )
+        self.assertEqual(human["capability-and-transport-resolution"], "inline-route")
+        self.assertEqual(human["renderer-selection"], "canonical-inline-two-block")
+
     def test_conceptual_human_fragment_remains_lightweight(self):
         case = DeliveryCase(
-            request_text="What might a short stop boundary look like?",
             produces_prompt=True,
             complete_executable=False,
             operator_viewer="human-operator",
@@ -191,7 +236,6 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
 
     def test_inline_renderer_requires_selected_inline_fallback(self):
         base = DeliveryCase(
-            request_text="Prepare the executable Codex handoff.",
             produces_prompt=True,
             complete_executable=True,
             operator_viewer="human-operator",
@@ -220,6 +264,67 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         self.assertEqual(blocked["presentation-selection"], "blocked")
         self.assertEqual(blocked["renderer-selection"], "none")
         self.assertEqual(blocked["delivery-outcome"], "blocked-no-renderer")
+
+    def test_no_prompt_stops_after_artifact_production(self):
+        case = DeliveryCase(
+            produces_prompt=False,
+            complete_executable=False,
+            operator_viewer="human-operator",
+            execution_recipient="unresolved",
+            recipient_class="unresolved",
+        )
+        self.assertEqual(
+            decision_trace(case),
+            (("artifact-production", "no-prompt"),),
+        )
+
+    def test_unresolved_recipient_blocks_without_renderer(self):
+        case = DeliveryCase(
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="unresolved",
+            recipient_class="unresolved",
+            inline_fallback_permitted=True,
+        )
+        trace = dict(decision_trace(case))
+        self.assertEqual(trace["capability-and-transport-resolution"], "blocked")
+        self.assertEqual(trace["presentation-selection"], "blocked")
+        self.assertEqual(trace["renderer-selection"], "none")
+
+    def test_capability_reentry_freezes_semantics_and_is_bounded(self):
+        case = DeliveryCase(
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="Codex",
+            recipient_class="machine-executor",
+            qualified_file_capability=True,
+            permitted_file_destination=True,
+        )
+        initial = decision_trace(case)
+        fallback = reroute_after_capability_failure(
+            case,
+            initial,
+            1,
+            qualified_file_capability=False,
+            permitted_file_destination=False,
+            inline_fallback_permitted=True,
+        )
+        self.assertEqual(fallback[:4], initial[:4])
+        self.assertEqual(dict(fallback)["renderer-selection"], "canonical-inline-two-block")
+
+        second_failure = reroute_after_capability_failure(
+            case,
+            fallback,
+            2,
+            qualified_file_capability=False,
+            permitted_file_destination=False,
+            inline_fallback_permitted=True,
+        )
+        self.assertEqual(second_failure[:4], initial[:4])
+        self.assertEqual(dict(second_failure)["presentation-selection"], "blocked")
+        self.assertEqual(dict(second_failure)["renderer-selection"], "none")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- define one canonical eight-stage prompt-delivery decision model in `docs/prompts.md`
- separate operator/viewer identity from the executable prompt execution recipient before capability and transport resolution
- project the frozen stage outputs into ChatGPT rendering so file-backed, inline, lightweight, and blocked outcomes cannot be reclassified downstream
- add deterministic end-to-end coverage for the CAK-200 cold-start sequence, wording variants, conceptual content, inline fallback, and fail-closed blocking

## Root cause

CAK-195 through CAK-199 established correct local rules, but no shared decision record froze the execution recipient across classification, capability selection, presentation, and rendering. Later presentation logic could therefore reinterpret the human viewer as the prompt recipient and select the correct inline renderer for the wrong transport decision.

## Claude review follow-up

An independent Claude Opus review was run read-only against the exact initial PR head. Its four substantive findings were dispositioned and addressed:

- make capability-failure re-evaluation canonical, preserve stages 1–4, and bound it to one retry before blocking
- remove raw request wording from the post-resolution conformance evaluator and prove recipient-driven machine versus human routing
- terminate `no-prompt` after stage 1 and remove the unreachable duplicate fragment output
- add an explicit unresolved-recipient outcome that fails closed without a renderer

## Validation

- `make check` — pass
- Markdown lint — 0 issues
- Python unit tests — 318 passed
- merge-tree check against current `origin/main` — clean before the review follow-up

## Scope

Linear: CAK-200

This is a non-material consolidation of existing accepted prompt-delivery semantics. It does not change authority, add a lifecycle gate, implement CAK-194 Dropbox byte verification, or redesign connector/storage behavior.
