### PR TITLE
CAK-212: clarify connector confirmation boundary

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -622,9 +622,13 @@ editing, and inline complete-prompt rendering are ineligible. A failed
 ineligible action does not make an alternate syntax or retry eligible; this is
 an action-class boundary, not a rigid global tool-call cap.
 
-Do not ask for fresh permission for a routine Dropbox operation already
-authorized by the current human instruction and owning storage contract. Reuse
-successful connector-action evidence under the current
+Do not invent a fresh Playbook approval for a routine Dropbox operation already
+authorized by the current human instruction and owning storage contract. This
+does not waive a confirmation that the current connector action contract
+requires after presenting its exact mutation plan. That confirmation is an
+external runtime prerequisite for the connector operation, not missing task
+authorization or a prompt-approval gate. Reuse successful connector-action
+evidence under the current
 [`connector-availability rule`](start-here.md#connector-availability-is-runtime-evidence);
 do not rediscover an already successful same action without one of that rule's
 recheck triggers.
@@ -675,6 +679,18 @@ eight stages. A record with another selection outside an explicitly activated
 attempt remains under the canonical decision model and does not enter this
 graph. No recipient is eligible unless its adapter explicitly activates this
 pilot.
+
+When the current connector action contract mandates explicit confirmation
+after its exact create plan is presented, the original handoff request still
+supplies task authorization but cannot satisfy that later runtime prerequisite.
+Record `PROMPT_READY -> BLOCKED` before any create action, name the connector-
+mandated confirmation as the blocker, and keep inline rendering and unrelated
+mutations ineligible. Ask only for the confirmation the connector contract
+requires; do not ask whether the prompt or Dropbox workflow is approved again.
+After confirmation, issue a correction revision that retains `PROMPT_READY`,
+the frozen prompt identity, recipient, issue destination, and all still-current
+route evidence, then resume qualification and transport. Do not repeat source
+hydration or prompt design, and do not add a confirmation-specific graph state.
 
 Once explicitly activated, use this fixed last-mile graph:
 
@@ -760,8 +776,11 @@ the operator or viewer identity:
 
 Preview is not raw-byte verification, approval, a send gate, delivery evidence,
 executor acknowledgement, a coordination state, or authority. A connector
-confirmation needed to create or preview the file authorizes only that
-connector operation, not a separate prompt-approval workflow.
+confirmation needed after the exact create or preview plan is an external
+runtime prerequisite. It authorizes only the named connector operation, does
+not repair missing task authorization, and is not a separate prompt-approval
+workflow. A Playbook-authorized operation remains blocked when that prerequisite
+is unsatisfied; Playbook prose cannot waive it.
 
 Prompt governance is a separate selection. A material prompt that passes its
 admission test additionally applies the

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -180,9 +180,24 @@ owning workflow requires it. If the client renders a card from the write action
 itself, classify that as client-enforced UI, avoid redundant preview calls or
 model narration, and report the limitation when material rather than claiming
 the card was suppressed. Current
-[OpenAI Apps guidance](https://help.openai.com/en/articles/11487775-connectors-in)
-documents rich in-chat app experiences and write confirmations, but does not
-establish a universal per-action client-rendering suppression control.
+[OpenAI Apps guidance](https://help.openai.com/en/articles/11487775), checked
+2026-09-03, documents that permission options may include `Allow all actions`
+for an eligible app or account, while availability is app- and account-specific
+and some safety or workspace protections still apply. Treat the effective
+setting and the exact action contract as runtime evidence; this repository
+cannot configure either one or infer that a general permission setting waives
+a more specific action requirement.
+
+When the current Dropbox `create_folder` or `create_file` action contract, as
+observed 2026-09-03, unconditionally requires the assistant to present the
+exact mutation plan and obtain explicit confirmation in chat, that contract
+owns the prerequisite for the attempt. The original `prompt me` request
+remains sufficient task authorization under the Playbook, but it precedes the
+required plan and therefore cannot satisfy that post-plan connector
+confirmation. Apply the shared pilot's
+existing `BLOCKED` and correction path until the prerequisite is satisfied;
+do not reinterpret the interruption as missing task authority, add another
+approval gate, or switch the machine recipient to inline prompt delivery.
 
 ### Recipient-Capability Prompt Presentation
 
@@ -222,9 +237,11 @@ but do not reinterpret it as route disqualification. Use the authorized file
 route, present the card produced by the write when available, and immediately
 provide the target-shaped handoff. A separate preview or open action remains
 optional under the connected-app rules above. Do not wait for prompt approval
-or require the operator to open a preview; connector confirmation authorizes
-only its file operation. File-card and preview behavior is product-dependent
-runtime evidence, so recheck the relevant action.
+or require the operator to open a preview. If the selected create action has
+the post-plan confirmation contract described above, pause on that external
+prerequisite and resume the shared transport path after it is satisfied;
+confirmation authorizes only its file operation. File-card and preview behavior
+is product-dependent runtime evidence, so recheck the relevant action.
 
 For the explicitly activated CAK-209 normal-use Codex trial, ChatGPT applies the
 shared

--- a/tests/test_workflow_action_latches.py
+++ b/tests/test_workflow_action_latches.py
@@ -22,6 +22,11 @@ class PromptState(str, Enum):
     FROZEN = "PROMPT_FROZEN"
     DROPBOX_TRANSPORT_ONLY = "DROPBOX_TRANSPORT_ONLY"
     HANDED_OFF = "HANDOFF_EMITTED"
+    BLOCKED = "BLOCKED"
+
+
+class RuntimePrerequisite(str, Enum):
+    CONNECTOR_MUTATION_CONFIRMATION = "connector-mutation-confirmation"
 
 
 class Action(str, Enum):
@@ -97,6 +102,10 @@ class ControllerLatch:
     model_route: str
     prompt_state: PromptState | None = None
     frozen_prompt_digest: str | None = None
+    task_authorized: bool = False
+    hydration_revision: int = 0
+    prompt_design_revision: int = 0
+    runtime_blocker: RuntimePrerequisite | None = None
     connector_evidence_complete: bool = False
     local_reproduction_authorized: bool = False
     proven_connector_actions: frozenset[str] = frozenset()
@@ -108,6 +117,9 @@ class ControllerLatch:
             mode=Mode.PROMPT_AUTHORING,
             model_route=model_route,
             prompt_state=PromptState.DESIGN,
+            task_authorized=True,
+            hydration_revision=1,
+            prompt_design_revision=1,
         )
 
     @classmethod
@@ -167,6 +179,28 @@ class ControllerLatch:
                     Action.RENDER_INLINE,
                 }
             ),
+        )
+
+    def block_on_connector_confirmation(self):
+        if self.prompt_state is not PromptState.FROZEN or not self.task_authorized:
+            raise ValueError("connector confirmation block requires authorized prompt")
+        return replace(
+            self,
+            prompt_state=PromptState.BLOCKED,
+            runtime_blocker=RuntimePrerequisite.CONNECTOR_MUTATION_CONFIRMATION,
+        )
+
+    def confirm_connector_mutation(self):
+        if (
+            self.prompt_state is not PromptState.BLOCKED
+            or self.runtime_blocker
+            is not RuntimePrerequisite.CONNECTOR_MUTATION_CONFIRMATION
+        ):
+            raise ValueError("connector confirmation is not required")
+        return replace(
+            self,
+            prompt_state=PromptState.FROZEN,
+            runtime_blocker=None,
         )
 
     def revise_prompt(self, digest, *, material_requirement_change):
@@ -309,6 +343,56 @@ class WorkflowActionLatchTests(unittest.TestCase):
                 "dropbox.create_file", provider_drift=True
             )
         )
+
+    def test_connector_confirmation_blocks_then_resumes_frozen_transport(self):
+        frozen = ControllerLatch.prompt_authoring(model_route="stronger").freeze(
+            "sha256:prompt-v1"
+        )
+        blocked = frozen.block_on_connector_confirmation()
+        self.assertEqual(blocked.prompt_state, PromptState.BLOCKED)
+        self.assertTrue(blocked.task_authorized)
+        self.assertEqual(
+            blocked.runtime_blocker,
+            RuntimePrerequisite.CONNECTOR_MUTATION_CONFIRMATION,
+        )
+        self.assertEqual(blocked.eligible_actions(), set())
+
+        resumed = blocked.confirm_connector_mutation().enter_dropbox_transport()
+        self.assertEqual(resumed.prompt_state, PromptState.DROPBOX_TRANSPORT_ONLY)
+        self.assertEqual(resumed.runtime_blocker, None)
+        self.assertEqual(resumed.frozen_prompt_digest, blocked.frozen_prompt_digest)
+        self.assertEqual(resumed.hydration_revision, blocked.hydration_revision)
+        self.assertEqual(
+            resumed.prompt_design_revision,
+            blocked.prompt_design_revision,
+        )
+
+        issue_folder_exists = False
+        transport_trace = (
+            (() if issue_folder_exists else (Action.CREATE_ISSUE_FOLDER,))
+            + (
+                Action.CREATE_PROMPT_FILE,
+                Action.VERIFY_PROMPT,
+                Action.MINT_DOWNLOAD_LINK,
+                Action.EMIT_HANDOFF,
+            )
+        )
+        self.assertEqual(
+            transport_trace,
+            (
+                Action.CREATE_ISSUE_FOLDER,
+                Action.CREATE_PROMPT_FILE,
+                Action.VERIFY_PROMPT,
+                Action.MINT_DOWNLOAD_LINK,
+                Action.EMIT_HANDOFF,
+            ),
+        )
+        for action in transport_trace:
+            resumed.assert_eligible(action)
+        self.assertTrue(PROMPT_MUTATION_FORBIDDEN.isdisjoint(transport_trace))
+        self.assertNotIn(Action.HYDRATE_SOURCES, transport_trace)
+        self.assertNotIn(Action.EDIT_PROMPT, transport_trace)
+        self.assertNotIn(Action.RENDER_INLINE, transport_trace)
 
     def test_transport_trace_is_exact_and_handoff_contains_no_prompt_body(self):
         transport = ControllerLatch.prompt_authoring(model_route="stronger").freeze(


### PR DESCRIPTION
## Summary
- Keep prompt me as sufficient task authorization for the bounded issue-owned handoff.
- Identify the current Dropbox create action contract as the authoritative owner of its post-plan confirmation prerequisite.
- Preserve the existing BLOCKED and correction path with no inline fallback, prompt redesign, or source rehydration.
- Add a structural regression for the absent-folder block-and-resume scenario.

## Outcome
The repository cannot enable one-turn authorization for the current Dropbox create actions. OpenAI app permissions may reduce confirmations for eligible apps or accounts, but the live create_folder and create_file contracts still mandate explicit confirmation after the exact mutation plan and expose no repository-owned override.

## Validation
- make check

Linear: [CAK-212](https://linear.app/ctrl-alt-keith/issue/CAK-212/reconcile-connector-mandated-dropbox-write-confirmation-with-prompt-me)