### PR TITLE
Prevent Claude bootstrap from intercepting auth preflight

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -558,7 +558,9 @@ Before an expensive independent review, run the same launcher with
 resolution, sends only the fixed `CLAUDE_AUTH_OK` prompt on standard input,
 disables all Claude tools, passes `--no-session-persistence`, and runs from a
 fresh private attempt-local directory through the qualified macOS or Linux
-route. It may retain the selected model and effort, but it is not substantive
+route. It also disables Claude instruction and auto-memory loading so a global
+or project bootstrap cannot intercept the fixed authentication canary. It may
+retain the selected model and effort, but it is not substantive
 review and does not read repository, candidate, or held-out content.
 For example:
 

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -3892,7 +3892,15 @@ def main(argv: list[str] | None = None) -> int:
     if not execution_fixture:
         child_environment.pop("CLAUDE_REVIEW_TEST_FIXTURE", None)
         child_environment.pop("CLAUDE_REVIEW_TEST_SCRATCH_PARENT", None)
-    child_environment.update({"HOME": effective_home, "USER": user, "LOGNAME": user})
+    child_environment.update(
+        {
+            "HOME": effective_home,
+            "USER": user,
+            "LOGNAME": user,
+            "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+            "CLAUDE_CODE_DISABLE_CLAUDE_MDS": "1",
+        }
+    )
     selected_arguments = preflight_arguments(args.claude_args) if args.auth_preflight else args.claude_args
     try:
         preflight_directory = (

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -1840,6 +1840,8 @@ class ClaudeReviewLauncherTests(unittest.TestCase):
             "assert sys.argv[sys.argv.index('--tools') + 1] == ''\n"
             "assert '--model' in sys.argv\n"
             "assert '--effort' in sys.argv\n"
+            "assert os.environ['CLAUDE_CODE_DISABLE_AUTO_MEMORY'] == '1'\n"
+            "assert os.environ['CLAUDE_CODE_DISABLE_CLAUDE_MDS'] == '1'\n"
             "assert not os.path.exists('.git')\n"
             "print('CLAUDE_AUTH_OK')\n",
             auth_preflight=True,


### PR DESCRIPTION
Context: CAK-225

## Summary
- disable Claude instruction and auto-memory loading for the fixed auth preflight
- preserve effective-user identity, authentication, model selection, and qualified executable checks
- document and regression-test the isolation boundary

## Validation
- make check — 207 tests passed