### PR TITLE
CAK-200: require frozen delivery records

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -413,6 +413,18 @@ consume an earlier output, but it must not re-read conversational wording to
 replace that output or infer a different artifact, viewer, recipient, or
 transport. Rendering begins only after presentation has been selected.
 
+For a complete prompt, stages 5 through 7 must be materially realized as one
+complete frozen decision record before any complete-prompt renderer or delivery
+application is eligible. The record contains the resolved route and
+qualification state, exact route identity when applicable, diagnostics and
+re-entry state, presentation, and renderer. Renderer and application entry
+points consume that record as their only delivery-decision input; they must not
+accept loose stage fields or reconstruct them from task prose, diagnostics,
+rationale, or conversational context. An absent, incomplete, stale, mismatched,
+or superseded record fails closed with no complete-prompt renderer. Material
+realization is a semantic state boundary: it does not require a durable
+artifact, provider-visible object, UI disclosure, or a second workflow engine.
+
 The decision record keeps the human operator or viewer separate from the
 executable prompt's execution recipient. The operator or viewer receives
 metadata, a file surface, or a handoff; the execution recipient consumes the
@@ -429,7 +441,7 @@ recipient of a prompt that is semantically directed to a machine executor.
 | 5 | `capability-and-transport-resolution` | Frozen recipient identity; a current route-qualification evidence record that binds the current runtime route observation, route class and exact identity, and current owning qualification contract; authority; and permitted destination | Route selection and exact identity when applicable: `qualified-file-route`, `inline-route`, `inline-fallback-permitted`, or `blocked`; separate qualification: `qualified`, `qualified-with-known-limitation`, `route-disqualified`, or `unresolved`; non-disqualifying diagnostics; current or prior owning-contract route-disqualification records; and whether bounded re-evaluation was consumed | Inspect or attempt unknown capability; retain known limitations without treating them as route-disqualifying unless the owning contract says they are. Never invent a destination or weaken an exact-byte contract. |
 | 6 | `presentation-selection` | Frozen artifact class, recipient class, and route resolution | `lightweight`, `file-backed`, `inline`, or `blocked` | Qualified machine execution selects file-backed delivery; operator visibility cannot override it. |
 | 7 | `renderer-selection` | Frozen presentation selection | `lightweight`, `thin-handoff`, `canonical-inline-two-block`, or `none` | Inline rendering is reachable only from `inline`; a renderer cannot change upstream state. |
-| 8 | `delivery-outcome` | Complete decision record and selected renderer result | Executed selected delivery action plus its evidence, or explicit fallback or blocked result | Apply the frozen presentation and renderer selection. Emit only the selected surface and preserve the owning failure contract. |
+| 8 | `delivery-outcome` | Current complete frozen stage-5-through-7 decision record and selected renderer result | Executed selected delivery action plus its evidence, or explicit fallback or blocked result | Apply only the record's presentation and renderer selection. Emit only the selected surface and preserve the owning failure contract. |
 
 Stage 5 has a closed evidence-provenance boundary. Its qualification evidence
 record accepts only observations about the current runtime route, classified
@@ -501,12 +513,15 @@ Apply these terminal mappings deterministically:
   the bounded re-evaluation sequence below; its resulting stage 5 state drives
   this terminal mapping.
 
-The final delivery application consumes the frozen stage 5 through 7 outputs
-and executes the selected action. For `file-backed`, it invokes the selected
-file route and returns the thin handoff. It must not inspect diagnostic state
-to substitute the canonical inline renderer. For `inline`, it invokes only the
-canonical inline renderer. Application failure may enter the bounded
-re-evaluation rule below, but application itself cannot recompute transport.
+The final delivery application consumes the current complete frozen decision
+record and executes the selected action. A caller cannot bypass the record and
+request a complete-prompt renderer directly. For `file-backed`, the record
+makes inline rendering unreachable: application invokes the selected file
+route and returns the thin handoff. It must not inspect diagnostic state to
+substitute the canonical inline renderer. For `inline`, it invokes only the
+canonical inline renderer recorded through the legitimate inline decision.
+Application failure may enter the bounded re-evaluation rule below, but
+application itself cannot recompute transport.
 
 The once-per-stage rule applies within one evaluation. If a selected route
 becomes explicitly `route-disqualified` before delivery completes, the same
@@ -530,8 +545,12 @@ route also fails, terminate as `blocked` with that newly observed
 as merely `unresolved`, or recompute the artifact, viewer, or execution
 recipient. If capability instead remains unresolved, retain the prior failure
 reason as evidence while the new stage 5 qualification remains `unresolved`.
-Every later application failure consumes the current stage 5 record. Replaying
-a superseded pre-re-evaluation record is not another valid delivery transition.
+After downstream re-evaluation resolves stages 5 through 7, materialize a new
+complete frozen decision record before application continues and supersede the
+prior record. Every later application failure consumes only that current
+record. A stale or superseded record cannot restart application or bounded
+re-entry, and replaying a superseded pre-re-evaluation record is not another
+valid delivery transition.
 
 Conversational wording is evidence available to the production,
 classification, and recipient-resolution stages. It is not a lookup table and

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -383,7 +383,15 @@ ChatGPT must not reclassify the produced artifact, replace the execution
 recipient with the operator or viewer, or reconsider transport from request
 wording or diagnostic limitations during rendering. The final application
 executes the selected file-backed, inline, lightweight, or blocked action from
-that record; it cannot select another renderer. Keep genuinely conceptual
+that record; it cannot select another renderer. Before any complete-prompt
+renderer or delivery application is eligible, ChatGPT must materially realize
+the complete current stage-5-through-7 state as one frozen decision record and
+pass that record as the only delivery-decision input. Loose route,
+qualification, presentation, or renderer fields; task prose; diagnostics;
+rationale; and conversational context are not application inputs. Missing,
+incomplete, stale, mismatched, or superseded records select no complete-prompt
+renderer and fail closed. This explicit state boundary need not be displayed,
+persisted, or implemented as a second workflow engine. Keep genuinely conceptual
 fragments and incomplete snippets lightweight through the model's
 `lightweight` renderer.
 
@@ -407,6 +415,12 @@ shared naming placeholder to nothing. This adapter does not ask ChatGPT to
 rename itself or report a naming limitation. A downstream visible name may be
 selected only when the downstream target executor adapter explicitly supports
 executor-applied naming.
+
+Bounded route re-evaluation must complete stages 5 through 7 again, freeze one
+new current record, and supersede the prior record before application resumes.
+Neither application nor bounded re-entry may consume the stale or superseded
+record. A `file-backed` record therefore cannot reach the inline renderer, while
+a legitimate `inline` record still reaches the canonical two-block surface.
 
 Do not nest Markdown code fences inside the executable block; represent any
 embedded example with indentation or plain text. Optimize this client rendering

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -254,6 +254,9 @@ class ChatGPTAdapterTests(unittest.TestCase):
         no_reclassification = prompt_presentation.index(
             "must not reclassify the produced artifact"
         )
+        state_realization = prompt_presentation.index(
+            "must materially realize the complete current stage-5-through-7 state"
+        )
         presentation = prompt_presentation.index(
             "unless `presentation-selection` produced `inline`"
         )
@@ -265,7 +268,8 @@ class ChatGPTAdapterTests(unittest.TestCase):
         )
 
         self.assertLess(frozen, no_reclassification)
-        self.assertLess(no_reclassification, presentation)
+        self.assertLess(no_reclassification, state_realization)
+        self.assertLess(state_realization, presentation)
         self.assertLess(presentation, renderer)
         self.assertLess(renderer, inline)
         self.assertIn(
@@ -288,6 +292,23 @@ class ChatGPTAdapterTests(unittest.TestCase):
             prompt_presentation,
         )
         self.assertIn("it cannot select another renderer", prompt_presentation)
+        self.assertIn(
+            "pass that record as the only delivery-decision input",
+            prompt_presentation,
+        )
+        self.assertIn(
+            "Missing, incomplete, stale, mismatched, or superseded records select no "
+            "complete-prompt renderer and fail closed",
+            prompt_presentation,
+        )
+        self.assertIn(
+            "freeze one new current record, and supersede the prior record",
+            prompt_presentation,
+        )
+        self.assertIn(
+            "A `file-backed` record therefore cannot reach the inline renderer",
+            prompt_presentation,
+        )
 
     def test_executable_examples_use_complete_prompt_presentation(self):
         prompts = (DOCS / "prompts.md").read_text(encoding="utf-8")

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -103,6 +103,65 @@ class AppliedDelivery:
     diagnostics: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True)
+class FrozenDeliveryDecisionRecord:
+    """Test-only materialization of the resolved stage 1 through 7 outputs."""
+
+    stage_outputs: tuple[tuple[str, object], ...]
+    record_revision: int = 0
+    supersedes_record_revision: int | None = None
+
+    def __post_init__(self):
+        if tuple(stage for stage, _ in self.stage_outputs) != STAGES[:7]:
+            raise ValueError(
+                "complete frozen decision record requires every ordered stage 1 "
+                "through 7 output"
+            )
+        if any(output is None for _, output in self.stage_outputs):
+            raise ValueError("complete frozen decision record has no missing output")
+        if self.record_revision < 0 or (
+            self.record_revision == 0
+            and self.supersedes_record_revision is not None
+        ) or (
+            self.record_revision > 0
+            and self.supersedes_record_revision != self.record_revision - 1
+        ):
+            raise ValueError("frozen decision record lineage is incomplete or mismatched")
+
+        decision = dict(self.stage_outputs)
+        classification = decision[STAGES[1]]
+        resolution = decision[STAGES[4]]
+        if not isinstance(resolution, CapabilityRouteResolution):
+            raise ValueError("complete frozen decision record requires stage 5 state")
+
+        if classification == "conceptual-fragment":
+            expected_presentation = "lightweight"
+        elif resolution.route == "qualified-file-route":
+            expected_presentation = "file-backed"
+        elif resolution.route in ("inline-route", "inline-fallback-permitted"):
+            expected_presentation = "inline"
+        else:
+            expected_presentation = "blocked"
+        expected_renderer = {
+            "lightweight": "lightweight",
+            "file-backed": "thin-handoff",
+            "inline": "canonical-inline-two-block",
+            "blocked": "none",
+        }[expected_presentation]
+        if decision[STAGES[5]] != expected_presentation:
+            raise ValueError(
+                "frozen decision record presentation mismatches stage 5 resolution"
+            )
+        if decision[STAGES[6]] != expected_renderer:
+            raise ValueError(
+                "frozen decision record renderer mismatches frozen presentation"
+            )
+
+    @property
+    def decision(self):
+        return dict(self.stage_outputs)
+
+
 def decision_tail(
     case,
     classification,
@@ -215,41 +274,60 @@ def decision_tail(
     )
 
 
-def apply_delivery(
-    frozen_trace,
+def freeze_delivery_decision(
+    trace,
     *,
-    presentation=None,
-    renderer=None,
-    outcome=None,
+    record_revision=0,
+    supersedes_record_revision=None,
 ):
-    """Apply the selected renderer without recomputing upstream semantics."""
+    """Materialize and validate one complete stage 1 through 7 record."""
 
-    decision = dict(frozen_trace)
+    if tuple(stage for stage, _ in trace) != STAGES:
+        raise ValueError("complete frozen decision record requires the ordered trace")
+    return FrozenDeliveryDecisionRecord(
+        stage_outputs=tuple(trace[:7]),
+        record_revision=record_revision,
+        supersedes_record_revision=supersedes_record_revision,
+    )
+
+
+def apply_delivery(frozen_record, *, current_record=None):
+    """Apply only the current complete frozen decision record."""
+
+    if not isinstance(frozen_record, FrozenDeliveryDecisionRecord):
+        raise ValueError(
+            "complete frozen decision record is required before delivery application"
+        )
+    if not isinstance(current_record, FrozenDeliveryDecisionRecord):
+        raise ValueError(
+            "current complete frozen decision record is required before application"
+        )
+    if frozen_record != current_record:
+        raise ValueError("stale or superseded decision record cannot be consumed")
+
+    decision = frozen_record.decision
     route_resolution = decision[STAGES[4]]
-    selected = (
-        decision[STAGES[5]],
-        decision[STAGES[6]],
-        decision[STAGES[7]],
-    )
-    requested = (
-        selected[0] if presentation is None else presentation,
-        selected[1] if renderer is None else renderer,
-        selected[2] if outcome is None else outcome,
-    )
-    if requested != selected:
-        raise ValueError("application cannot replace the frozen delivery selection")
+    presentation = decision[STAGES[5]]
+    renderer = decision[STAGES[6]]
+    outcome = {
+        "lightweight": "lightweight-response",
+        "file-backed": "dropbox-backed-thin-handoff",
+        "inline": "inline-complete-prompt",
+        "blocked": "blocked-no-renderer",
+    }[presentation]
 
     return AppliedDelivery(
-        presentation=selected[0],
-        renderer=selected[1],
-        outcome=selected[2],
+        presentation=presentation,
+        renderer=renderer,
+        outcome=outcome,
         diagnostics=route_resolution.diagnostics,
     )
 
 
 def evaluate_and_apply(case):
     trace = decision_trace(case)
-    return trace, apply_delivery(trace)
+    record = freeze_delivery_decision(trace)
+    return trace, apply_delivery(record, current_record=record)
 
 
 def decision_trace(case):
@@ -281,15 +359,21 @@ def decision_trace(case):
 
 def reroute_after_capability_failure(
     case,
-    original_trace,
+    original_record,
     route_disqualification,
+    *,
+    current_record,
     **changes,
 ):
     """Re-evaluate only transport and downstream stages after route failure."""
 
+    if not isinstance(original_record, FrozenDeliveryDecisionRecord):
+        raise ValueError("capability re-entry requires a complete frozen decision record")
+    if original_record != current_record:
+        raise ValueError("stale or superseded decision record cannot restart re-entry")
     if route_disqualification is None:
         raise ValueError("capability re-entry requires owning route disqualification")
-    original_resolution = dict(original_trace)[STAGES[4]]
+    original_resolution = original_record.decision[STAGES[4]]
     if (
         original_resolution.route != route_disqualification.route
         or original_resolution.route_id != route_disqualification.route_id
@@ -304,10 +388,10 @@ def reroute_after_capability_failure(
             "capability re-entry case must match the current frozen route identity"
         )
     updated = replace(case, initial_route_disqualification=None, **changes)
-    classification = dict(original_trace)[STAGES[1]]
+    classification = original_record.decision[STAGES[1]]
     terminal_failure = original_resolution.capability_reentry_count >= 1
-    return (
-        *original_trace[:4],
+    trace = (
+        *original_record.stage_outputs[:4],
         *decision_tail(
             updated,
             classification,
@@ -315,6 +399,11 @@ def reroute_after_capability_failure(
             terminal_failure=terminal_failure,
             capability_reentry_count=1,
         ),
+    )
+    return freeze_delivery_decision(
+        trace,
+        record_revision=original_record.record_revision + 1,
+        supersedes_record_revision=original_record.record_revision,
     )
 
 
@@ -424,7 +513,31 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             normalized_section,
         )
         self.assertIn(
-            "Every later application failure consumes the current stage 5 record",
+            "Every later application failure consumes only that current record",
+            normalized_section,
+        )
+        self.assertIn(
+            "stages 5 through 7 must be materially realized as one complete frozen "
+            "decision record",
+            normalized_section,
+        )
+        self.assertIn(
+            "must not accept loose stage fields or reconstruct them from task prose, "
+            "diagnostics, rationale, or conversational context",
+            normalized_section,
+        )
+        self.assertIn(
+            "An absent, incomplete, stale, mismatched, or superseded record fails "
+            "closed with no complete-prompt renderer",
+            normalized_section,
+        )
+        self.assertIn(
+            "A caller cannot bypass the record and request a complete-prompt renderer "
+            "directly",
+            normalized_section,
+        )
+        self.assertIn(
+            "A stale or superseded record cannot restart application or bounded re-entry",
             normalized_section,
         )
         for mapping in (
@@ -507,22 +620,28 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             [output for _, output in trace],
         )
 
-        human = dict(
-            decision_trace(
-                replace(
-                    base,
-                    execution_recipient="human",
-                    recipient_class="human",
-                    qualified_file_capability=False,
-                    permitted_file_destination=False,
-                )
+        human_trace = decision_trace(
+            replace(
+                base,
+                execution_recipient="human",
+                recipient_class="human",
+                qualified_file_capability=False,
+                permitted_file_destination=False,
             )
         )
+        human = dict(human_trace)
         self.assertEqual(
             human["capability-and-transport-resolution"].route,
             "inline-route",
         )
         self.assertEqual(human["renderer-selection"], "canonical-inline-two-block")
+        human_record = freeze_delivery_decision(human_trace)
+        human_applied = apply_delivery(
+            human_record,
+            current_record=human_record,
+        )
+        self.assertEqual(human_applied.presentation, "inline")
+        self.assertEqual(human_applied.renderer, "canonical-inline-two-block")
 
     def test_conceptual_human_fragment_remains_lightweight(self):
         case = DeliveryCase(
@@ -627,7 +746,7 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             permitted_file_destination=True,
             qualified_file_route_id="dropbox:primary",
         )
-        initial = decision_trace(case)
+        initial = freeze_delivery_decision(decision_trace(case))
         fallback = reroute_after_capability_failure(
             case,
             initial,
@@ -636,12 +755,13 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 route_id="dropbox:primary",
                 reason="selected Dropbox write was rejected by its owning contract",
             ),
+            current_record=initial,
             qualified_file_capability=False,
             permitted_file_destination=False,
             inline_fallback_permitted=True,
         )
-        self.assertEqual(fallback[:4], initial[:4])
-        fallback_resolution = dict(fallback)[
+        self.assertEqual(fallback.stage_outputs[:4], initial.stage_outputs[:4])
+        fallback_resolution = fallback.decision[
             "capability-and-transport-resolution"
         ]
         self.assertEqual(fallback_resolution.qualification, "route-disqualified")
@@ -651,7 +771,10 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             fallback_resolution.current_route_disqualification.reason,
             "selected Dropbox write was rejected by its owning contract",
         )
-        self.assertEqual(dict(fallback)["renderer-selection"], "canonical-inline-two-block")
+        self.assertEqual(
+            fallback.decision["renderer-selection"],
+            "canonical-inline-two-block",
+        )
 
         unresolved = reroute_after_capability_failure(
             case,
@@ -661,11 +784,12 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 route_id="dropbox:primary",
                 reason="selected Dropbox route failed during application",
             ),
+            current_record=initial,
             capability_resolved=False,
             qualified_file_capability=False,
             permitted_file_destination=False,
         )
-        unresolved_resolution = dict(unresolved)[
+        unresolved_resolution = unresolved.decision[
             "capability-and-transport-resolution"
         ]
         self.assertEqual(unresolved_resolution.qualification, "unresolved")
@@ -674,7 +798,7 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             unresolved_resolution.prior_route_disqualification.reason,
             "selected Dropbox route failed during application",
         )
-        self.assertEqual(dict(unresolved)["presentation-selection"], "blocked")
+        self.assertEqual(unresolved.decision["presentation-selection"], "blocked")
 
         same_route = reroute_after_capability_failure(
             case,
@@ -684,11 +808,12 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 route_id="dropbox:primary",
                 reason="selected Dropbox destination became unavailable",
             ),
+            current_record=initial,
             qualified_file_capability=True,
             permitted_file_destination=True,
             qualified_file_route_id="dropbox:primary",
         )
-        same_route_resolution = dict(same_route)[
+        same_route_resolution = same_route.decision[
             "capability-and-transport-resolution"
         ]
         self.assertEqual(same_route_resolution.route, "blocked")
@@ -696,7 +821,7 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             same_route_resolution.current_route_disqualification.route_id,
             "dropbox:primary",
         )
-        self.assertEqual(dict(same_route)["presentation-selection"], "blocked")
+        self.assertEqual(same_route.decision["presentation-selection"], "blocked")
 
         alternate = reroute_after_capability_failure(
             case,
@@ -706,14 +831,15 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 route_id="dropbox:primary",
                 reason="selected Dropbox destination became unavailable",
             ),
+            current_record=initial,
             qualified_file_capability=True,
             permitted_file_destination=True,
             qualified_file_route_id="dropbox:alternate",
         )
-        alternate_resolution = dict(alternate)[
+        alternate_resolution = alternate.decision[
             "capability-and-transport-resolution"
         ]
-        self.assertEqual(alternate[:4], initial[:4])
+        self.assertEqual(alternate.stage_outputs[:4], initial.stage_outputs[:4])
         self.assertEqual(alternate_resolution.route, "qualified-file-route")
         self.assertEqual(alternate_resolution.route_id, "dropbox:alternate")
         self.assertEqual(alternate_resolution.qualification, "qualified")
@@ -723,7 +849,7 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             alternate_resolution.prior_route_disqualification.route_id,
             "dropbox:primary",
         )
-        self.assertEqual(dict(alternate)["renderer-selection"], "thin-handoff")
+        self.assertEqual(alternate.decision["renderer-selection"], "thin-handoff")
 
         alternate_case = replace(
             case,
@@ -739,18 +865,23 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 case,
                 alternate,
                 second_disqualification,
+                current_record=alternate,
             )
 
         second_failure = reroute_after_capability_failure(
             alternate_case,
             alternate,
             second_disqualification,
+            current_record=alternate,
             qualified_file_capability=False,
             permitted_file_destination=False,
             inline_fallback_permitted=True,
         )
-        self.assertEqual(second_failure[:4], initial[:4])
-        second_resolution = dict(second_failure)[
+        self.assertEqual(
+            second_failure.stage_outputs[:4],
+            initial.stage_outputs[:4],
+        )
+        second_resolution = second_failure.decision[
             "capability-and-transport-resolution"
         ]
         self.assertEqual(second_resolution.qualification, "route-disqualified")
@@ -760,8 +891,8 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             second_resolution.current_route_disqualification.reason,
             "re-evaluated file route also failed",
         )
-        self.assertEqual(dict(second_failure)["presentation-selection"], "blocked")
-        self.assertEqual(dict(second_failure)["renderer-selection"], "none")
+        self.assertEqual(second_failure.decision["presentation-selection"], "blocked")
+        self.assertEqual(second_failure.decision["renderer-selection"], "none")
 
     def test_capability_reentry_requires_explicit_route_disqualification(self):
         with self.assertRaisesRegex(
@@ -805,13 +936,14 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             permitted_file_destination=True,
             qualified_file_route_id="dropbox:primary",
         )
-        initial = decision_trace(case)
+        initial = freeze_delivery_decision(decision_trace(case))
 
         with self.assertRaisesRegex(ValueError, "owning route disqualification"):
             reroute_after_capability_failure(
                 case,
                 initial,
                 None,
+                current_record=initial,
                 qualified_file_capability=False,
                 permitted_file_destination=False,
                 inline_fallback_permitted=True,
@@ -824,14 +956,18 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             qualified_file_route_id=None,
         )
         with self.assertRaisesRegex(ValueError, "previously selected qualified route"):
+            never_qualified_record = freeze_delivery_decision(
+                decision_trace(never_qualified)
+            )
             reroute_after_capability_failure(
                 never_qualified,
-                decision_trace(never_qualified),
+                never_qualified_record,
                 owned_current_route_disqualification(
                     route="qualified-file-route",
                     route_id="dropbox:primary",
                     reason="caller asserted a failure without a selected route",
                 ),
+                current_record=never_qualified_record,
                 inline_fallback_permitted=True,
             )
 
@@ -869,13 +1005,99 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         self.assertEqual(applied.outcome, "dropbox-backed-thin-handoff")
         self.assertEqual(applied.diagnostics, resolution.diagnostics)
 
-        with self.assertRaisesRegex(ValueError, "frozen delivery selection"):
+        record = freeze_delivery_decision(trace)
+        with self.assertRaisesRegex(ValueError, "complete frozen decision record"):
             apply_delivery(
-                trace,
-                presentation="inline",
-                renderer="canonical-inline-two-block",
-                outcome="inline-complete-prompt",
+                "canonical-inline-two-block",
+                current_record=record,
             )
+
+    def test_narrative_direct_render_without_frozen_record_fails_closed(self):
+        narrative_inline_substitution = (
+            (
+                "capability-and-transport-resolution",
+                CapabilityRouteResolution(
+                    route="qualified-file-route",
+                    qualification="qualified-with-known-limitation",
+                    route_id="dropbox:primary",
+                    diagnostics=(
+                        "controller post-write raw-byte SHA verification unavailable",
+                    ),
+                ),
+            ),
+            ("presentation-selection", "inline"),
+            ("renderer-selection", "canonical-inline-two-block"),
+            ("delivery-outcome", "inline-complete-prompt"),
+        )
+
+        with self.assertRaisesRegex(ValueError, "complete frozen decision record"):
+            apply_delivery(narrative_inline_substitution, current_record=None)
+
+    def test_missing_incomplete_or_mismatched_record_fails_closed(self):
+        case = DeliveryCase(
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="Codex",
+            recipient_class="machine-executor",
+            qualified_file_capability=True,
+            permitted_file_destination=True,
+            qualified_file_route_id="dropbox:primary",
+        )
+        trace = decision_trace(case)
+        record = freeze_delivery_decision(trace)
+
+        with self.assertRaisesRegex(ValueError, "complete frozen decision record"):
+            apply_delivery(None, current_record=record)
+        with self.assertRaisesRegex(ValueError, "every ordered stage 1 through 7"):
+            FrozenDeliveryDecisionRecord(stage_outputs=record.stage_outputs[:-1])
+
+        mismatched_outputs = tuple(
+            (stage, "inline") if stage == "presentation-selection" else (stage, output)
+            for stage, output in record.stage_outputs
+        )
+        with self.assertRaisesRegex(ValueError, "presentation mismatches stage 5"):
+            FrozenDeliveryDecisionRecord(stage_outputs=mismatched_outputs)
+
+    def test_superseded_record_cannot_restart_application_or_reentry(self):
+        case = DeliveryCase(
+            produces_prompt=True,
+            complete_executable=True,
+            operator_viewer="human-operator",
+            execution_recipient="Codex",
+            recipient_class="machine-executor",
+            qualified_file_capability=True,
+            permitted_file_destination=True,
+            qualified_file_route_id="dropbox:primary",
+        )
+        initial = freeze_delivery_decision(decision_trace(case))
+        disqualification = owned_current_route_disqualification(
+            route="qualified-file-route",
+            route_id="dropbox:primary",
+            reason="selected Dropbox destination became unavailable",
+        )
+        current = reroute_after_capability_failure(
+            case,
+            initial,
+            disqualification,
+            current_record=initial,
+            qualified_file_route_id="dropbox:alternate",
+        )
+
+        with self.assertRaisesRegex(ValueError, "stale or superseded"):
+            apply_delivery(initial, current_record=current)
+        with self.assertRaisesRegex(ValueError, "stale or superseded"):
+            reroute_after_capability_failure(
+                case,
+                initial,
+                disqualification,
+                current_record=current,
+                qualified_file_capability=False,
+                permitted_file_destination=False,
+            )
+        applied = apply_delivery(current, current_record=current)
+        self.assertEqual(applied.presentation, "file-backed")
+        self.assertEqual(applied.renderer, "thin-handoff")
 
     def test_task_target_capability_cannot_disqualify_current_file_route(self):
         case = DeliveryCase(
@@ -906,6 +1128,23 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         self.assertEqual(applied.renderer, "thin-handoff")
         self.assertEqual(applied.outcome, "dropbox-backed-thin-handoff")
         self.assertEqual(resolution.diagnostics, case.known_route_limitations)
+
+        without_target = replace(case, delegated_task_target_capabilities=())
+        frozen_without_target = freeze_delivery_decision(
+            decision_trace(without_target)
+        )
+        frozen_with_target = freeze_delivery_decision(trace)
+        self.assertEqual(
+            frozen_with_target.stage_outputs,
+            frozen_without_target.stage_outputs,
+        )
+        self.assertEqual(
+            apply_delivery(
+                frozen_without_target,
+                current_record=frozen_without_target,
+            ).renderer,
+            "thin-handoff",
+        )
 
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
## Summary

- require stages 5 through 7 to materialize as one complete frozen decision record before complete-prompt rendering or delivery application
- make renderer and application consume only the current record and fail closed on absent, incomplete, mismatched, stale, or superseded state
- preserve qualified file-backed thin handoff, legitimate canonical inline rendering, stage-5 evidence provenance, and bounded route re-entry
- model the new seam only in the existing test conformance harness, without a provider runtime or parallel workflow engine

## Fail-before evidence

The focused fixture represented a complete Codex prompt, a qualified Dropbox route with a known non-disqualifying limitation, and a narrative direct-render path that requested inline presentation without consuming a formal frozen record. On the fetched PR #374 baseline, application accepted that caller-assembled tuple and the fixture failed because no error was raised.

## Validation

- focused fail-before: 1 expected failure because the narrative inline tuple was accepted
- focused pass-after: the same fixture passed
- focused prompt-delivery and ChatGPT adapter suites: 24 tests passed
- `make check`: Markdown clean; 326 tests passed
- hosted checks: authoritative-source-check and markdownlint passed

## Independent review

### Attempt 1 — infrastructure failure, no verdict used

The first governed Claude Opus attempt against exact head `8685ebfd88350c62a61da640e8478f658653cc84` passed authentication and command/source preflight, then terminated with `reviewer_side_effect_failure` before producing a verdict. Guarded postflight detected unattributed shared Git-administration changes to `FETCH_HEAD`, `ORIG_HEAD`, and the primary-worktree `HEAD` reflog while the candidate head and protected candidate evidence remained unchanged.

The attempt was non-retryable under its launch contract. Terminal receipt: 19,972 bytes, SHA-256 `55028e40eb01173e2f8c39f52b0d5016eb17c663adc8762d935a1bbd6085c4c5`. No reviewer verdict or candidate output from this attempt is used.

### Attempt 2 — successful governed review

After explicit human authorization and exact qualification of Claude Code 2.1.252, a fresh one-attempt governed Claude Opus review ran through the qualified `claude-review` wrapper against the unchanged exact head. The wrapper verified the 4,393-byte prompt at SHA-256 `de7d0674e7f11d9f5c9779a6d0b736c5608404fb0fe52dd4e8c137a96744e259`, enforced the configured read-only command allowlist, and passed no-delta postflight with no candidate or shared Git-administration changes.

Verdict: **ACCEPT**. Blocking findings: none.

Evidence identities:

- review output: 9,291 bytes, SHA-256 `126954477477e6bafed18159b969d22f0b1dc90f040a57586c6cd31a7b88970a`
- terminal receipt: 15,085 bytes, SHA-256 `12616a829b8dabc9782ada818aca8f0bf2ec19b5a603d1d97a087a77e371dd02`
- raw stream: 326,156 bytes, SHA-256 `fab434a178b6d55aad51df4bc9991a553ba725c40818f8337153c922d588426d`
- preflight receipt: 3,764 bytes, SHA-256 `915e4307c15ba5d88311df223ab7213388c6d908d85558af81ea63937faff5ae`

Finding dispositions:

- repeated route/outcome mappings in the test harness: no change; independent re-derivation is the fail-closed validator for caller-forged records, and consolidation would make that check self-validating
- caller-asserted current-record identity: accepted limitation; a registry would create the explicitly excluded second workflow engine, so the evidence claim remains limited to refusal of known stale/superseded state
- no separate executable renderer entry point in the harness: no change; the harness tests the application boundary while doctrine governs renderer eligibility, and adding a fake hosted renderer would overstate local equivalence
- pre-existing stage-8 value in `decision_trace`: no change; it remains evaluator/diagnostic output and is not eligible as an application input after this PR
- task-target non-interference assertion is structurally simple: no change; it complements the genuine stage-5 `RouteDisqualification` provenance guard and does not carry that guarantee alone

These are optional observations, not merge conditions, and none changes the accepted scope or claims. No code changed after the exact-head review.

## Scope and residual risk

No CAK-194 Dropbox provider implementation, new provider or storage architecture, phrase guard, broad prompt taxonomy redesign, or hosted-runtime emulation is included.

The local harness proves semantic conformance at the documented decision-record boundary. It does not prove hosted ChatGPT materializes the same internal state. Repository validation and review do not complete CAK-200; the planning item remains In Progress until merge and another genuinely fresh hosted replay passes.

Linear: CAK-200

Do not merge or enable auto-merge as part of this delivery.
