### PR TITLE
CAK-211: make prompt retrieval paths shell-safe

### DIFF
--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -485,6 +485,14 @@ explicit owner assigns it a non-disposable role; prefer a role-specific name.
 Generic persistent `scratch/` is prohibited by default for disposable
 mechanics.
 
+Constrain workflow-generated attempt-local retrieval basenames to
+`[A-Za-z0-9._-]+`, including generated child-directory and local-file
+basenames. Do not derive them from issue titles, prompt text, or other free-form
+labels that can introduce spaces, quotes, brackets, colons, parentheses, shell
+metacharacters, or avoidable quoting hazards. Continue to pass paths as data and
+quote them defensively whenever a shell is genuinely required; the restricted
+basename is an ergonomics safeguard, not permission for string interpolation.
+
 Environment variables such as `TMPDIR`, `TEMP`, and `TMP` are observations or
 inputs, not authority. Temporary-directory helpers are allocation mechanics,
 not authority. An applicable owner qualifies a platform mapping in its own

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -288,9 +288,11 @@ Reason:
 ```text
 Download: [fresh single-use raw-download URL]
 Dropbox ID: [exact returned file ID]
+Attempt directory basename: prompt-retrieval.XXXXXXXX
+Local filename: prompt.md
 Expected bytes: [byte count]
 Expected SHA-256: [digest]
-Execute: Download once, verify the exact identity, byte count, and SHA-256, then execute the complete prompt file.
+Execute: Download exactly once with a direct argv/process invocation into the qualified private attempt-local directory, verify the exact identity, byte count, and SHA-256, then execute the complete prompt file.
 Stop: Fail closed on retrieval, identity, size, or SHA-256 mismatch. Do not reconstruct the prompt from chat.
 ```
 

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -314,12 +314,12 @@ consumed local bytes and declared text format before acceptance. Do not use a
 locally synchronized provider mount as provider or durable identity, treat the
 local retrieval as durable, or create an exchange root.
 
-For this fallback, constrain every workflow-generated attempt-local directory
-and file basename to `[A-Za-z0-9._-]+`. Invoke the downloader with a direct
-argv/process invocation when shell syntax is not genuinely required, passing
-the URL and output path as separate arguments. If a shell is required, retain
-normal defensive quoting and path-as-data treatment; shell-safe basenames do
-not authorize interpolation into command strings.
+For this fallback, apply the shared attempt-local retrieval basename and
+path-as-data rules in
+[`repo-readiness.md#repo-local-workflow-state`](../repo-readiness.md#repo-local-workflow-state).
+Invoke the downloader with a direct argv/process invocation when shell syntax
+is not genuinely required, passing the URL and output path as separate
+arguments.
 
 Record the delivery operation and Codex attempt separately from the durable
 prompt. Distinguish `DELIVERED`, `ACCEPTED`, `STARTED`, and the terminal

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -314,6 +314,13 @@ consumed local bytes and declared text format before acceptance. Do not use a
 locally synchronized provider mount as provider or durable identity, treat the
 local retrieval as durable, or create an exchange root.
 
+For this fallback, constrain every workflow-generated attempt-local directory
+and file basename to `[A-Za-z0-9._-]+`. Invoke the downloader with a direct
+argv/process invocation when shell syntax is not genuinely required, passing
+the URL and output path as separate arguments. If a shell is required, retain
+normal defensive quoting and path-as-data treatment; shell-safe basenames do
+not authorize interpolation into command strings.
+
 Record the delivery operation and Codex attempt separately from the durable
 prompt. Distinguish `DELIVERED`, `ACCEPTED`, `STARTED`, and the terminal
 attempt outcome rather than inferring one from another. Preserve required

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 import re
+import subprocess
+import sys
+import tempfile
 import unittest
 
 
@@ -26,6 +29,7 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
         cls.contract = normalized(DOCS / "prompt-contracts.md")
         cls.evidence = normalized(DOCS / "evidence-lifecycle.md")
         cls.prompts = normalized(DOCS / "prompts.md")
+        cls.readiness = normalized(DOCS / "repo-readiness.md")
         cls.codex = normalized(DOCS / "tool-adapters" / "codex.md")
         cls.claude = normalized(DOCS / "tool-adapters" / "claude.md")
         cls.chatgpt = normalized(DOCS / "tool-adapters" / "chatgpt.md")
@@ -427,6 +431,82 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             self.assertIn(field, bootstrap)
         self.assertIn("Keep the complete prompt in Dropbox", section)
         self.assertIn("do not summarize or reproduce the prompt", section)
+
+    def test_retrieval_bootstrap_uses_a_shell_safe_name_and_direct_process(self):
+        section = self.chatgpt_dropbox_bootstrap
+        blocks = re.findall(r"```[^\n]*\n(.*?)\n```", section, re.DOTALL)
+        self.assertEqual(len(blocks), 1)
+        bootstrap = blocks[0]
+        directory_name_line = next(
+            line
+            for line in bootstrap.splitlines()
+            if line.startswith("Attempt directory basename:")
+        )
+        directory_name = directory_name_line.partition(":")[2].strip()
+        local_name_line = next(
+            line for line in bootstrap.splitlines() if line.startswith("Local filename:")
+        )
+        local_name = local_name_line.partition(":")[2].strip()
+
+        self.assertRegex(directory_name, re.compile(r"\A[A-Za-z0-9._-]+\Z"))
+        self.assertRegex(local_name, re.compile(r"\A[A-Za-z0-9._-]+\Z"))
+        self.assertIn("direct argv/process invocation", bootstrap)
+        self.assertIn(
+            "workflow-generated attempt-local retrieval basenames",
+            self.readiness,
+        )
+        self.assertIn("direct argv/process invocation", self.codex)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            probe = root / "downloader-probe"
+            marker = root / "downloader-invoked"
+            probe.write_text(
+                f"#!{sys.executable}\n"
+                "from pathlib import Path\n"
+                "import sys\n"
+                "Path(sys.argv[1]).write_text('\\n'.join(sys.argv[2:]), "
+                "encoding='utf-8')\n",
+                encoding="utf-8",
+            )
+            probe.chmod(0o700)
+
+            unsafe_target = root / "prompt retrieval (first attempt)" / local_name
+            single_use_url = "https://example.invalid/file?token=a&single_use=1"
+            shell_built_command = (
+                f"{probe} {marker} --output {unsafe_target} {single_use_url}"
+            )
+            rejected = subprocess.run(
+                ["/bin/sh", "-c", shell_built_command],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertFalse(marker.exists())
+
+            safe_directory = root / directory_name.replace("XXXXXXXX", "A1")
+            self.assertRegex(safe_directory.name, re.compile(r"\A[A-Za-z0-9._-]+\Z"))
+            safe_target = safe_directory / local_name
+            invoked = subprocess.run(
+                [
+                    str(probe),
+                    str(marker),
+                    "--output",
+                    str(safe_target),
+                    single_use_url,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(invoked.returncode, 0, invoked.stderr)
+            self.assertEqual(
+                marker.read_text(encoding="utf-8").splitlines(),
+                ["--output", str(safe_target), single_use_url],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_issue_owned_prompt_handoff.py
+++ b/tests/test_issue_owned_prompt_handoff.py
@@ -456,6 +456,13 @@ class IssueOwnedPromptHandoffTests(unittest.TestCase):
             self.readiness,
         )
         self.assertIn("direct argv/process invocation", self.codex)
+        codex_retrieval = self.adapter_profiles[0]
+        self.assertIn(
+            "repo-readiness.md#repo-local-workflow-state",
+            codex_retrieval,
+        )
+        self.assertNotIn("[A-Za-z0-9._-]+", codex_retrieval)
+        self.assertNotIn("spaces, quotes, brackets", codex_retrieval)
 
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)


### PR DESCRIPTION
## Summary
- constrain workflow-generated attempt-local retrieval directory and file basenames to `[A-Za-z0-9._-]+`
- make the canonical Dropbox-to-executor bootstrap provide fixed shell-safe names and require direct argv/process downloader invocation
- preserve defensive path-as-data handling when a shell is genuinely required

## Root cause
The canonical Dropbox-to-executor bootstrap supplied provider identity and byte-verification data but left the local basename and downloader command form unspecified. Executors could therefore derive free-form paths and assemble shell command strings, allowing local parsing to fail before the downloader started.

## Regression coverage
- reproduces the prior unquoted path shape with spaces and parentheses and verifies the shell rejects it before the downloader probe runs
- verifies the documented shell-safe directory and file basenames
- verifies direct process invocation reaches the downloader probe with the output path and single-use URL preserved as distinct arguments

## Validation
- `make check`
- Markdown lint: 0 issues
- unit tests: 347 passed

Linear: CAK-211