### PR TITLE
CAK-179: add prompt and Dropbox workflow latches

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -586,6 +586,71 @@ selection consume only the decision record. Representative requests such as
 upstream evidence; they are neither transport selectors nor repeated inputs to
 the downstream stages.
 
+### Prompt freeze and transport-only latch
+
+Apply the interaction-mode action eligibility latch in
+[`repo-readiness.md`](repo-readiness.md#interaction-mode-action-eligibility-latch)
+before this delivery latch. This section constrains action eligibility around
+the canonical decision model and the existing file-backed handoff pilot; it is
+not a second delivery controller, graph, or prompt architecture.
+
+Use this semantic progression for an issue-owned machine-executor handoff:
+
+```text
+PROMPT_DESIGN -> PROMPT_FROZEN -> DROPBOX_TRANSPORT_ONLY
+```
+
+- `PROMPT_DESIGN` permits the selected source reads and prompt construction
+  authorized by orchestration/prompt-authoring mode.
+- `PROMPT_FROZEN` means the complete rendered bytes and their exact identity
+  are fixed for the attempt. Transport, diagnostics, preview, or operator
+  presentation may not revise them.
+- `DROPBOX_TRANSPORT_ONLY` begins when the frozen stages 5 through 7 record
+  selects the qualified issue-owned Dropbox route, file-backed presentation,
+  and thin-handoff renderer. It remains active through the selected delivery
+  outcome or a named blocked state.
+
+In `DROPBOX_TRANSPORT_ONLY`, the eligible operations are limited to the owning
+storage and transport contract: create the issue folder if absent, create one
+absent prompt file, verify provider identity and exact content or qualified
+integrity evidence, preview only when the selected presentation requires it,
+mint one fresh download link, and emit the compact retrieval handoff. The
+complete prompt stays out of chat. Repository or GitHub mutation, Linear
+mutation, unrelated provider or authentication changes, downstream execution,
+source hydration, repository analysis, prompt redesign or polish, issue
+editing, and inline complete-prompt rendering are ineligible. A failed
+ineligible action does not make an alternate syntax or retry eligible; this is
+an action-class boundary, not a rigid global tool-call cap.
+
+Do not ask for fresh permission for a routine Dropbox operation already
+authorized by the current human instruction and owning storage contract. Reuse
+successful connector-action evidence under the current
+[`connector-availability rule`](start-here.md#connector-availability-is-runtime-evidence);
+do not rediscover an already successful same action without one of that rule's
+recheck triggers.
+
+An operator correction replaces the incompatible active envelope and resumes
+from the nearest still-valid verified state. A material change to prompt
+requirements returns to `PROMPT_DESIGN` and produces a new frozen revision. A
+delivery or presentation correction that does not change prompt requirements
+retains the exact `PROMPT_FROZEN` bytes, invalidates incompatible pending
+renderers or actions, and enters or resumes `DROPBOX_TRANSPORT_ONLY` without
+replaying source hydration, capability discovery, or prompt design.
+
+Immediately before the external Dropbox write, surface one concise
+operator-visible transition stating that the prompt is frozen, Dropbox
+transport-only mode is active, and unrelated GitHub, Linear, and repository
+mutations are ineligible. This is observability under
+[`core-model.md`](core-model.md#operator-observability), not a permission
+request or per-tool narration.
+
+For the Prose-DAG pilot below, `PROMPT_FROZEN` satisfies the frozen-body part
+of `PROMPT_READY`; the pilot still performs its existing entry and route
+qualification. Once `ROUTE_QUALIFIED` selects the file-backed record,
+`DROPBOX_TRANSPORT_ONLY` constrains the eligible operations through
+`HANDOFF_EMITTED` or `BLOCKED`. The pilot graph and its transition receipts
+remain the execution record; these latches do not add another DAG.
+
 ### Issue-Owned File-Backed Handoff Prose-DAG Pilot
 
 This pilot is opt-in for a normal-use trial. For an explicitly activated
@@ -1093,7 +1158,8 @@ Retrieval:
   mergeability, and task fit are clear enough for the requested depth.
 
 Instructions:
-- Apply `docs/review-packet.md#direct-pr-inspection`.
+- Apply `docs/review-packet.md#direct-pr-inspection`, including its
+  connector-sufficient review latch.
 - Stay in review/audit mode unless the human explicitly changes the task.
 - Treat user summaries, completion reports, and pasted excerpts as navigation,
   not PR evidence.

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -171,6 +171,36 @@ Examples:
   orchestration/prompt-authoring mode until the human explicitly asks for
   implementation.
 
+### Interaction-mode action eligibility latch
+
+Mode selection constrains the current controller's eligible action classes; it
+is not only a label for the final response. Resolve the bounded deliverable from
+the current human instruction, materialize its allowed action set, and
+invalidate every incompatible pending action before the next tool call. A
+narrower current instruction replaces a broader active envelope from earlier
+conversation. Superseded plans, queued actions, fallback attempts, and failed
+out-of-scope operations retain no residual execution eligibility.
+
+A request whose bounded deliverable is a prompt or machine handoff selects
+orchestration/prompt-authoring mode for the current controller. Representative
+requests include `Prompt me to ...`, `Create the Codex prompt`, `Kick this off
+with Codex`, `Give me the handoff`, and `Put this prompt in Dropbox`. These are
+regression examples, not a phrase-matching classifier: the semantic deliverable
+controls. Once selected, the controller may perform only the reads needed to
+construct the prompt and the exact issue-owned preservation and delivery
+operations authorized by the task and owning storage contract. GitHub writes,
+repository mutation, Linear writes, unrelated provider changes,
+authentication changes, and downstream execution are ineligible unless the
+current human instruction explicitly adds that action class.
+
+Review/audit mode similarly invalidates implementation and local-reproduction
+plans unless the human explicitly authorizes those actions for the current
+review. Apply the narrower connector-backed rule in
+[`review-packet.md`](review-packet.md#connector-sufficient-review-latch) when a
+connector can supply the required review evidence. A material human change may
+select a new mode and action set; convergence, tool availability, a failed
+forbidden attempt, or broader conversational history cannot.
+
 Do not infer implementation mode from vague wording such as "fix this",
 "handle this", or "let's fix the bug" when the surrounding context suggests
 advisory review, audit, orchestration, or prompt generation.

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -205,6 +205,27 @@ If the human corrects tool or connector usage in the thread, treat that
 correction as a hard workflow constraint for subsequent similar review
 requests.
 
+### Connector-sufficient review latch
+
+Once review/audit mode is selected and the available connector supplies the
+exact PR head, changed files and relevant patches, checks, comments, reviews,
+mergeability, and task context needed for the requested review, restrict the
+eligible action set to those connector-backed reads and the chat response.
+Source-first retrieval does not require independent local reproduction when
+the authoritative review surface is already sufficient.
+
+Clone, checkout, worktree creation, repository or local-filesystem mutation,
+local test execution, temporary-repository setup, and cleanup commands are
+ineligible unless the current human instruction explicitly requests
+independent local reproduction. Selecting the connector-backed review path
+invalidates any previously considered local-execution plan before another tool
+call. If an out-of-scope action is attempted and fails, do not retry the same
+forbidden action class with another command, syntax, wrapper, or cleanup plan.
+
+When a concrete evidence gap remains after connector inspection, report the
+exact missing evidence first. Propose local reproduction only as a separately
+authorized next step; do not perform it from review/audit authority.
+
 ## Single-Operator Review Posture
 
 When a repository ecosystem fits the single-operator posture in

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -84,10 +84,14 @@ Never explain inability to perform an operation by speculating about connector
 availability. A successful connector invocation in the current conversation is
 positive evidence that the connector remains available; successful use of a
 specific capability is positive evidence that the capability remains
-available. Do not contradict that evidence unless a subsequent connector
-inspection or invocation demonstrates otherwise. Prior use of a different
-action does not establish that a requested read or write capability exists, so
-inspect or attempt the relevant operation before reaching that conclusion.
+available. After one connector action succeeds in the current execution
+context, do not rediscover or re-probe that same action before using it again.
+Recheck only when the action later fails, the acting identity or connection
+changes, the next step requires a materially different capability, or the
+provider reports drift. Do not contradict still-current success evidence
+without one of those triggers. Prior use of a different action does not
+establish that a requested read or write capability exists, so inspect or
+attempt the relevant operation before reaching that conclusion.
 
 ## Canonical Ownership
 

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -190,6 +190,11 @@ Apply the complete shared
 [`prompt delivery decision model`](../prompts.md#prompt-delivery-decision-model),
 with the transport rules in
 [`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation).
+Apply its shared
+[`prompt freeze and transport-only latch`](../prompts.md#prompt-freeze-and-transport-only-latch)
+without copying the state or action allowlist into this adapter. ChatGPT
+consumes that canonical frozen state and projects only the selected connector
+actions and response surface.
 Record the human operator or viewer and the executable prompt's execution
 recipient as independent stage outputs before inspecting capability. The fact
 that the operator asks to receive, view, or be given a handoff is evidence

--- a/tests/test_workflow_action_latches.py
+++ b/tests/test_workflow_action_latches.py
@@ -1,0 +1,385 @@
+from dataclasses import dataclass, replace
+from enum import Enum
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO_READINESS = ROOT / "docs" / "repo-readiness.md"
+PROMPTS = ROOT / "docs" / "prompts.md"
+START_HERE = ROOT / "docs" / "start-here.md"
+REVIEW_PACKET = ROOT / "docs" / "review-packet.md"
+CHATGPT_ADAPTER = ROOT / "docs" / "tool-adapters" / "chatgpt.md"
+
+
+class Mode(str, Enum):
+    PROMPT_AUTHORING = "orchestration/prompt-authoring"
+    REVIEW_AUDIT = "review/audit"
+
+
+class PromptState(str, Enum):
+    DESIGN = "PROMPT_DESIGN"
+    FROZEN = "PROMPT_FROZEN"
+    DROPBOX_TRANSPORT_ONLY = "DROPBOX_TRANSPORT_ONLY"
+    HANDED_OFF = "HANDOFF_EMITTED"
+
+
+class Action(str, Enum):
+    READ_ISSUE = "read-issue"
+    READ_REPOSITORY = "read-repository"
+    READ_GITHUB_PR = "read-github-pr"
+    HYDRATE_SOURCES = "hydrate-sources"
+    FREEZE_PROMPT = "freeze-prompt"
+    EDIT_PROMPT = "edit-prompt"
+    DISCOVER_CONNECTOR = "discover-connector"
+    REQUEST_PERMISSION = "request-permission"
+    CREATE_ISSUE_FOLDER = "create-issue-folder"
+    CREATE_PROMPT_FILE = "create-prompt-file"
+    VERIFY_PROMPT = "verify-prompt"
+    PREVIEW_PROMPT = "preview-prompt"
+    MINT_DOWNLOAD_LINK = "mint-download-link"
+    EMIT_HANDOFF = "emit-handoff"
+    RENDER_INLINE = "render-inline"
+    GITHUB_WRITE = "github-write"
+    LINEAR_WRITE = "linear-write"
+    REPOSITORY_MUTATION = "repository-mutation"
+    PROVIDER_CONFIGURATION = "provider-configuration"
+    AUTHENTICATION_MUTATION = "authentication-mutation"
+    DOWNSTREAM_EXECUTION = "downstream-execution"
+    CLONE = "clone"
+    CHECKOUT = "checkout"
+    CREATE_WORKTREE = "create-worktree"
+    RUN_LOCAL_TESTS = "run-local-tests"
+    CREATE_TEMP_REPOSITORY = "create-temp-repository"
+    CLEANUP_TEMP_REPOSITORY = "cleanup-temp-repository"
+    SHELL_WRAPPER = "shell-wrapper"
+
+
+PROMPT_READS = {
+    Action.READ_ISSUE,
+    Action.READ_REPOSITORY,
+    Action.READ_GITHUB_PR,
+    Action.HYDRATE_SOURCES,
+}
+TRANSPORT_ACTIONS = {
+    Action.CREATE_ISSUE_FOLDER,
+    Action.CREATE_PROMPT_FILE,
+    Action.VERIFY_PROMPT,
+    Action.PREVIEW_PROMPT,
+    Action.MINT_DOWNLOAD_LINK,
+    Action.EMIT_HANDOFF,
+}
+PROMPT_MUTATION_FORBIDDEN = {
+    Action.GITHUB_WRITE,
+    Action.LINEAR_WRITE,
+    Action.REPOSITORY_MUTATION,
+    Action.PROVIDER_CONFIGURATION,
+    Action.AUTHENTICATION_MUTATION,
+    Action.DOWNSTREAM_EXECUTION,
+}
+LOCAL_REPRODUCTION_ACTIONS = {
+    Action.CLONE,
+    Action.CHECKOUT,
+    Action.CREATE_WORKTREE,
+    Action.REPOSITORY_MUTATION,
+    Action.RUN_LOCAL_TESTS,
+    Action.CREATE_TEMP_REPOSITORY,
+    Action.CLEANUP_TEMP_REPOSITORY,
+    Action.SHELL_WRAPPER,
+}
+
+
+@dataclass(frozen=True)
+class ControllerLatch:
+    """Test-only conformance evaluator for post-classification action eligibility."""
+
+    mode: Mode
+    model_route: str
+    prompt_state: PromptState | None = None
+    frozen_prompt_digest: str | None = None
+    connector_evidence_complete: bool = False
+    local_reproduction_authorized: bool = False
+    proven_connector_actions: frozenset[str] = frozenset()
+    invalidated_actions: frozenset[Action] = frozenset()
+
+    @classmethod
+    def prompt_authoring(cls, *, model_route: str):
+        return cls(
+            mode=Mode.PROMPT_AUTHORING,
+            model_route=model_route,
+            prompt_state=PromptState.DESIGN,
+        )
+
+    @classmethod
+    def review(cls, *, connector_evidence_complete: bool):
+        return cls(
+            mode=Mode.REVIEW_AUDIT,
+            model_route="review-model",
+            connector_evidence_complete=connector_evidence_complete,
+            invalidated_actions=frozenset(LOCAL_REPRODUCTION_ACTIONS),
+        )
+
+    def eligible_actions(self):
+        if self.mode is Mode.REVIEW_AUDIT:
+            actions = {Action.READ_GITHUB_PR}
+            if self.local_reproduction_authorized:
+                actions |= LOCAL_REPRODUCTION_ACTIONS - {Action.SHELL_WRAPPER}
+            return actions - set(self.invalidated_actions)
+
+        if self.prompt_state is PromptState.DESIGN:
+            return (PROMPT_READS | {Action.FREEZE_PROMPT}) - set(
+                self.invalidated_actions
+            )
+        if self.prompt_state is PromptState.FROZEN:
+            return {Action.EDIT_PROMPT} - set(self.invalidated_actions)
+        if self.prompt_state is PromptState.DROPBOX_TRANSPORT_ONLY:
+            return TRANSPORT_ACTIONS - set(self.invalidated_actions)
+        return set()
+
+    def assert_eligible(self, action):
+        if action not in self.eligible_actions():
+            raise ValueError(f"ineligible action: {action.value}")
+
+    def freeze(self, digest):
+        if self.prompt_state is not PromptState.DESIGN or not digest:
+            raise ValueError("prompt can freeze only from design with an exact digest")
+        return replace(
+            self,
+            prompt_state=PromptState.FROZEN,
+            frozen_prompt_digest=digest,
+            invalidated_actions=self.invalidated_actions
+            | frozenset(PROMPT_MUTATION_FORBIDDEN),
+        )
+
+    def enter_dropbox_transport(self):
+        if self.prompt_state is not PromptState.FROZEN:
+            raise ValueError("transport-only requires frozen prompt bytes")
+        return replace(
+            self,
+            prompt_state=PromptState.DROPBOX_TRANSPORT_ONLY,
+            invalidated_actions=self.invalidated_actions
+            | frozenset(
+                {
+                    Action.HYDRATE_SOURCES,
+                    Action.EDIT_PROMPT,
+                    Action.DISCOVER_CONNECTOR,
+                    Action.REQUEST_PERMISSION,
+                    Action.RENDER_INLINE,
+                }
+            ),
+        )
+
+    def revise_prompt(self, digest, *, material_requirement_change):
+        if not material_requirement_change:
+            raise ValueError("transport correction cannot revise frozen prompt bytes")
+        return replace(
+            self,
+            prompt_state=PromptState.FROZEN,
+            frozen_prompt_digest=digest,
+            invalidated_actions=self.invalidated_actions
+            | frozenset(PROMPT_MUTATION_FORBIDDEN),
+        )
+
+    def connector_discovery_required(
+        self,
+        action_name,
+        *,
+        later_failure=False,
+        acting_identity_changed=False,
+        materially_different_capability=False,
+        provider_drift=False,
+    ):
+        if action_name not in self.proven_connector_actions:
+            return True
+        return any(
+            (
+                later_failure,
+                acting_identity_changed,
+                materially_different_capability,
+                provider_drift,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class PromptHandoffEvidence:
+    expected_file_id: str
+    observed_file_id: str
+    expected_size: int
+    observed_size: int
+    expected_sha256: str
+    observed_sha256: str
+    download_url: str
+    retrieval_succeeded: bool = True
+    collision: bool = False
+
+    def compact_handoff(self):
+        if not self.retrieval_succeeded:
+            raise ValueError("prompt retrieval failed")
+        if self.collision:
+            raise ValueError("prompt destination collision")
+        if self.observed_file_id != self.expected_file_id:
+            raise ValueError("Dropbox identity mismatch")
+        if self.observed_size != self.expected_size:
+            raise ValueError("prompt size mismatch")
+        if self.observed_sha256 != self.expected_sha256:
+            raise ValueError("prompt digest mismatch")
+        if not self.download_url:
+            raise ValueError("fresh download URL missing")
+        return (
+            f"Download: {self.download_url}\n"
+            f"Dropbox ID: {self.observed_file_id}\n"
+            f"Expected bytes: {self.observed_size}\n"
+            f"Expected SHA-256: {self.observed_sha256}\n"
+        )
+
+
+class WorkflowActionLatchTests(unittest.TestCase):
+    def test_docs_assign_each_latch_to_one_existing_owner(self):
+        repo_readiness = REPO_READINESS.read_text(encoding="utf-8")
+        prompts = PROMPTS.read_text(encoding="utf-8")
+        start_here = START_HERE.read_text(encoding="utf-8")
+        review_packet = REVIEW_PACKET.read_text(encoding="utf-8")
+        chatgpt = CHATGPT_ADAPTER.read_text(encoding="utf-8")
+
+        self.assertIn("### Interaction-mode action eligibility latch", repo_readiness)
+        self.assertIn("### Prompt freeze and transport-only latch", prompts)
+        self.assertIn("### Connector-sufficient review latch", review_packet)
+        self.assertIn("do not rediscover or re-probe that same action", start_here)
+        self.assertIn(
+            "prompt freeze and transport-only latch", chatgpt.lower()
+        )
+        self.assertNotIn("PROMPT_DESIGN -> PROMPT_FROZEN", chatgpt)
+
+    def test_prompt_authoring_allowlist_is_model_independent(self):
+        for model_route in ("stronger", "lower-cost"):
+            latch = ControllerLatch.prompt_authoring(model_route=model_route)
+            self.assertEqual(latch.mode, Mode.PROMPT_AUTHORING)
+            self.assertTrue(PROMPT_MUTATION_FORBIDDEN.isdisjoint(latch.eligible_actions()))
+
+            frozen = latch.freeze("sha256:prompt-v1")
+            transport = frozen.enter_dropbox_transport()
+            self.assertEqual(transport.frozen_prompt_digest, "sha256:prompt-v1")
+            self.assertEqual(transport.eligible_actions(), TRANSPORT_ACTIONS)
+            self.assertTrue(
+                PROMPT_MUTATION_FORBIDDEN.isdisjoint(transport.eligible_actions())
+            )
+
+    def test_material_constraint_change_revises_only_prompt_bytes(self):
+        frozen = ControllerLatch.prompt_authoring(model_route="stronger").freeze(
+            "sha256:prompt-v1"
+        )
+        revised = frozen.revise_prompt(
+            "sha256:prompt-v2", material_requirement_change=True
+        )
+
+        self.assertNotEqual(frozen.frozen_prompt_digest, revised.frozen_prompt_digest)
+        self.assertNotIn(Action.LINEAR_WRITE, revised.eligible_actions())
+        self.assertNotIn(Action.REPOSITORY_MUTATION, revised.eligible_actions())
+
+    def test_dropbox_correction_reuses_frozen_state_and_connector_evidence(self):
+        frozen = replace(
+            ControllerLatch.prompt_authoring(model_route="lower-cost").freeze(
+                "sha256:prompt-v1"
+            ),
+            proven_connector_actions=frozenset(
+                {
+                    "dropbox.create_file",
+                    "dropbox.get_file_metadata",
+                    "dropbox.download_link",
+                }
+            ),
+        )
+        transport = frozen.enter_dropbox_transport()
+
+        self.assertEqual(transport.frozen_prompt_digest, frozen.frozen_prompt_digest)
+        for action in (
+            Action.REQUEST_PERMISSION,
+            Action.HYDRATE_SOURCES,
+            Action.DISCOVER_CONNECTOR,
+            Action.RENDER_INLINE,
+        ):
+            with self.assertRaisesRegex(ValueError, "ineligible action"):
+                transport.assert_eligible(action)
+        self.assertFalse(
+            transport.connector_discovery_required("dropbox.create_file")
+        )
+        self.assertTrue(
+            transport.connector_discovery_required(
+                "dropbox.create_file", provider_drift=True
+            )
+        )
+
+    def test_transport_trace_is_exact_and_handoff_contains_no_prompt_body(self):
+        transport = ControllerLatch.prompt_authoring(model_route="stronger").freeze(
+            "sha256:prompt-v1"
+        ).enter_dropbox_transport()
+        trace = (
+            Action.CREATE_ISSUE_FOLDER,
+            Action.CREATE_PROMPT_FILE,
+            Action.VERIFY_PROMPT,
+            Action.PREVIEW_PROMPT,
+            Action.MINT_DOWNLOAD_LINK,
+            Action.EMIT_HANDOFF,
+        )
+        for action in trace:
+            transport.assert_eligible(action)
+
+        self.assertEqual(trace.count(Action.CREATE_PROMPT_FILE), 1)
+        self.assertEqual(trace.count(Action.MINT_DOWNLOAD_LINK), 1)
+        self.assertNotIn(Action.RENDER_INLINE, trace)
+
+        evidence = PromptHandoffEvidence(
+            expected_file_id="id:prompt-v1",
+            observed_file_id="id:prompt-v1",
+            expected_size=13761,
+            observed_size=13761,
+            expected_sha256="8cc802ede64d9454f50aa533b0316b076072c35f7303efeba8857747c3949363",
+            observed_sha256="8cc802ede64d9454f50aa533b0316b076072c35f7303efeba8857747c3949363",
+            download_url="https://dropbox.example/single-use",
+        )
+        handoff = evidence.compact_handoff()
+        self.assertIn("Dropbox ID: id:prompt-v1", handoff)
+        self.assertIn("Expected bytes: 13761", handoff)
+        self.assertIn("Expected SHA-256: 8cc802ed", handoff)
+        self.assertNotIn("complete prompt body", handoff)
+
+    def test_prompt_handoff_integrity_failures_are_terminal(self):
+        valid = PromptHandoffEvidence(
+            expected_file_id="id:prompt-v1",
+            observed_file_id="id:prompt-v1",
+            expected_size=100,
+            observed_size=100,
+            expected_sha256="a" * 64,
+            observed_sha256="a" * 64,
+            download_url="https://dropbox.example/single-use",
+        )
+        failures = (
+            (replace(valid, retrieval_succeeded=False), "retrieval failed"),
+            (replace(valid, collision=True), "destination collision"),
+            (replace(valid, observed_file_id="id:other"), "identity mismatch"),
+            (replace(valid, observed_size=99), "size mismatch"),
+            (replace(valid, observed_sha256="b" * 64), "digest mismatch"),
+            (replace(valid, download_url=""), "download URL missing"),
+        )
+        for evidence, message in failures:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    evidence.compact_handoff()
+
+    def test_connector_sufficient_review_invalidates_local_execution_plan(self):
+        review = ControllerLatch.review(connector_evidence_complete=True)
+        self.assertEqual(review.eligible_actions(), {Action.READ_GITHUB_PR})
+
+        for action in LOCAL_REPRODUCTION_ACTIONS:
+            with self.assertRaisesRegex(ValueError, "ineligible action"):
+                review.assert_eligible(action)
+
+        # A failed forbidden clone cannot make alternate clone or cleanup forms eligible.
+        for retry in (Action.CLONE, Action.SHELL_WRAPPER, Action.CLEANUP_TEMP_REPOSITORY):
+            with self.assertRaisesRegex(ValueError, "ineligible action"):
+                review.assert_eligible(retry)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- latch orchestration/prompt-authoring requests to a narrow action allowlist that invalidates incompatible pending work
- freeze prompt bytes before a Dropbox transport-only phase, reuse valid correction and connector state, and keep the existing delivery model and Prose-DAG authoritative
- prevent connector-sufficient PR reviews from drifting into clone, worktree, local-test, or cleanup actions
- add behavioral conformance coverage for prompt, transport, integrity, correction, model-route, and review-drift scenarios

## Rationale

Addresses CAK-179 without introducing a second workflow controller or duplicating the canonical transport architecture.

## Validation

- `make check` (Markdown lint and 358 tests)

Issue: CAK-179