### PR TITLE
CAK-221: remove proposal-first delivery

### DIFF
--- a/docs/alignment-checkpoints.md
+++ b/docs/alignment-checkpoints.md
@@ -45,20 +45,21 @@ Start a new thread when:
 - the new task needs a clean brief and a fresh review surface
 - capture work would otherwise be buried inside delivery chatter
 
-## New Branch And PR Required When
+## Split A Branch Or PR When
 
-Every semantic phase boundary retains an explicit review and authority
-boundary. Implementation and approval may share the current PR only when the
-approval is anchored to the exact reviewed commit or bytes and downstream
-authority remains fail-closed. A semantic change to the reviewed material
-requires renewed review; this allowance does not reduce lifecycle phases or
-create a general same-PR rule.
+A semantic phase boundary retains any applicable review and authority boundary,
+but it does not require a new branch or pull request. Keep one focused
+implementation branch and pull request when the same change can carry a clear
+review surface through its lifecycle. Required review or approval may apply to
+the exact implementation identity in that pull request; a later semantic change
+to the reviewed material requires renewed review.
 
-A new branch and PR are required when:
+Split into a new branch and pull request when:
 
-- the current phase has merged and the next phase begins
-- release is complete and post-release capture starts
-- the work changes from delivery to reusable playbook capture
-- the review audience or decision surface changes materially
+- the current pull request has merged and a separately authorized change begins
+- the human or a narrowly applicable workflow explicitly requires a separate
+  delivery surface
+- scope, ownership, validation, merge timing, revert strategy, or review
+  audience differs enough to make the next change an independent deliverable
 
-The default should be smaller, phase-shaped branches rather than one branch that tries to carry the whole story.
+Do not split work merely because its lifecycle phase label changes.

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -47,8 +47,8 @@ ordinary chat, brainstorming, or conceptual discussion procedural.
 - **Use a proportional decision boundary before consequential execution.**
   Increase design, review, or approval separation with ambiguity, risk,
   authority sensitivity, and irreversibility. Small, obvious, reversible work
-  should not inherit unnecessary ceremony. Repository proposal-first delivery
-  remains owned by [`feature-lifecycle.md`](feature-lifecycle.md).
+  should not inherit unnecessary ceremony. Repository lifecycle and delivery
+  mechanics remain owned by [`feature-lifecycle.md`](feature-lifecycle.md).
 - **Validate or verify before relying on consequential conclusions.** Choose
   checks that match the claim and risk. Passing validation is evidence about
   what was checked; it is not acceptance, approval, or broader authority.

--- a/docs/external-ai-reviewer.md
+++ b/docs/external-ai-reviewer.md
@@ -254,7 +254,7 @@ termination and never authorizes a replacement attempt.
 
 Use [`review-packet.md#independent-review-findings-and-re-review`](review-packet.md#independent-review-findings-and-re-review)
 for finding disposition and the decision between no re-review, focused
-re-review, and a fresh proposal with full review. Do not duplicate those
+re-review, and a fresh artifact with full review. Do not duplicate those
 semantics in a provider adapter or reviewer prompt.
 
 ## When To Use an External AI Reviewer

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -54,7 +54,7 @@ separate artifact, branch, or pull request. Apply the repository-mutation and
 decision-boundary rule in
 [`repo-readiness.md`](repo-readiness.md#repository-mutation-and-decision-boundaries).
 
-Before consequential implementation:
+Across a consequential change:
 
 1. retrieve the authoritative sources and identify owners, scope, exclusions,
    risks, and acceptance criteria;

--- a/docs/feature-lifecycle.md
+++ b/docs/feature-lifecycle.md
@@ -27,12 +27,10 @@ prerequisite workflow owns the current completion boundary, it remains the
 governing workflow until the current authorized action transitions into
 feature-delivery planning or execution.
 
-Lifecycle planning includes defining intended behavior, constraints, risks, or
-acceptance shape; preparing a proposal-first change; and defining contract
-tests. Proposal-first planning therefore activates this guidance before
-mutation. Activation does not grant implementation authority, and an
-implementation blocker does not deactivate lifecycle planning that is already
-the current authorized action.
+Lifecycle planning includes defining intended behavior, constraints, risks,
+acceptance shape, or contract tests. Activation does not grant implementation
+authority, and an implementation blocker does not deactivate lifecycle
+planning that is already the current authorized action.
 
 ## Phase Guidance
 
@@ -40,47 +38,41 @@ the current authorized action.
 
 Define the intended behavior, constraints, risks, and acceptance shape. The goal is alignment, not code volume.
 
-### Proportional proposal-first delivery
+### Proportional decision boundaries
 
-Use a proposal-first path when implementation depends on material ambiguity,
-cross-repository ownership, policy or authority boundaries, irreversible or
-high-risk consequences, or a review cost that is meaningfully reduced by
-agreeing on the change before mutation. A human or repo-local workflow may also
-require this path explicitly.
+Use a design, review, or approval boundary before consequential implementation
+when material ambiguity, cross-repository ownership, policy or authority
+sensitivity, irreversible or high-risk consequences, or costly review makes
+that separation useful or required. Keep the boundary proportional: small,
+mechanical, reversible work with clear authority can move directly from source
+inspection to implementation.
 
-Keep it proportional. Small, mechanical, low-risk changes with an obvious
-owner, bounded diff, and ordinary validation can move directly from source
-inspection to implementation. They do not need a proposal artifact,
-independent review, or proposal-only pull request merely to follow a longer
-example.
+The boundary is semantic, not a delivery pattern. It may occur in the active
+interaction, the owning issue or decision record, an existing review surface,
+or the exact implementation pull request. It does not by itself require a
+separate artifact, branch, or pull request. Apply the repository-mutation and
+decision-boundary rule in
+[`repo-readiness.md`](repo-readiness.md#repository-mutation-and-decision-boundaries).
 
-Before naming or selecting the proposal artifact in the transition below,
-apply the current-phase mutation-authority and proposal-surface decision in
-[`repo-readiness.md`](repo-readiness.md#current-phase-mutation-authority-and-proposal-surfaces).
-
-When the proposal-first path applies, preserve these semantic transitions:
+Before consequential implementation:
 
 1. retrieve the authoritative sources and identify owners, scope, exclusions,
    risks, and acceptance criteria;
-2. prepare the bounded proposal and name its exact artifact identity;
-3. obtain independent review when the human, task, or selected risk contract
-   requires it;
-4. disposition every substantive finding and decide whether the original
-   review remains applicable using
+2. obtain any review or approval required before implementation and disposition
+   substantive findings under
    [`review-packet.md`](review-packet.md#independent-review-findings-and-re-review);
-5. freeze the exact proposal identity and obtain human approval that states the
-   implementation authority granted;
-6. implement only the approved scope, then run canonical validation;
-7. present the exact implementation head for final human review and separate
-   merge authorization; and
-8. after merge, retrieve the resulting integrated identity and reconcile any
-   external authority that tracks completion.
+3. confirm that current human direction or the owning workflow authorizes the
+   bounded implementation;
+4. implement only that scope and run canonical validation; and
+5. present the exact implementation head for final human review and merge
+   authorization, then retrieve the integrated identity after merge when the
+   workflow requires reconciliation.
 
-These transitions do not require eight separate gates, branches, or pull
-requests. A selected independent review is evidence for a human decision, not
-approval or execution authority. A frozen proposal makes implementation more
-bounded; it does not eliminate implementation judgment, validation, or final
-review.
+A selected independent review is evidence for a human decision, not approval
+or execution authority. When implementation is already authorized, required
+review or human approval may apply to the exact implementation artifact if the
+owning workflow permits it. A separate design or proposal artifact remains
+valid only when explicitly requested or narrowly required.
 
 ### Contract tests
 
@@ -251,9 +243,10 @@ provenance vocabulary:
 
 1. Preserve the research, operational evidence, negative evidence, and
    competing hypotheses in their existing evidence or staging owner.
-2. Prepare one bounded candidate synthesis with an exact artifact identity,
-   scope, exclusions, proposed normative effect, and materiality
-   classification.
+2. Prepare one bounded candidate artifact with an exact identity, scope,
+   exclusions, proposed normative effect, and materiality classification. When
+   implementation is authorized, this may be the exact implementation commit;
+   a separate design or proposal artifact is not required.
 3. For a material promotion, obtain governed independent review of that exact
    artifact. Record the selected reviewer identity and provider, and handle a
    named reviewer failure or proposed substitution under
@@ -266,9 +259,9 @@ provenance vocabulary:
    re-review merely because bytes changed.
 5. Prepare the
    [`doctrine-provenance`](review-packet.md#doctrine-provenance) review packet.
-   Link the evidence, candidate identity, review record, finding dispositions,
-   validation, open questions, and exact implementation artifact without
-   copying the full evidence history into doctrine.
+   Link the evidence, exact reviewed artifact, review record, finding
+   dispositions, validation, and open questions without copying the full
+   evidence history into doctrine.
 6. Obtain an explicit human promotion decision against the exact reviewed
    artifact. Review, validation, repository or CI state, automation, tool
    capability, merge mechanics, and merge results grant no such authority.
@@ -277,7 +270,9 @@ provenance vocabulary:
    withdrawn, and superseded material retains its historical status under the
    existing staging and preservation guidance.
 
-The human promotion decision may share a pull request with implementation when
+The reviewed candidate may be the implementation pull request head when the
+implementation authority and review contract permit it. The human promotion
+decision may share that pull request with implementation when
 the approval-identity rules in
 [`review-packet.md`](review-packet.md#approval-identity-and-ownership) are
 satisfied. After every required prerequisite is satisfied, one explicit human
@@ -344,35 +339,28 @@ project-map-only PRs for release updates.
 
 ## Branch And PR Rules
 
-Every semantic phase boundary requires an explicit review and authority
-boundary. After a phase merges, start a new branch and PR for the next lifecycle
-phase. This keeps the review surface narrow and preserves clean checkpoints.
+Lifecycle phases organize goals and review boundaries; they do not prescribe
+branch or pull-request topology. One focused implementation branch and pull
+request may carry a coherent change through design, contract tests,
+implementation, and hardening. A direct implementation request uses that
+one-PR path by default.
 
-Implementation and approval may share one PR only when the approval is anchored
-to the exact reviewed commit or bytes and downstream authority remains
-fail-closed until that approval is recorded. Any semantic change after the
-reviewed identity requires a new review. This narrow same-PR allowance does not
-remove a lifecycle phase, reduce a required gate, or permit another semantic
-phase boundary to pass without explicit review and authority.
+Keep every required review and authority boundary explicit. Implementation,
+review, and approval may share one pull request when approval is anchored to
+the exact reviewed commit or bytes and downstream authority remains fail-closed
+until the approval is recorded. Any semantic change after the reviewed identity
+requires the applicable renewed review or approval.
 
-Proposal-first names the semantic decision boundary above, not a proposal
-branch or pull-request topology. Apply
-[`repo-readiness.md#current-phase-mutation-authority-and-proposal-surfaces`](repo-readiness.md#current-phase-mutation-authority-and-proposal-surfaces)
-before choosing the artifact surface. Without repository-mutation authority for
-the current phase, create no worktree, branch, commit, repository document, or
-pull request; return a compact proposal in the active interaction or, when its
-exact durable identity qualifies and storage admission passes, use the existing
-governed-artifact route selected by its owner.
-
-A proposal-only draft PR can still be a proportionate collaboration surface
-when the human or a narrower owning workflow explicitly authorizes that
-repository artifact for the current phase and repository policy permits it.
-The exact proposal may then be approved on that branch and bounded
-implementation may continue on the same branch and PR. Keep proposal approval
-and final implementation review distinct: proposal approval authorizes only the
-stated implementation, and merge still requires separate authorization against
-the exact reviewed implementation head. Materiality or an independent-review
-requirement does not itself choose the proposal PR.
+Split work into another branch or pull request only when the human or a
+narrowly applicable workflow requires it, or when the next change is an
+independent deliverable with meaningfully different scope, ownership,
+validation, review audience, merge timing, or revert strategy. A separate
+design document or proposal-only pull request is valid when explicitly
+requested or narrowly required, but authority for that artifact does not
+authorize implementation. Materiality or an independent-review requirement
+alone does not select a separate artifact or Git surface. Apply
+[`repo-readiness.md#repository-mutation-and-decision-boundaries`](repo-readiness.md#repository-mutation-and-decision-boundaries)
+before creating repository topology.
 
 Record two different identities when merge follows. The implementation head is
 the pre-merge commit reviewed for merge authorization. The resulting integrated
@@ -529,12 +517,10 @@ and blocked cleanup reporting, follow
 other executors, follow the matching adapter when one documents stricter
 worktree handling.
 
-The expected pattern is:
-
-1. Merge the current phase
-2. Open a new branch for the next phase
-3. Open a new PR for that phase
-4. Complete post-release capture before starting the next major arc
+Do not split a coherent change merely because it crosses a lifecycle phase
+label. After the current pull request merges, any later independently
+authorized change starts from freshly fetched `origin/main` on its own branch.
+Complete required post-release capture before starting the next major arc.
 
 When overlapping PRs touch the same shared surface, merge behavior, workflow, or other source-of-truth changes before formatting, restructuring, or cleanup. Let cleanup absorb the settled state last.
 
@@ -542,7 +528,5 @@ When concurrent PRs have no file overlap and no open review concerns, merge orde
 is flexible. Say that explicitly in the review packet instead of inventing a
 false dependency.
 
-Do not roll multiple lifecycle phases into one long-running branch unless there
-is a strong reason and the review surface remains clear. The same-PR
-implementation-and-approval allowance above is not a blanket exception to this
-sequential lifecycle discipline.
+Keep one-PR delivery focused and reviewable; it is not permission to accumulate
+unrelated lifecycle work on a long-running branch.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -137,30 +137,28 @@ controller's declared boundary, not prompt-contract machinery: hydrators,
 adapters, renderers, validators, receipts, and checkpoints remain unable to
 drive lifecycle state or orchestration.
 
-### Repository-topology authorization check
+### Repository mutation and decision-boundary check
 
-Before a generated prompt or handoff requires implementation mode, a worktree,
-branch, repository edit, commit, push, or pull request, identify the current
-human direction or narrower owning-workflow rule that authorizes repository
-mutation in the current phase. Apply the canonical decision rule in
-[`repo-readiness.md#current-phase-mutation-authority-and-proposal-surfaces`](repo-readiness.md#current-phase-mutation-authority-and-proposal-surfaces).
-Do not infer repository-mutation authority from future implementation intent,
-planning or design authority, materiality, an independent-review requirement,
-an issue-owned evidence write, or the usefulness of durable collaboration.
+Before a generated prompt or handoff requires implementation mode or Git
+mutation, identify the current human direction or narrower owning-workflow rule
+that authorizes it. Apply the canonical decision rule in
+[`repo-readiness.md#repository-mutation-and-decision-boundaries`](repo-readiness.md#repository-mutation-and-decision-boundaries).
 
-When current intent is discussion-first and repository mutation is not
-authorized, select review/audit or orchestration/prompt-authoring mode for the
-current phase. Omit Git topology and state the zero-repository-mutation stop
-boundary. Return a compact proposal in the active interaction, or direct a
-substantial proposal through the existing governed-artifact capture and owning
-storage-admission contract when exact identity is required for review, handoff,
-recovery, or independent review and regeneration or interaction-only retention
-would weaken that dependency. Stop for the human decision.
+A direct request to implement and open a pull request should produce one
+focused implementation branch and pull request unless the human explicitly
+requests another artifact or a narrowly applicable workflow requires one.
+Materiality, design work, or an independent-review requirement may add a
+semantic decision or review boundary, but does not independently add a design
+document, staging branch, or proposal-only pull request. Put required review or
+approval against the exact implementation artifact when the owning workflow
+permits it.
 
-Do not use a keyword-only rule: `proposal` and `design` do not prohibit a
-repository artifact when the human explicitly requests a design document or
-proposal pull request. Conversely, recorded later implementation intent does
-not authorize Git in the discussion phase.
+When current intent asks only for discussion, design, a specification, or a
+review, select review/audit or orchestration/prompt-authoring mode and omit
+implementation topology. Create a separate repository artifact only when it is
+explicitly requested or narrowly required, and keep its authority distinct
+from later implementation authority. Do not infer current repository mutation
+from recorded future intent.
 
 ## Thread Routing And Configuration Continuity
 

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -242,60 +242,38 @@ Keep this policy in the shared playbook. Repo-local `AGENTS.md` files should
 reference or rely on it rather than duplicate it, except where a repository
 truly requires different behavior.
 
-### Current-phase mutation authority and proposal surfaces
+### Repository mutation and decision boundaries
 
-Keep three decisions separate before producing a proposal, design, spec,
-review package, or similar planning artifact:
+Resolve the current requested deliverable and mutation authority before
+creating repository topology. A direct request to implement and open a pull
+request selects normal implementation delivery: one focused worktree, branch,
+and pull request by default. Ambiguity, risk, authority sensitivity, or
+irreversibility may still require a design, review, or approval boundary before
+consequential implementation, but that semantic boundary does not create a
+separate document, branch, or pull request.
 
-1. What is the current semantic phase?
-2. Does current human intent or a narrower owning workflow authorize
-   repository mutation in that phase?
-3. Does the produced material qualify for durable governed-artifact capture?
+Place the boundary on the smallest suitable surface: the active interaction,
+the owning issue or decision record, an existing review surface, or the exact
+implementation pull request. Current human direction or a narrower owning
+workflow must authorize implementation when that boundary is crossed. When an
+owning workflow requires exact review or approval, the exact implementation
+commit may satisfy the identity requirement if that workflow permits it.
 
-Proposal-first and design-first describe a semantic decision boundary, not a
-Git topology. Planning or design authority permits producing the requested
-recommendation; it does not by itself authorize implementation mode, a
-worktree, branch, repository file, commit, push, pull request, or another Git
-artifact. Issue-owned orchestration or evidence writes that are separately
-permitted also do not create repository-mutation authority.
+When the human asks only for discussion, design, a specification, or a review,
+keep repository implementation read-only and return the requested result on
+the natural authorized surface. Create a separate design document, proposal
+document, or proposal-only pull request only when the human explicitly requests
+that artifact or a narrowly applicable workflow requires it. Authority to
+produce such an artifact remains bounded to that artifact and does not
+authorize implementation.
 
-For discussion-first intent such as `come up with a proposal we can discuss,
-then implement`, keep repositories read-only for the current phase. Return a
-compact proposal in the active interaction. When the proposal is substantial,
-its exact identity is required for review, handoff, recovery, or independent
-review, and regeneration or interaction-only retention would weaken that
-dependency, apply the existing governed-artifact candidate and
-storage-admission contract in
-[`evidence-lifecycle.md`](evidence-lifecycle.md#governed-artifact-capture). Use
-the issue-owned provider destination only when the current project's owning
-storage contract selects and admits that route. The shared Playbook does not
-select Dropbox or another provider as a universal destination.
-
-Do not create a worktree, branch, empty commit, repository proposal document,
-or proposal pull request merely to make discussion-first material durable or
-reviewable. A mutable pull-request description is not frozen or given an exact
-proposal identity by an empty commit. When exact proposal bytes matter, retain
-them through their natural durable owner and reference that identity from the
-interaction, planning, or review surface.
-
-Select a repository document or proposal pull request only when the human or a
-narrower owning workflow explicitly authorizes that artifact surface for the
-current phase. That authority remains bounded to the named proposal artifact;
-it does not authorize implementation. Once implementation is explicitly
-authorized, use normal repository delivery.
-
-| Current-phase intent | Repository mutation | Proposal surface | Stop boundary |
-| --- | --- | --- | --- |
-| Discussion-first, compact proposal | Not authorized | Active interaction | Human decision before implementation |
-| Discussion-first, substantial proposal whose exact identity qualifies and is admitted | Not authorized | Existing governed-artifact route selected by its owning storage contract | Human decision before implementation |
-| Explicit repository design document | Authorized for the named artifact only | Named repository document | Separate implementation authority |
-| Explicit proposal pull request | Authorized for the proposal surface only | Repository worktree, branch, and proposal pull request | Separate implementation authority |
-| Direct implementation and pull-request delivery | Authorized | Normal implementation worktree, branch, and pull request | Stop before merge unless separately authorized |
-
-An independent-review or material-doctrine requirement may require an exact
-durable proposal identity, but it does not select Git, a pull request, or any
-other storage surface. Select that surface from current authority and the
-owning artifact contract.
+Do not create Git topology merely to make planning material durable or
+reviewable. If an explicitly requested or narrowly required separate artifact
+needs exact durable identity, apply the governed-artifact capture and storage
+admission contract in
+[`evidence-lifecycle.md`](evidence-lifecycle.md#governed-artifact-capture).
+Materiality or an independent-review requirement alone does not select Git, a
+pull request, or another storage surface.
 
 ## Single-Operator Review Posture
 

--- a/docs/review-packet.md
+++ b/docs/review-packet.md
@@ -112,14 +112,14 @@ verdicts remain evidence for the human decision. None grants implementation,
 merge, release, or other transition authority.
 
 After corrections, ask: **Is the original review still applicable to the
-frozen proposal or artifact?** Record one of three outcomes and the reason:
+reviewed artifact?** Record one of three outcomes and the reason:
 
 - no re-review when bounded corrections preserve the reviewed scope,
   ownership, claims, authority, acceptance criteria, omissions, and delivery
   topology;
 - focused re-review when a material part of those surfaces changed but the
-  artifact remains recognizably the same proposal or implementation; or
-- a fresh proposal and full review when the corrected artifact is no longer
+  artifact remains recognizably the same work; or
+- a fresh artifact and full review when the corrected artifact is no longer
   meaningfully the same reviewed work.
 
 Do not require another review merely because bytes changed, and do not skip one
@@ -286,11 +286,11 @@ observation, maturity, disposition, target, and exact implementation artifact
 or commit so a reviewer can trace the rule without copying the complete
 retrospective into the doctrine file.
 
-State which material was frozen before implementation, which items remained
-open questions or were otherwise not promoted, and whether the implementation
-preserved the reviewed decision. Keep the evidence artifact and implementation
-lifecycle distinct; neither a retrospective nor its summary grants approval to
-merge the doctrine change.
+Identify the exact artifact reviewed for promotion, which items remained open
+questions or were otherwise not promoted, and whether that artifact is the
+implementation identity or an earlier reviewed decision. Keep evidence and
+implementation state distinct even when they share one pull request; neither a
+retrospective nor its summary grants approval to merge the doctrine change.
 
 ## What The Human Should Focus On
 


### PR DESCRIPTION
## Summary

- remove the named proposal-first delivery path and its exact-proposal-artifact prerequisite
- make design, review, and approval boundaries semantic rather than branch or pull-request topology
- default direct implementation requests to one focused implementation branch and pull request
- retain current implementation authority, exact-artifact approval, and material-doctrine promotion requirements

The regression instruction “Implement the validated Airtable replacement for Dropbox handoffs and open the PR.” now selects one implementation branch and PR unless a separate design artifact is explicitly requested or narrowly required.

## Review and provenance

This is a material Playbook doctrine change. Governed independent review of parent commit da0abf8295516b5c6d04ddb94cba93ff49b05637 returned ACCEPT WITH CHANGES with no blocking findings and one wording correction. That finding was accepted with modification in commit 3081f61565d05b2b3f8c706b231cf29a5c192c1f. Focused governed re-review of that exact final commit returned ACCEPT with no findings.

The immutable evidence bundle and producing receipt are stored in Dropbox at /issues/CAK-221/. Producing receipt file ID: id:FHKdoRfTdTUAAAAAAAAJmw. Review, validation, capture, and repository state grant no promotion or merge authority.

## Validation

- make check
- markdownlint: 0 issues
- unit tests: 247 passed

## Scope

Seven documentation owners changed; no wording-presence test was added because this prose is not machine-consumed.

Linear: [CAK-221](https://linear.app/ctrl-alt-keith/issue/CAK-221/remove-proposal-first-language-that-creates-unnecessary-staging-prs)
