### PR TITLE
docs: centralize GitHub CLI command policy

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -540,11 +540,17 @@ aliases, or equivalent wrapper shells only for convenience. In particular,
 `zsh -lc`, `bash -lc`, `sh -c`, or equivalent forms are not normal wrappers for
 ordinary repo commands.
 
-For standard Git or GitHub CLI work, choose the `git` or `gh` command directly
-instead of substituting alternate APIs, helper tools, wrapper scripts, or
-connector-specific operations. Use alternate APIs or tools only when the task
-explicitly calls for capabilities the CLI cannot provide or when direct CLI
-access is unavailable and the fallback is reported clearly.
+For standard Git work, choose the `git` command directly instead of
+substituting alternate APIs, helper tools, wrapper scripts, or
+connector-specific operations. For ordinary GitHub workflow operations, choose
+high-level `gh` subcommands directly. Do not use `gh api` or `gh api graphql`
+as a fallback for normal repository workflows, and do not bypass this rule with
+direct GitHub REST or GraphQL HTTP calls or equivalent wrappers. When a required
+capability is unavailable through a high-level `gh` command, use an approved
+available connector or tool when it supports that operation. If neither a
+high-level `gh` command nor an approved connector or tool supports the required
+operation, report the capability gap rather than dropping to a lower-level API
+route.
 
 Preserve that directness at the execution layer too. Prefer native argv-style
 execution, such as `["git", "status"]` or `["gh", "pr", "create"]`, when the

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -353,21 +353,8 @@ Before repo-scoped work:
 - Apply the runtime verification rule in
   [`start-here.md`](../start-here.md#connector-availability-is-runtime-evidence);
   do not infer that a connector capability is absent because its tool has not
-  been loaded or inspected. Before falling back to a direct service API or
-  authenticated CLI for remote service state, determine whether the connector
-  provides the required capability. Direct APIs and CLIs remain appropriate
-  for verified connector gaps, repository-local workflows, or explicit
-  repository policy.
-- For GitHub hydration and ordinary source-first retrieval, treat `gh api` as
-  a direct-service-API fallback rather than the default retrieval primitive.
-  Do not select it only because the REST endpoint is flexible or familiar. Use
-  an available GitHub connector when it provides the required source, or the
-  narrowest high-level `gh` command when that is the appropriate direct
-  repository CLI. If neither provides the required capability, keep `gh api`
-  read-only and scoped to the required state unless the current task separately
-  authorizes mutation. This avoids unnecessary approval friction; it does not
-  create a human approval gate or prohibit `gh api` when it is the narrowest
-  available way to retrieve authoritative state.
+  been loaded or inspected. Follow the shared GitHub command-selection rule in
+  [`repo-readiness.md`](../repo-readiness.md#command-form-and-intent-visibility).
 - For policy-sensitive changes, apply the repo-family alignment check in
   [`repo-readiness.md`](../repo-readiness.md#repo-family-policy-alignment)
   before implementation.

--- a/tests/test_codex_adapter.py
+++ b/tests/test_codex_adapter.py
@@ -66,18 +66,11 @@ class CodexAdapterTests(unittest.TestCase):
         ):
             self.assertIn(phrase, self.contents)
 
-    def test_github_hydration_uses_gh_api_only_for_capability_gaps(self):
-        for phrase in (
-            "GitHub hydration and ordinary source-first retrieval",
-            "`gh api` as a direct-service-API fallback",
-            "REST endpoint is flexible or familiar",
-            "available GitHub connector",
-            "narrowest high-level `gh` command",
-            "`gh api` read-only and scoped to the required state",
-            "does not create a human approval gate",
-            "narrowest available way to retrieve authoritative state",
-        ):
-            self.assertIn(phrase, self.contents)
+    def test_github_command_selection_inherits_the_shared_rule(self):
+        self.assertIn(
+            "repo-readiness.md#command-form-and-intent-visibility", self.contents
+        )
+        self.assertNotIn("`gh api`", self.contents)
 
     def test_pr_evidence_requires_current_connector_backed_state(self):
         for phrase in (


### PR DESCRIPTION
Summary: Make docs/repo-readiness.md the canonical GitHub CLI command-selection owner; remove the Codex-specific gh api fallback exception; retain an adapter test enforcing inheritance of the shared rule.

Rationale: Normal repository workflows use high-level gh commands or an approved available connector/tool. Unsupported operations now fail closed as a capability gap.

Validation: make check.