### PR TITLE
CAK-209: add prose DAG pilot for Codex handoffs

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -569,10 +569,12 @@ complete executable prompt for the one machine recipient named by the
 activating adapter, the governing issue and intended issue-owned destination
 are known, and the prompt body is frozen for this attempt. The
 `PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the already-frozen stages
-5 through 7 decision record when it selects a qualified file route,
+5 through 7 decision record when that record selects a qualified file route,
 `file-backed` presentation, and the `thin-handoff` renderer. The pilot does not
-replace, repeat, or recompute any of the eight stages. No recipient is eligible
-unless its adapter explicitly activates this pilot.
+replace, repeat, or recompute any of the eight stages. A record with another
+selection remains under the canonical decision model and does not enter this
+graph. No recipient is eligible unless its adapter explicitly activates this
+pilot.
 
 Once explicitly activated, use this fixed last-mile graph:
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -563,14 +563,16 @@ the downstream stages.
 
 ### Issue-Owned File-Backed Handoff Prose-DAG Pilot
 
-This pilot is opt-in for a normal-use trial. Activate it only after the
-canonical decision model has resolved a complete executable prompt for the one
-machine recipient named by the activating adapter, the governing issue and
-intended issue-owned destination are known, the prompt body is frozen for this
-attempt, and stages 5 through 7 have selected a qualified file route,
-`file-backed` presentation, and the `thin-handoff` renderer. It consumes those
-decisions; it does not replace or recompute any of the eight stages. No
-recipient is eligible unless its adapter explicitly activates this pilot.
+This pilot is opt-in for a normal-use trial. Activate it once the
+`PROMPT_READY` prerequisites hold: the canonical decision model has resolved a
+complete executable prompt for the one machine recipient named by the
+activating adapter, the governing issue and intended issue-owned destination
+are known, and the prompt body is frozen for this attempt. The
+`PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the already-frozen stages
+5 through 7 decision record when it selects a qualified file route,
+`file-backed` presentation, and the `thin-handoff` renderer. The pilot does not
+replace, repeat, or recompute any of the eight stages. No recipient is eligible
+unless its adapter explicitly activates this pilot.
 
 Once explicitly activated, use this fixed last-mile graph:
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -561,6 +561,72 @@ selection consume only the decision record. Representative requests such as
 upstream evidence; they are neither transport selectors nor repeated inputs to
 the downstream stages.
 
+### Issue-Owned File-Backed Handoff Prose-DAG Pilot
+
+This pilot is opt-in for a normal-use trial. Activate it only after the
+canonical decision model has resolved a complete executable prompt for the one
+machine recipient named by the activating adapter, the governing issue and
+intended issue-owned destination are known, the prompt body is frozen for this
+attempt, and stages 5 through 7 have selected a qualified file route,
+`file-backed` presentation, and the `thin-handoff` renderer. It consumes those
+decisions; it does not replace or recompute any of the eight stages. No
+recipient is eligible unless its adapter explicitly activates this pilot.
+
+Once explicitly activated, use this fixed last-mile graph:
+
+```text
+PROMPT_READY
+    -> ROUTE_QUALIFIED
+    -> PROMPT_STORED
+    -> ARTIFACT_VERIFIED
+    -> HANDOFF_EMITTED
+
+Any unmet prerequisite -> BLOCKED
+Human correction -> new revision, retaining the nearest still-valid state
+```
+
+- `PROMPT_READY` means the complete prompt, machine execution recipient,
+  governing issue, destination intent, and frozen body are resolved.
+- `ROUTE_QUALIFIED` means the current Dropbox route, acting account,
+  destination permission, and required capability were inspected or
+  successfully exercised. Inline complete-prompt rendering is ineligible.
+- `PROMPT_STORED` means one issue-owned Dropbox object was created and its
+  provider identity was captured under the existing durable handoff profile.
+- `ARTIFACT_VERIFIED` means current provider identity and applicable integrity
+  evidence were re-observed and matched before handoff creation.
+- `HANDOFF_EMITTED` means the operator received the selected compact
+  target-shaped retrieval handoff without the complete prompt body. It is
+  terminal success for this delivery attempt.
+- `BLOCKED` means one named prerequisite or action failed. Take no downstream
+  transition or delivery action.
+
+For every material transition in an activated attempt, surface one compact
+operator-visible receipt at the transition boundary. Keep it outside both the
+stored prompt and the receiver's copyable execution instructions:
+
+```text
+Issue-owned file-backed handoff pilot | revision [n]
+[from] -> [to] | [succeeded | blocked]
+Basis: [decisive observed prerequisite or exact block reason] | Action: [selected action]
+Ineligible: [actions excluded by this transition] | Next: [eligible transition or terminal state]
+Correction: supersedes revision [n]; retains [nearest valid state]; invalidates [state or pending action]
+```
+
+Include the correction line only after human correction, and increment the
+revision. A successful receipt relies only on observed provider or connector
+facts where they are decisive; it must not invent evidence. It records
+execution-state evidence, grants no authority, performs no lifecycle
+transition, and contains no complete prompt body, secret, or hidden reasoning.
+
+The observed action must match the selected action and transition. Treat a
+wrong transition, an unsupported prerequisite, an action contradiction, a
+stale or superseded revision, or an omitted receipt as a visible pilot failure.
+A correct `BLOCKED` receipt names the failure and leaves downstream actions
+ineligible. This vocabulary is only for this pilot, not a general incident
+taxonomy, retry model, or workflow framework. Ordinary chat, prompt authoring,
+conceptual fragments, human-recipient inline delivery, and non-pilot handoffs
+do not inherit it.
+
 ## Cross-Executor Prompt Presentation
 
 This section supplies the transport and presentation rules consumed by stages
@@ -608,6 +674,7 @@ surface.
 
 - [Task-Shape Surface Selection And Thin Handoffs](#task-shape-surface-selection-and-thin-handoffs)
 - [Prompt Delivery Decision Model](#prompt-delivery-decision-model)
+- [Issue-Owned File-Backed Handoff Prose-DAG Pilot](#issue-owned-file-backed-handoff-prose-dag-pilot)
 - [Cross-Executor Prompt Presentation](#cross-executor-prompt-presentation)
 - [Repository Implementation Task](#repository-implementation-task)
 - [Parallel Batch Add-On](#parallel-batch-add-on)

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -253,6 +253,25 @@ preserve the target-shaped handoff with an explicit blocked state and stop. Do
 not degrade the required prompt or handoff into unconstrained status prose
 merely because one downstream prerequisite failed.
 
+### Issue-Owned Codex Handoff Pilot Projection
+
+During an explicitly activated CAK-209 normal-use pilot attempt, apply the
+shared
+[`Issue-Owned File-Backed Handoff Prose-DAG Pilot`](../prompts.md#issue-owned-file-backed-handoff-prose-dag-pilot)
+only after the current decision record has selected the qualified Dropbox
+file route, `file-backed` presentation, and the `thin-handoff` renderer. Display
+each compact transition receipt at the matching action boundary, outside the
+stored prompt and outside the receiver's copyable handoff instructions.
+
+Populate decisive evidence only from provider or connector facts ChatGPT
+actually observed. Ensure the visible connector action and response surface
+match the receipt's selected action: a file-backed transition must not render
+the complete prompt inline. A `BLOCKED` receipt performs no downstream action,
+and a human correction increments the revision, makes the superseded revision
+ineligible, and resumes only from the nearest still-valid state. Do not apply
+this projection to ordinary chat, prompt authoring, non-Codex recipients,
+inline delivery, or handoffs where the pilot was not explicitly activated.
+
 ### Dropbox Preview And Minimal Executor Handoff
 
 When optional operator preview is selected, complete the shared pre-link checks,

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -221,6 +221,12 @@ or require the operator to open a preview; connector confirmation authorizes
 only its file operation. File-card and preview behavior is product-dependent
 runtime evidence, so recheck the relevant action.
 
+For the explicitly activated CAK-209 normal-use Codex trial, ChatGPT applies the
+shared
+[`Issue-Owned File-Backed Handoff Prose-DAG Pilot`](../prompts.md#issue-owned-file-backed-handoff-prose-dag-pilot)
+and presents its transition receipts as operator-visible metadata outside the
+receiver's copyable handoff.
+
 For a human execution recipient, or a machine execution recipient whose
 inspected capability state permits inline fallback, the model selects `inline`
 presentation and the existing
@@ -252,25 +258,6 @@ When the governing exact-byte or durable contract prohibits that fallback,
 preserve the target-shaped handoff with an explicit blocked state and stop. Do
 not degrade the required prompt or handoff into unconstrained status prose
 merely because one downstream prerequisite failed.
-
-### Issue-Owned Codex Handoff Pilot Projection
-
-During an explicitly activated CAK-209 normal-use pilot attempt, apply the
-shared
-[`Issue-Owned File-Backed Handoff Prose-DAG Pilot`](../prompts.md#issue-owned-file-backed-handoff-prose-dag-pilot)
-only after the current decision record has selected the qualified Dropbox
-file route, `file-backed` presentation, and the `thin-handoff` renderer. Display
-each compact transition receipt at the matching action boundary, outside the
-stored prompt and outside the receiver's copyable handoff instructions.
-
-Populate decisive evidence only from provider or connector facts ChatGPT
-actually observed. Ensure the visible connector action and response surface
-match the receipt's selected action: a file-backed transition must not render
-the complete prompt inline. A `BLOCKED` receipt performs no downstream action,
-and a human correction increments the revision, makes the superseded revision
-ineligible, and resumes only from the nearest still-valid state. Do not apply
-this projection to ordinary chat, prompt authoring, non-Codex recipients,
-inline delivery, or handoffs where the pilot was not explicitly activated.
 
 ### Dropbox Preview And Minimal Executor Handoff
 

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -91,7 +91,6 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "Persistent-context activation",
             "Chat, Work, and execution locality",
             "Connected apps, approvals, and consequential actions",
-            "Issue-Owned Codex Handoff Pilot Projection",
             "Workspace Agents",
             "Prompt and downstream-context projection",
             "Generated artifacts",
@@ -119,23 +118,23 @@ class ChatGPTAdapterTests(unittest.TestCase):
         )
         self.assertIn("not symptom-by-symptom repair", contents)
 
-    def test_issue_owned_codex_handoff_pilot_projection_is_explicit_and_thin(self):
+    def test_issue_owned_codex_handoff_pilot_hook_is_explicit_and_thin(self):
         contents = (DOCS / "tool-adapters/chatgpt.md").read_text(
             encoding="utf-8"
         )
-        start = contents.index("### Issue-Owned Codex Handoff Pilot Projection")
-        end = contents.index("### Dropbox Preview And Minimal Executor Handoff")
-        pilot = contents[start:end]
-        normalized_pilot = " ".join(pilot.split())
+        anchor = "#issue-owned-file-backed-handoff-prose-dag-pilot"
+        hook = next(
+            paragraph for paragraph in contents.split("\n\n") if anchor in paragraph
+        )
+        normalized_hook = " ".join(hook.split())
 
-        self.assertIn("#issue-owned-file-backed-handoff-prose-dag-pilot", pilot)
-        self.assertIn("explicitly activated", pilot)
-        self.assertIn("`file-backed`", pilot)
-        self.assertIn("`thin-handoff`", pilot)
-        self.assertIn("outside the stored prompt", normalized_pilot)
-        self.assertIn("`BLOCKED`", pilot)
-        self.assertIn("must not render the complete prompt inline", normalized_pilot)
-        self.assertIn("ordinary chat", pilot)
+        self.assertNotIn("### Issue-Owned Codex Handoff Pilot Projection", contents)
+        self.assertIn(anchor, hook)
+        self.assertRegex(normalized_hook, r"explicitly activated.*CAK-209.*Codex trial")
+        self.assertRegex(
+            normalized_hook,
+            r"transition receipts.*operator-visible metadata.*outside.*copyable handoff",
+        )
 
     def test_adapter_keeps_chat_and_work_under_chatgpt(self):
         chatgpt = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")

--- a/tests/test_chatgpt_adapter.py
+++ b/tests/test_chatgpt_adapter.py
@@ -91,6 +91,7 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "Persistent-context activation",
             "Chat, Work, and execution locality",
             "Connected apps, approvals, and consequential actions",
+            "Issue-Owned Codex Handoff Pilot Projection",
             "Workspace Agents",
             "Prompt and downstream-context projection",
             "Generated artifacts",
@@ -117,6 +118,24 @@ class ChatGPTAdapterTests(unittest.TestCase):
             "does not expand the human-authorized task", " ".join(contents.split())
         )
         self.assertIn("not symptom-by-symptom repair", contents)
+
+    def test_issue_owned_codex_handoff_pilot_projection_is_explicit_and_thin(self):
+        contents = (DOCS / "tool-adapters/chatgpt.md").read_text(
+            encoding="utf-8"
+        )
+        start = contents.index("### Issue-Owned Codex Handoff Pilot Projection")
+        end = contents.index("### Dropbox Preview And Minimal Executor Handoff")
+        pilot = contents[start:end]
+        normalized_pilot = " ".join(pilot.split())
+
+        self.assertIn("#issue-owned-file-backed-handoff-prose-dag-pilot", pilot)
+        self.assertIn("explicitly activated", pilot)
+        self.assertIn("`file-backed`", pilot)
+        self.assertIn("`thin-handoff`", pilot)
+        self.assertIn("outside the stored prompt", normalized_pilot)
+        self.assertIn("`BLOCKED`", pilot)
+        self.assertIn("must not render the complete prompt inline", normalized_pilot)
+        self.assertIn("ordinary chat", pilot)
 
     def test_adapter_keeps_chat_and_work_under_chatgpt(self):
         chatgpt = (DOCS / "tool-adapters/chatgpt.md").read_text(encoding="utf-8")

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -559,7 +559,9 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
                 "## Cross-Executor Prompt Presentation"
             )
         ]
+        opening = pilot[: pilot.index("Once explicitly activated")]
         normalized_pilot = " ".join(pilot.split())
+        normalized_opening = " ".join(opening.split())
 
         states = (
             "PROMPT_READY",
@@ -579,12 +581,15 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             "does not replace, repeat, or recompute any of the eight stages",
             normalized_pilot,
         )
-        self.assertIn("`PROMPT_READY` prerequisites hold", normalized_pilot)
-        self.assertIn(
-            "`PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the "
+        for relationship in (
+            "`PROMPT_READY` prerequisites hold",
+            "`PROMPT_READY -> ROUTE_QUALIFIED`",
             "already-frozen stages 5 through 7 decision record",
-            normalized_pilot,
-        )
+            "qualified file route",
+            "`file-backed` presentation",
+            "`thin-handoff` renderer",
+        ):
+            self.assertIn(relationship, normalized_opening)
 
     def test_resolved_codex_semantics_exclude_request_wording(self):
         prompts = PROMPTS.read_text(encoding="utf-8")

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -551,6 +551,37 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         ):
             self.assertIn(mapping, normalized_section)
 
+    def test_docs_define_bounded_issue_owned_codex_handoff_pilot(self):
+        prompts = PROMPTS.read_text(encoding="utf-8")
+        heading = "### Issue-Owned File-Backed Handoff Prose-DAG Pilot"
+        pilot = prompts[
+            prompts.index(heading) : prompts.index(
+                "## Cross-Executor Prompt Presentation"
+            )
+        ]
+        normalized_pilot = " ".join(pilot.split())
+
+        states = (
+            "PROMPT_READY",
+            "ROUTE_QUALIFIED",
+            "PROMPT_STORED",
+            "ARTIFACT_VERIFIED",
+            "HANDOFF_EMITTED",
+        )
+        positions = [pilot.index(state) for state in states]
+        self.assertEqual(positions, sorted(positions))
+        self.assertIn("Any unmet prerequisite -> BLOCKED", pilot)
+        self.assertIn("Human correction -> new revision", pilot)
+        self.assertIn("[from] -> [to] | [succeeded | blocked]", pilot)
+        self.assertIn("Ineligible:", pilot)
+        self.assertIn("Correction:", pilot)
+        self.assertIn(
+            "does not replace or recompute any of the eight stages",
+            normalized_pilot,
+        )
+        self.assertIn("Ordinary chat", pilot)
+        self.assertIn("not a general incident taxonomy", normalized_pilot)
+
     def test_resolved_codex_semantics_exclude_request_wording(self):
         prompts = PROMPTS.read_text(encoding="utf-8")
         decision_section = prompts[

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -576,11 +576,15 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
         self.assertIn("Ineligible:", pilot)
         self.assertIn("Correction:", pilot)
         self.assertIn(
-            "does not replace or recompute any of the eight stages",
+            "does not replace, repeat, or recompute any of the eight stages",
             normalized_pilot,
         )
-        self.assertIn("Ordinary chat", pilot)
-        self.assertIn("not a general incident taxonomy", normalized_pilot)
+        self.assertIn("`PROMPT_READY` prerequisites hold", normalized_pilot)
+        self.assertIn(
+            "`PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the "
+            "already-frozen stages 5 through 7 decision record",
+            normalized_pilot,
+        )
 
     def test_resolved_codex_semantics_exclude_request_wording(self):
         prompts = PROMPTS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Rationale

Add a small operator-visible control for the last-mile delivery of an already-complete issue-owned prompt while keeping one canonical semantic owner. The pilot makes material transitions visible without replacing the canonical eight-stage prompt-delivery model.

## Pilot scope and ownership

`docs/prompts.md` solely owns the bounded five-state graph, prerequisites, transition receipt, correction behavior, failure vocabulary, and exclusions. The pilot activates when `PROMPT_READY` holds; its first transition consumes the already-frozen stages 5 through 7 decision record when that record selects a qualified file route, `file-backed` presentation, and the `thin-handoff` renderer. Other selections remain under the canonical decision model and do not enter the graph.

`docs/tool-adapters/chatgpt.md` contains one compact hook only: ChatGPT activates the shared pilot for the CAK-209 Codex trial and places transition receipts as operator-visible metadata outside the receiver's copyable handoff. It does not duplicate shared semantics.

## Exact identity

- Correction range: `6997991a46c2b1835ef86ae0e569542fe1091aff..35da4eddb3c4ea69bbe08d9fdde8d909ff2a783c`
- Current head: `35da4eddb3c4ea69bbe08d9fdde8d909ff2a783c`
- Base: `83292557afb02307722ad35f41dcf75219ed5440`

## Files changed

- `docs/prompts.md`: shared bounded graph and coherent `PROMPT_READY` activation/route-consumption relationship
- `docs/tool-adapters/chatgpt.md`: one shared-reference plus ChatGPT-specific activation/receipt-placement hook
- `tests/test_prompt_delivery_decision_model.py`: structural owner-side coverage
- `tests/test_chatgpt_adapter.py`: structural reference/activation/placement coverage and removal of the retired heading

## Validation

- `make check`: passed after the final disposition
- Markdown lint: 0 issues
- Unit tests: 335 passed
- Hosted `authoritative-source-check`: passed on the current head
- Hosted `markdownlint`: passed on the current head

## Governed Claude review

- Initial exact-head review of `3db1eab4753b40315482a2c20c68a88b83aac05b`: `ACCEPT WITH CHANGES`
- Dispositions: canonical non-file-selection clarification accepted; selector ambiguity accepted; restoration of deleted prose-only scope assertions declined because the governing correction explicitly required their removal and prohibited replacement wording ratchets
- Focused rereview of final head `35da4eddb3c4ea69bbe08d9fdde8d909ff2a783c`: `ACCEPT`
- Final rereview artifact: `/issues/CAK-209/cak-209-pr382-shrinkage-claude-rereview-v2-2026-09-03.md` (`id:FHKdoRfTdTUAAAAAAAAJVA`)
- Final terminal receipt: `/issues/CAK-209/cak-209-pr382-shrinkage-claude-rereview-attempt-1-terminal-receipt-v2-2026-09-03.json` (`id:FHKdoRfTdTUAAAAAAAAJVQ`)

The review evaluated reference-based ownership as the intended architecture and found no ChatGPT-specific behavior requiring more adapter prose. Review evidence grants no merge authority.

## Non-goals and stop boundary

No additional adapter section, executable controller, machine-readable schema, workflow engine or DSL, generalized prose DAG, prompt generator, Dropbox mechanics, enforcement change, or production reliability claim. This PR stops before merge, CAK-209 closure, the post-merge Chat trial, and any resumption of CAK-205 or CAK-206.

Relates to CAK-209
