### PR TITLE
CAK-224: prevent test-only models from counting as coverage

### DIFF
--- a/docs/engineering-baseline.md
+++ b/docs/engineering-baseline.md
@@ -25,6 +25,11 @@ Define shared engineering expectations across repositories. This baseline forms 
   - Do not create wrapper scripts, aggregation scripts, secondary audit
     engines, parser forks, or validation-semantic copies that partially
     reimplement canonical tooling.
+  - Tests presented as implementation coverage must exercise repository-owned
+    executable behavior or externally meaningful interfaces. A helper, model,
+    validator, workflow, or protocol implementation that exists only in the
+    test suite is scaffolding, not evidence that repository implementation
+    semantics are covered.
 - Repository isolation
   - One repository per PR.
   - One dedicated worktree per implementation change.


### PR DESCRIPTION
## Summary

- Require tests presented as implementation coverage to exercise repository-owned executable behavior or externally meaningful interfaces.
- Classify helper, model, validator, workflow, or protocol implementations defined only in the test suite as scaffolding rather than repository implementation coverage.

## Rationale

This closes the gap in the existing canonical-executable-truth guidance while preserving the separate rule against prose-policing tests and avoiding new enforcement machinery.

## Validation

- make check

## Planning

- Linear: CAK-224