### PR TITLE
CAK-209: enter prose DAG before route qualification

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -563,16 +563,26 @@ the downstream stages.
 
 ### Issue-Owned File-Backed Handoff Prose-DAG Pilot
 
-This pilot is opt-in for a normal-use trial. Activate it once the
-`PROMPT_READY` prerequisites hold: the canonical decision model has resolved a
-complete executable prompt for the one machine recipient named by the
-activating adapter, the governing issue and intended issue-owned destination
-are known, and the prompt body is frozen for this attempt. The
-`PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the already-frozen stages
-5 through 7 decision record when that record selects a qualified file route,
-`file-backed` presentation, and the `thin-handoff` renderer. The pilot does not
-replace, repeat, or recompute any of the eight stages. A record with another
-selection remains under the canonical decision model and does not enter this
+This pilot is opt-in for a normal-use trial. For an explicitly activated
+attempt, enter the graph at `PROMPT_READY` once its prerequisites hold: the
+canonical decision model has resolved a complete executable prompt for the one
+machine recipient named by the activating adapter, the governing issue and
+intended issue-owned destination are known, and the prompt body is frozen for
+this attempt. Entry at `PROMPT_READY` precedes route qualification. A qualified
+route, existing destination, destination permission, or required write
+capability is not an activation prerequisite.
+
+After graph entry, the canonical decision model resolves stages 5 through 7
+once. The `PROMPT_READY -> ROUTE_QUALIFIED` transition consumes the resulting
+frozen decision record when it selects a qualified file route, `file-backed`
+presentation, and the `thin-handoff` renderer. If route, destination,
+permission, or required-capability qualification instead fails, record
+`PROMPT_READY -> BLOCKED`, select `blocked` presentation with no complete-prompt
+renderer, and keep every downstream graph transition and inline complete-prompt
+fallback ineligible. That failure does not retroactively remove the attempt
+from the graph. The pilot does not replace, repeat, or recompute any of the
+eight stages. A record with another selection outside an explicitly activated
+attempt remains under the canonical decision model and does not enter this
 graph. No recipient is eligible unless its adapter explicitly activates this
 pilot.
 

--- a/tests/test_prompt_delivery_decision_model.py
+++ b/tests/test_prompt_delivery_decision_model.py
@@ -581,15 +581,31 @@ class PromptDeliveryDecisionModelTests(unittest.TestCase):
             "does not replace, repeat, or recompute any of the eight stages",
             normalized_pilot,
         )
-        for relationship in (
-            "`PROMPT_READY` prerequisites hold",
+        for semantic_anchor in (
+            "enter the graph at `PROMPT_READY`",
+            "route qualification",
+            "activation prerequisite",
             "`PROMPT_READY -> ROUTE_QUALIFIED`",
-            "already-frozen stages 5 through 7 decision record",
+            "resulting frozen decision record",
             "qualified file route",
             "`file-backed` presentation",
             "`thin-handoff` renderer",
+            "`PROMPT_READY -> BLOCKED`",
+            "`blocked` presentation",
+            "no complete-prompt renderer",
+            "inline complete-prompt fallback",
+            "retroactively remove the attempt from the graph",
         ):
-            self.assertIn(relationship, normalized_opening)
+            self.assertIn(semantic_anchor, normalized_opening)
+
+        self.assertLess(
+            normalized_opening.index("enter the graph at `PROMPT_READY`"),
+            normalized_opening.index("After graph entry"),
+        )
+        self.assertLess(
+            normalized_opening.index("`PROMPT_READY -> ROUTE_QUALIFIED`"),
+            normalized_opening.index("`PROMPT_READY -> BLOCKED`"),
+        )
 
     def test_resolved_codex_semantics_exclude_request_wording(self):
         prompts = PROMPTS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Fix the repeated CAK-209 normal-use failure where route or destination problems kept an otherwise activated Codex handoff outside the prose DAG.
- Enter explicitly activated attempts at `PROMPT_READY` before route qualification. A missing destination, permission, content-write capability, or other route prerequisite now yields `PROMPT_READY -> BLOCKED` with no inline complete-prompt renderer.
- Preserve the fixed five-state graph, existing receipts and correction semantics, the canonical eight-stage decision model, and the thin ChatGPT adapter hook.

## Files changed

- `docs/prompts.md` — clarifies graph entry and the fail-closed route-qualification branch in the shared canonical owner.
- `tests/test_prompt_delivery_decision_model.py` — protects the state, renderer, and ordering relationships without pinning the full prose sentence.

## Validation

- `make check`
  - Markdown lint: 0 issues
  - Unit tests: 335 passed

## Non-goals

- No new states, retry or fallback tree, workflow engine, prompt generator, or mechanical enforcement.
- No automatic Dropbox folder creation or change to connector confirmation requirements.
- No ChatGPT adapter expansion, non-pilot delivery change, CAK-205/206 work, CAK-204 disposition change, or merge.

Relates to CAK-209