### PR TITLE
CAK-218: clarify combined doctrine promotion authority

### DIFF
--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -287,10 +287,10 @@ human intent are unambiguous. The decision is semantic: it requires neither
 promotion-specific wording nor duplicate authorization, and its durable record
 may faithfully record the existing instruction.
 
-Do not infer that combined authority from generic approval, an ambiguous
-referent, changed identity, an incomplete prerequisite, automation, or
-non-human evidence. Those cases remain separate or fail closed; merge execution
-never supplies missing promotion authority.
+Do not infer that combined authority from generic approval, ambiguity in the
+referent, human intent, or normative effect, changed identity, an incomplete
+prerequisite, automation, or non-human evidence. Those cases remain separate or
+fail closed; merge execution never supplies missing promotion authority.
 
 ### Classification examples
 

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -270,9 +270,8 @@ provenance vocabulary:
    validation, open questions, and exact implementation artifact without
    copying the full evidence history into doctrine.
 6. Obtain an explicit human promotion decision against the exact reviewed
-   artifact. A reviewer verdict, finding resolution, validation result,
-   approval or execution capability, repository or CI state, automation, merge
-   mechanics, or a merge result does not grant that authority.
+   artifact. Review, validation, repository or CI state, automation, tool
+   capability, merge mechanics, and merge results grant no such authority.
 7. After the repository transition, retrieve the integrated identity and
    preserve the promotion decision and provenance. Rejected, demoted,
    withdrawn, and superseded material retains its historical status under the
@@ -281,33 +280,17 @@ provenance vocabulary:
 The human promotion decision may share a pull request with implementation when
 the approval-identity rules in
 [`review-packet.md`](review-packet.md#approval-identity-and-ownership) are
-satisfied. The decision must unambiguously accept the exact reviewed artifact
-and its established normative effect, but it does not require the literal words
-`promote` or `promotion`, a fixed sentence form, or a second authorization.
+satisfied. After every required prerequisite is satisfied, one explicit human
+instruction may both promote the exact reviewed artifact and authorize its
+merge when the artifact, unchanged semantic identity, normative effect, and
+human intent are unambiguous. The decision is semantic: it requires neither
+promotion-specific wording nor duplicate authorization, and its durable record
+may faithfully record the existing instruction.
 
-After every required promotion prerequisite is satisfied, one explicit human
-instruction may both constitute that promotion decision and authorize merge of
-the exact reviewed artifact. This combined interpretation is valid only when
-the current context makes the human intent, exact artifact, unchanged semantic
-identity, and accepted normative effect unambiguous. The durable workflow
-record may faithfully record both effects of that existing instruction; making
-the record must not require the human to repeat the decision.
-
-Do not infer the combined decision from generic approval, an ambiguous
-referent, a changed artifact identity, incomplete review, unresolved findings,
-an applicable re-review that has not completed, automation-originated action,
-or non-human evidence. Keep promotion and merge authority separate or fail
-closed when either intent is unclear. A merge operation or result never creates
-promotion authority independently of the explicit human decision it executes.
-
-| Current context and instruction | Doctrine-promotion result |
-| --- | --- |
-| Required review and disposition are complete for exact unchanged head `H`; the human explicitly instructs merge of that reviewed PR | The instruction may be recorded as promotion of `H` and merge authorization without a second formulaic statement |
-| Exact reviewed material PR `P` and dependent PR `E` are established with their order; the human explicitly instructs merge of both | The instruction may promote `P` and authorize both merges in the established order |
-| Governed review or finding disposition remains incomplete | Merge wording does not waive the prerequisite; promotion and merge remain blocked |
-| Review covered `H1`, but the proposed semantic artifact is now `H2` | Do not extend the decision to `H2`; apply the normal changed-identity and re-review contract |
-| More than one candidate artifact is in context and the referent is unclear | Do not choose an artifact on the human's behalf; resolve the ambiguity before promotion or merge |
-| CI, a reviewer verdict, mergeability, tool capability, or automation is the only positive signal | No human doctrine-promotion authority exists |
+Do not infer that combined authority from generic approval, an ambiguous
+referent, changed identity, an incomplete prerequisite, automation, or
+non-human evidence. Those cases remain separate or fail closed; merge execution
+never supplies missing promotion authority.
 
 ### Classification examples
 

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -271,8 +271,8 @@ provenance vocabulary:
    copying the full evidence history into doctrine.
 6. Obtain an explicit human promotion decision against the exact reviewed
    artifact. A reviewer verdict, finding resolution, validation result,
-   approval capability, execution capability, or merge result does not grant
-   that authority.
+   approval or execution capability, repository or CI state, automation, merge
+   mechanics, or a merge result does not grant that authority.
 7. After the repository transition, retrieve the integrated identity and
    preserve the promotion decision and provenance. Rejected, demoted,
    withdrawn, and superseded material retains its historical status under the
@@ -281,9 +281,33 @@ provenance vocabulary:
 The human promotion decision may share a pull request with implementation when
 the approval-identity rules in
 [`review-packet.md`](review-packet.md#approval-identity-and-ownership) are
-satisfied. It must state that the exact artifact is promoted and what reusable
-guidance becomes authoritative; ordinary approval or merge without that record
-is not doctrine promotion.
+satisfied. The decision must unambiguously accept the exact reviewed artifact
+and its established normative effect, but it does not require the literal words
+`promote` or `promotion`, a fixed sentence form, or a second authorization.
+
+After every required promotion prerequisite is satisfied, one explicit human
+instruction may both constitute that promotion decision and authorize merge of
+the exact reviewed artifact. This combined interpretation is valid only when
+the current context makes the human intent, exact artifact, unchanged semantic
+identity, and accepted normative effect unambiguous. The durable workflow
+record may faithfully record both effects of that existing instruction; making
+the record must not require the human to repeat the decision.
+
+Do not infer the combined decision from generic approval, an ambiguous
+referent, a changed artifact identity, incomplete review, unresolved findings,
+an applicable re-review that has not completed, automation-originated action,
+or non-human evidence. Keep promotion and merge authority separate or fail
+closed when either intent is unclear. A merge operation or result never creates
+promotion authority independently of the explicit human decision it executes.
+
+| Current context and instruction | Doctrine-promotion result |
+| --- | --- |
+| Required review and disposition are complete for exact unchanged head `H`; the human explicitly instructs merge of that reviewed PR | The instruction may be recorded as promotion of `H` and merge authorization without a second formulaic statement |
+| Exact reviewed material PR `P` and dependent PR `E` are established with their order; the human explicitly instructs merge of both | The instruction may promote `P` and authorize both merges in the established order |
+| Governed review or finding disposition remains incomplete | Merge wording does not waive the prerequisite; promotion and merge remain blocked |
+| Review covered `H1`, but the proposed semantic artifact is now `H2` | Do not extend the decision to `H2`; apply the normal changed-identity and re-review contract |
+| More than one candidate artifact is in context and the referent is unclear | Do not choose an artifact on the human's behalf; resolve the ambiguity before promotion or merge |
+| CI, a reviewer verdict, mergeability, tool capability, or automation is the only positive signal | No human doctrine-promotion authority exists |
 
 ### Classification examples
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -46,12 +46,11 @@ human-owned approval record. Link the human decision to that identity and state
 the authority it grants and the next action it permits.
 
 Execution systems may prepare a packet and identify the approval being
-requested. They may faithfully record the authority already expressed by an
-explicit human instruction when its decision, exact artifact, and granted
-authority are unambiguous, but they must not author, mutate, backfill, broaden,
-or silently infer human approval. For the narrower case where one human
-instruction may constitute doctrine promotion and merge authorization, apply
-[`feature-lifecycle.md#doctrine-promotion`](feature-lifecycle.md#doctrine-promotion).
+requested, but must not author, mutate, backfill, broaden, or silently infer the
+human approval record. They may faithfully record unambiguous authority already
+expressed by an explicit human instruction under the owning workflow; apply
+[`feature-lifecycle.md#doctrine-promotion`](feature-lifecycle.md#doctrine-promotion)
+for doctrine promotion and merge authorization.
 Capability, successful execution, validation, status fields, receipts, or the
 absence of objections cannot be interpreted as approval. The human role and
 decision ownership remain defined in

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -46,10 +46,15 @@ human-owned approval record. Link the human decision to that identity and state
 the authority it grants and the next action it permits.
 
 Execution systems may prepare a packet and identify the approval being
-requested. They must not author, mutate, backfill, or infer the human approval
-record. Capability, successful execution, validation, status fields, receipts,
-or the absence of objections cannot be interpreted as approval. The human role
-and decision ownership remain defined in
+requested. They may faithfully record the authority already expressed by an
+explicit human instruction when its decision, exact artifact, and granted
+authority are unambiguous, but they must not author, mutate, backfill, broaden,
+or silently infer human approval. For the narrower case where one human
+instruction may constitute doctrine promotion and merge authorization, apply
+[`feature-lifecycle.md#doctrine-promotion`](feature-lifecycle.md#doctrine-promotion).
+Capability, successful execution, validation, status fields, receipts, or the
+absence of objections cannot be interpreted as approval. The human role and
+decision ownership remain defined in
 [`core-model.md#human-role`](core-model.md#human-role).
 
 ## Approval Validity

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -46,7 +46,7 @@ human-owned approval record. Link the human decision to that identity and state
 the authority it grants and the next action it permits.
 
 Execution systems may prepare a packet and identify the approval being
-requested, but must not author, mutate, backfill, broaden, or silently infer the
+requested, but must not author, mutate, backfill, broaden, or infer the
 human approval record. They may faithfully record unambiguous authority already
 expressed by an explicit human instruction under the owning workflow; apply
 [`feature-lifecycle.md#doctrine-promotion`](feature-lifecycle.md#doctrine-promotion)


### PR DESCRIPTION
## Summary

- clarify that one explicit human instruction may both promote an exact reviewed doctrine artifact and authorize its merge when every prerequisite, identity, normative effect, and intent is unambiguous
- preserve fail-closed behavior for incomplete prerequisites, changed identity, ambiguous referents, automation, and non-human evidence while keeping approval-record handling subordinate to `feature-lifecycle.md`

## Rationale

CAK-214 exposed a magic-words failure: an explicit instruction to merge the exact, fully reviewed doctrine PR was treated as insufficient until the same human repeated the decision using promotion-specific language. This keeps the real human authority boundary while removing duplicate authorization ceremony.

## Material-doctrine classification

**Material — authority boundary.** The change clarifies how an explicit human decision can authorize doctrine promotion and merge execution.

## Governed independent review

- Claude Opus initial review of exact head `2c2201609c0374f279fe6b62d0bcfcde83ece460`: **ACCEPT WITH CHANGES**
- accepted two wording findings: removed the qualifier on the no-inference rule and made ambiguity in human intent or normative effect explicitly fail closed
- rejected one apparent scope finding after verifying it was caused by the review command using the wrong comparison; the actual PR diff contains only the two intended documentation files
- Claude Opus focused re-review of exact head `295309c6682b2efa1db29a3b986b67f256ac726e`: **ACCEPT**
- declined one non-blocking readability suggestion because both readings preserve fail-closed behavior and expanding the sentence would add unnecessary doctrine
- durable evidence: `ns:14959974083//issues/CAK-218/` (eight immutable files, exact-byte verified)

The review and its disposition satisfy a prerequisite; they grant no promotion or merge authority.

## Authority invariant

Merge mechanics, merge results, repository or CI state, validation, reviewer verdicts, automation, tool capability, and agent judgment create zero doctrine-promotion authority. Required independent review, finding disposition, identity checks, and applicable re-review remain mandatory.

## Validation

- `make check` — passed: Markdown lint and 247 tests
- required PR checks — passed

## Coordination

- Linear: [CAK-218](https://linear.app/ctrl-alt-keith/issue/CAK-218/clarify-doctrine-promotion-so-explicit-merge-authorization-can-satisfy)
- Motivating incident: [CAK-214](https://linear.app/ctrl-alt-keith/issue/CAK-214/retire-codex-safe-rm-and-prune-its-deletion-policy-caveats)

Stop before merge.