### PR TITLE
docs: clarify Codex preflight host binding

### DIFF
--- a/docs/codex-preflight.md
+++ b/docs/codex-preflight.md
@@ -7,7 +7,9 @@ prerequisites before Codex automation fan-out or real repository work begins.
 
 It verifies:
 
-- GitHub SSH authentication succeeds with `ssh -T git@github.com`
+- GitHub SSH authentication succeeds with `ssh -T` against the configured
+  GitHub SSH target (default: `git@github.com`)
+- The configured SSH target and repository URL use the same host
 - `gh` is installed and authenticated
 - the playbook repository is reachable through `git ls-remote`
 
@@ -15,7 +17,8 @@ When available, `ssh-add -l` is used only for diagnostic context. It is not a
 readiness gate because some agent-backed flows, including 1Password SSH agent,
 can authenticate to GitHub without listing identities through `ssh-add -l`.
 The authoritative SSH readiness check is actual GitHub SSH authentication via
-`ssh -T git@github.com`.
+`ssh -T` against the effective SSH target. Before that check, the script
+rejects a repository URL and SSH target that name different hosts.
 
 The script does not install tools, mutate Git state, change credentials, push,
 commit, or update SSH configuration. SSH checks use batch mode and strict host
@@ -48,8 +51,9 @@ endpoint with the same read-only pattern:
 - `CODEX_PREFLIGHT_REPO_URL`: repository URL used for the final
   `git ls-remote` reachability check.
 - `CODEX_PREFLIGHT_GITHUB_SSH_TARGET`: SSH target used for the direct
-  `ssh -T` GitHub authentication check.
+  `ssh -T` GitHub authentication check (default: `git@github.com`).
 
-Keep both overrides pointed at the same GitHub account or host context. If they
-describe different environments, the preflight can pass one credential surface
-while failing or misrepresenting the other.
+Keep both overrides pointed at the same GitHub account or host context. The
+preflight fails before authentication if their hosts differ. If they describe
+different environments, the preflight must not be allowed to pass one
+credential surface while failing or misrepresenting the other.


### PR DESCRIPTION
## Summary\n- document that Codex preflight authenticates against the configured SSH target\n- document the same-host guard between SSH target and repository URL\n\n## Validation\n- make check (Markdown lint; 334 tests)\n\nThis is a narrow implementation-driven documentation correction for the host-binding behavior added in #366.