### PR TITLE
CAK-184: require minimum-sufficient source retrieval

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -758,10 +758,15 @@ Context:
 Retrieval:
 - Read `ai-workflow-playbook/docs/start-here.md`, the target repo's
   `AGENTS.md`, and any required tool adapter before acting.
-- Retrieve or revalidate authoritative repository, issue, PR, file, CI, log, or
-  artifact state before relying on it.
-- Stop broad search once the target files, constraints, validation path, and
-  delivery expectation are clear.
+- Apply
+  `docs/source-first-retrieval.md#minimum-sufficient-retrieval`: state the claim
+  or decision and its evidence boundary, then retrieve only the authoritative
+  state needed to support it. Do not prescribe speculative provider-object
+  inventories.
+- For overlap or collision risk, inspect current `main`, relevant pull
+  requests, target files, and specifically identified refs as needed. Do not
+  inventory every branch, ref, workflow, or provider object unless that
+  inventory is materially necessary to the decision.
 
 Scope:
 - In scope: [files, behavior, or workflow area]

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -599,13 +599,14 @@ For standard Git work, choose the `git` command directly instead of
 substituting alternate APIs, helper tools, wrapper scripts, or
 connector-specific operations. For ordinary GitHub workflow operations, choose
 high-level `gh` subcommands directly. Do not use `gh api` or `gh api graphql`
-as a fallback for normal repository workflows, and do not bypass this rule with
-direct GitHub REST or GraphQL HTTP calls or equivalent wrappers. When a required
-capability is unavailable through a high-level `gh` command, use an approved
-available connector or tool when it supports that operation. If neither a
-high-level `gh` command nor an approved connector or tool supports the required
-operation, report the capability gap rather than dropping to a lower-level API
-route.
+merely because a high-level convenience command is unavailable, and do not
+bypass this rule with direct GitHub REST or GraphQL HTTP calls or equivalent
+wrappers. Use an approved available connector or tool when it supports the
+required hosted fact. If a materially necessary fact remains unavailable,
+apply the minimum-sufficient retrieval and explicit-escalation rule in
+[`source-first-retrieval.md`](source-first-retrieval.md#minimum-sufficient-retrieval)
+before considering a bounded lower-level read; otherwise omit the nonessential
+fact or report the capability gap.
 
 Preserve that directness at the execution layer too. Prefer native argv-style
 execution, such as `["git", "status"]` or `["gh", "pr", "create"]`, when the

--- a/docs/source-first-retrieval.md
+++ b/docs/source-first-retrieval.md
@@ -72,6 +72,49 @@ observed action and outcome, the verified source state or action and outcome
 control. This matters because reasoning traces can be post-hoc, incomplete, or
 optimized toward what the workflow appears to reward.
 
+## Minimum-Sufficient Retrieval
+
+Source-first retrieval means obtaining the minimum sufficient authoritative
+evidence needed for the current claim or decision. Name that claim or decision,
+identify the source that owns each required fact, and set the evidence boundary
+before retrieval. Inspect only the state needed to satisfy that boundary, and
+stop when the claim or decision is supported. More provider objects do not make
+the evidence more authoritative.
+
+This boundary does not weaken a mandatory trigger or permit an essential
+unknown to be ignored. If a materially necessary fact cannot be verified, mark
+the gate partial or blocked. If a fact is not necessary to the current claim or
+decision, omit it instead of expanding retrieval into a speculative inventory.
+
+For ordinary repository inspection and delivery, prefer the narrowest normal
+supported surface that owns or directly exposes the required fact:
+
+- repository-native `git` commands for repository, ref, and worktree facts;
+- high-level provider CLI commands for supported hosted facts;
+- connected GitHub reads for hosted state they expose; and
+- repository-native validation or workflow commands for facts they own.
+
+The absence of a high-level convenience command does not by itself justify
+`gh api`, an equivalent raw provider API, or a provider-wide inventory. In
+ordinary repository inspection, use a lower-level provider read only when a
+concrete fact is materially necessary for the current claim or decision and
+normal supported surfaces cannot establish it. Before that escalation, state
+the exact missing fact, why it matters, and why the first-class surfaces are
+insufficient. When those conditions are not met, omit the fact or report the
+capability gap.
+
+Specialized evidence-surface audits may intentionally use a separately
+constrained low-level read path when their required evidence classes are not
+available through ordinary surfaces. Investigations where provider API behavior
+is itself the subject may also inspect that API directly. Those workflows name
+the low-level surface and its safeguards as part of their task; they are not
+ordinary-repository fallback precedent.
+
+For overlap or collision risk, current `main`, relevant pull requests, target
+files, and specifically identified refs are normally sufficient. Do not require
+an inventory of every active branch, ref, workflow, or provider object unless
+the inventory itself is materially necessary to the decision.
+
 ## Triggers
 
 Classify triggers before using prior conversation, summaries, memory, or pasted

--- a/tests/test_minimum_sufficient_retrieval.py
+++ b/tests/test_minimum_sufficient_retrieval.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+
+def section(path: Path, heading: str) -> str:
+    contents = path.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^## {re.escape(heading)}\n(?P<body>.*?)(?=^## |\Z)",
+        contents,
+        re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        raise AssertionError(f"missing section: {heading}")
+    return " ".join(match.group("body").split())
+
+
+class MinimumSufficientRetrievalTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.retrieval = section(
+            DOCS / "source-first-retrieval.md", "Minimum-Sufficient Retrieval"
+        )
+        cls.readiness = section(
+            DOCS / "repo-readiness.md", "Command Form And Intent Visibility"
+        )
+        cls.prompts = section(DOCS / "prompts.md", "Repository Implementation Task")
+
+    def test_canonical_rule_binds_retrieval_to_the_decision(self):
+        for pattern in (
+            r"minimum sufficient authoritative evidence.*claim or decision",
+            r"evidence boundary.*before retrieval",
+            r"provider objects.*more authoritative",
+            r"not necessary.*omit.*speculative inventory",
+            r"materially necessary fact.*partial or blocked",
+        ):
+            self.assertRegex(self.retrieval, pattern)
+
+    def test_raw_provider_reads_require_a_concrete_material_fact(self):
+        for pattern in (
+            r"repository-native `git`.*high-level provider CLI.*connected GitHub",
+            r"absence of a high-level convenience command.*does not.*justify.*`gh api`",
+            r"lower-level provider read only when.*fact is materially necessary",
+            r"state the exact missing fact.*why it matters.*first-class surfaces",
+            r"Specialized evidence-surface audits.*constrained low-level read path",
+            r"provider API behavior.*itself the subject.*inspect that API directly",
+        ):
+            self.assertRegex(self.retrieval, pattern)
+
+    def test_collision_risk_does_not_require_a_provider_inventory(self):
+        for contents in (self.retrieval, self.prompts):
+            for phrase in (
+                "current `main`",
+                "relevant pull requests",
+                "target files",
+                "specifically identified refs",
+            ):
+                self.assertIn(phrase, contents)
+        self.assertIn(
+            "Do not inventory every branch, ref, workflow, or provider object",
+            self.prompts,
+        )
+
+    def test_prompt_and_command_guidance_route_to_the_canonical_rule(self):
+        self.assertIn(
+            "docs/source-first-retrieval.md#minimum-sufficient-retrieval",
+            self.prompts,
+        )
+        self.assertIn(
+            "source-first-retrieval.md#minimum-sufficient-retrieval",
+            self.readiness,
+        )
+        self.assertRegex(
+            self.readiness,
+            r"materially necessary fact.*minimum-sufficient retrieval.*lower-level read",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define minimum-sufficient authoritative evidence as the canonical source-first retrieval boundary
- prefer repository-native, first-class CLI, connected-source, and repository validation surfaces before bounded raw-provider reads
- update the implementation prompt and add semantic regression coverage for collision-risk retrieval

## Rationale

Source-first retrieval should establish the current claim or decision without expanding into speculative provider inventories. A missing convenience command is not sufficient reason to drop to a raw API; ordinary inspection must first identify a concrete material fact that normal supported surfaces cannot establish. Specialized evidence-surface audits and API-specific investigations remain distinct.

## Validation

- `make check` (Markdown lint and 350 tests)

Linear: CAK-184