### PR TITLE
test: keep advisory source scan resilient

### DIFF
--- a/scripts/check_authoritative_sources.py
+++ b/scripts/check_authoritative_sources.py
@@ -237,6 +237,8 @@ def markdown_sources(paths: list[Path]) -> list[tuple[str, str]]:
             sources.append((str(path), path.read_text(encoding="utf-8")))
         except UnicodeDecodeError:
             print(f"authoritative-source-check: skipped non-UTF-8 file {path}")
+        except OSError:
+            print(f"authoritative-source-check: skipped unreadable file {path}")
     return sources
 
 

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -365,6 +365,20 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
 
         self.assertEqual(sources, [])
 
+    def test_markdown_sources_skip_unreadable_files_without_aborting_scan(self) -> None:
+        path = Path("docs/unreadable.md")
+
+        with mock.patch.object(Path, "is_symlink", return_value=False), mock.patch.object(
+            Path, "is_file", return_value=True
+        ), mock.patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+            with mock.patch("builtins.print") as print_mock:
+                sources = scanner.markdown_sources([path])
+
+        self.assertEqual(sources, [])
+        print_mock.assert_called_once_with(
+            "authoritative-source-check: skipped unreadable file docs/unreadable.md"
+        )
+
     def test_all_markdown_files_excludes_symbolic_links(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_check_authoritative_sources.py
+++ b/tests/test_check_authoritative_sources.py
@@ -366,15 +366,20 @@ class AuthoritativeSourceScannerTest(unittest.TestCase):
         self.assertEqual(sources, [])
 
     def test_markdown_sources_skip_unreadable_files_without_aborting_scan(self) -> None:
-        path = Path("docs/unreadable.md")
+        unreadable = Path("docs/unreadable.md")
+        readable = Path("docs/readable.md")
 
         with mock.patch.object(Path, "is_symlink", return_value=False), mock.patch.object(
             Path, "is_file", return_value=True
-        ), mock.patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+        ), mock.patch.object(
+            Path,
+            "read_text",
+            side_effect=[PermissionError("denied"), "https://example.com/readable"],
+        ):
             with mock.patch("builtins.print") as print_mock:
-                sources = scanner.markdown_sources([path])
+                sources = scanner.markdown_sources([unreadable, readable])
 
-        self.assertEqual(sources, [])
+        self.assertEqual(sources, [("docs/readable.md", "https://example.com/readable")])
         print_mock.assert_called_once_with(
             "authoritative-source-check: skipped unreadable file docs/unreadable.md"
         )


### PR DESCRIPTION
## Summary
- skip unreadable Markdown files during advisory authoritative-source scans
- prove scanning continues and preserves a later readable source after the injected read failure

## Validation
- make check
- git diff --check

Human review and merge remain required.