### PR TITLE
CAK-228: add provisional Astra routing and concise completion reports

### DIFF
--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -105,25 +105,27 @@ client-forced output as a limitation rather than claiming it was suppressed.
 
 ### Successful completion projection
 
-A successful completion report is an operator review surface, not a replay of
-the durable receipt. For delegated repository execution, normally report only
-the completed outcome, the reviewable repository result and its current
-status, the canonical validation and review outcome at a useful summary level,
-the exact implementation identity when it materially aids review or approval,
-and the current stop boundary. This is a semantic minimum, not a required
-sentence template or layout.
+A successful completion report orients the operator to the review surface.
+For an ordinary successful repository run, default to roughly 2–4 short
+sentences covering only the completed outcome, the reviewable artifact and its
+current status, canonical validation at a useful summary level, and the current
+stop boundary. Include one additional fact only when it materially changes
+what the operator should review, decide, or do next. This is a semantic
+projection, not an exact wording template or layout.
 
-Leave prompt acquisition and delivery mechanics, byte counts and digests,
-provider object metadata, routine preflight attempts, temporary-scratch and
-cleanup mechanics, retained evidence identities, routine artifact-deletion
-authority reminders, command history, and raw test counts in their owning
-durable evidence rather than routinely replaying them in normal completion
-prose. This projection reduces operator-facing repetition only; it does not
-weaken evidence collection, verification, identity, retention, or
-retrievability.
+The PR, issue, and durable evidence remain the detailed record. Do not routinely
+replay prompt transport or Airtable verification, hashes, byte counts, record
+IDs, receipts, source inventories, retrieval or preflight mechanics, temporary
+scratch or cleanup mechanics, command history, or raw test counts. Leave
+runtime/model evidence, adjacent issue dispositions, research findings, and
+unresolved claims there unless they materially affect operator review or
+action. Omit unchanged authority reminders, implementation mechanics already
+visible in the review artifact, and exhaustive lists of unchanged surfaces.
+This projection reduces operator-facing repetition only; it does not weaken
+evidence collection, verification, identity, retention, or retrievability.
 
-Surface additional detail when it changes what the operator needs to know or
-do, including failure or partial success, identity or integrity mismatch, a
+Expand beyond the normal projection for a material exception, including failure
+or partial success, identity or integrity mismatch, a
 retry that materially affected execution, validation or review failure,
 capability or authentication limits, unexpected state, unresolved risk or
 blocker, a required human decision, or cleanup residue. Report the material

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -846,7 +846,3 @@ Use the PR readiness, validation, and delivery rules in
 When reporting successful completion for Codex implementation work, apply the
 core model's
 [`Successful completion projection`](../core-model.md#successful-completion-projection).
-Normally include the opened or updated PR and its status, the canonical
-validation and review summary, the exact implementation head when useful, and
-the stop boundary. Add changed-file, blocker, risk, or forensic-evidence detail
-only when it materially affects operator review or action.

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -9,20 +9,33 @@ concrete capability in use. Use this adapter with `docs/start-here.md`,
 `docs/core-model.md`, `docs/source-first-retrieval.md`, `docs/repo-readiness.md`,
 and repo-local `AGENTS.md`; do not treat it as a second copy of those rules.
 
-## GPT-5.6 Model And Reasoning Routing
+## OpenAI Model And Reasoning Routing
 
-Choose the lowest-cost GPT-5.6 model and reasoning effort that preserves the
+Choose the lowest-cost available model and reasoning effort that preserves the
 confidence required by the bounded task. Model selection and reasoning effort
 are separate configuration decisions: select both deliberately, and do not
-default substantial work to Sol merely because it is long-running.
+default substantial work to Sol or Astra merely because it is long-running.
 
-The current official positioning, checked 2026-08-10, is: Sol for frontier
-capability, Terra for an intelligence/cost balance, and Luna for efficient,
-high-volume, cost-sensitive workloads. GPT-5.6 supports `none`, `low`,
-`medium`, `high`, `xhigh`, and `max` reasoning effort; availability of a
-specific combination remains executor/runtime evidence. This adapter uses
-Light, Medium, and High as portable recommendation classes, mapped to the
-available runtime setting by the operator.
+The official model references, checked 2026-09-04, position
+[GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)
+(`gpt-6-astra`) for the hardest end-to-end reasoning, coding, computer-use,
+research, and document tasks;
+[GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
+for complex professional work;
+[Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
+for an intelligence/cost balance; and
+[Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
+for cost-sensitive, high-volume workloads. Astra's documented API reasoning
+efforts are `low`, `medium`, `high`, `xhigh`, and `max`; GPT-5.6 also supports
+`none`. A Codex surface may expose a different set: verify the selected
+model/effort combination in that runtime rather than copying the API list.
+This adapter uses Light, Medium, and High as portable recommendation classes,
+mapped to the available runtime setting by the operator.
+
+OpenAI's [Codex release guidance](https://learn.chatgpt.com/docs/whats-new)
+documents Astra as an option once available to the account. Rollout and
+administrator enablement remain separate from model capability; verify access
+on the actual interactive or scheduled execution surface.
 
 Use task characteristics, not duration, to route: ambiguity, consequence of
 error, repository-context breadth, novelty, architectural judgment,
@@ -38,8 +51,9 @@ remain on Luna.
 | Substantial but bounded analysis; moderate synthesis; difficult localized debugging | Terra | High | architecture or authority decisions, conflicting evidence, or unresolved ambiguity remain after bounded investigation | move deterministic execution and verification to Luna |
 | Protocol/design work; architecture synthesis; ambiguous root-cause debugging; high-consequence authority or controller semantics; difficult adversarial review | Sol | High; consider `xhigh` or `max` only with a measured need | use a bounded supported Pro-mode execution, independent review, or explicit human decision when the unresolved risk remains material | delegate established-contract implementation to Terra and mechanical verification to Luna |
 
-Defaults are routing hypotheses, not a guarantee that the lower-cost choice is
-sufficient. Do not downgrade when consequences are high, ambiguity is
+The Luna/Terra/Sol defaults remain in place pending representative Astra
+qualification. Defaults are routing hypotheses, not a guarantee that the
+lower-cost choice is sufficient. Do not downgrade when consequences are high, ambiguity is
 material, validation is weak, work is hard to reverse, or a failure could
 silently corrupt authority or evidence. `xhigh` and `max` are exceptional:
 use them only for a bounded demanding task with an observed quality need; do
@@ -52,6 +66,30 @@ exposes it and a bounded quality/reliability need justifies the added cost and
 latency; it is not a routine Sol default. The `gpt-5.6` alias resolves to Sol,
 so use an explicit Terra or Luna identifier whenever that lower-cost routing is
 intended.
+
+### Provisional Astra Placement
+
+Consider Astra for a bounded quality-first escalation or a demanding workflow
+spanning code, browsers, research, and professional artifacts when its
+documented strengths match an observed need. This is a provisional routing
+recommendation, not a demonstrated improvement over Sol for Playbook work.
+Before changing defaults, compare representative outcomes, boundary adherence,
+latency, cost per accepted result, and intervention behavior under controlled
+conditions. Launch benchmarks and a single successful run do not qualify a
+task class. Use current provider pricing rather than assuming fewer output
+tokens makes Astra cheaper for the workload.
+
+The published Astra context/output limits do not exceed those of Luna, Terra,
+or Sol; a model switch alone does not justify a larger source set. OpenAI's
+[misalignment monitoring](https://developers.openai.com/api/docs/guides/safety-checks/misalignment-monitoring)
+can stop covered conversations and can flag legitimate activity or miss issues.
+It does not undo prior actions or replace the existing authority, evidence,
+review, and human-decision boundaries.
+
+Astra's existence does not require a change to the
+[autonomous maintenance layer](../maintenance-automations.md). Deterministic
+hosted stewardship gains no model dependency; residual model-backed jobs are
+candidates for later qualification on their actual execution surfaces.
 
 ### Escalation And Delegation
 
@@ -76,7 +114,8 @@ work for other purposes.
 
 Apply the shared `FRESH THREAD`, `SAME THREAD`, and `CHILD TASK` vocabulary in
 [`prompts.md`](../prompts.md#thread-routing-and-configuration-continuity). For
-a FRESH THREAD, select the matrix's task-appropriate GPT-5.6 model and effort.
+a FRESH THREAD, select the task-appropriate model and effort using the matrix
+and provisional Astra guidance above.
 For a SAME THREAD, preserve the requested parent model and effort by default:
 task-class sufficiency alone does not justify intentionally mutating an
 already-running configuration. Record the effective model and effort separately
@@ -145,14 +184,24 @@ variables can be evaluated separately, do not change the model, prompt,
 reasoning effort, tool behavior, and workflow at the same time.
 
 Preserve the prior effective reasoning effort as the first migration baseline.
+For an Astra comparison from `none` or `minimal`, OpenAI recommends `low`;
+record that required configuration change as a comparison limitation.
 Treat reasoning effort as execution configuration rather than prompt prose,
 then tune it against representative tasks. Do not recommend a global increase
 or compensate for a configuration mismatch by bloating the prompt.
 
 Keep Pro mode, persisted reasoning, programmatic tool calling, explicit prompt
-caching, and multi-agent execution outside the baseline migration. Evaluate
-each optional feature separately only when the workload shape and measured
+caching, multi-agent execution, async tool calling, and mid-turn steering
+outside the baseline migration. Evaluate each optional feature separately only
+when the workload shape and measured
 results justify it. Preserve behavior and settings before optimizing.
+
+The API's [async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling)
+allows useful work while application-managed tools are pending;
+[mid-turn steering](https://developers.openai.com/api/docs/guides/steering)
+accepts user updates through Responses WebSockets without undoing prior actions
+or canceling started tools. These API capabilities do not establish their
+availability or behavior in every Codex runtime.
 
 ### Operator Metadata And Reasoning Recommendations
 
@@ -161,7 +210,7 @@ executable prompt with this plain-text operator metadata:
 
 ```text
 Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>
-Recommended model: <FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol; SAME THREAD: Preserve requested thread model and observe effective runtime model>
+Recommended model: <FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol | GPT-6 Astra (provisional); SAME THREAD: Preserve requested thread model and observe effective runtime model>
 Recommended reasoning level: <FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve requested thread setting and observe effective runtime setting>
 
 Reason:
@@ -227,9 +276,10 @@ guarantee, the attempt fails closed rather than silently choosing a weaker
 setting.
 
 This posture is derived from OpenAI's current
-[GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+[model guidance](https://developers.openai.com/api/docs/guides/latest-model)
 and [OpenAI models reference](https://developers.openai.com/api/docs/models),
-checked 2026-08-10.
+checked 2026-09-04. Provider positioning supports candidate selection; the
+Playbook's task-class defaults still require workload evidence.
 
 ## Prompt-Contract Mapping
 


### PR DESCRIPTION
The Codex adapter still framed all model selection as GPT-5.6-only. This update acknowledges GPT-6 Astra and offers provisional placement for demanding work while retaining the existing Luna/Terra/Sol task defaults.

`docs/tool-adapters/codex.md` refreshes official references and the checked date, distinguishes API reasoning settings from Codex availability, adds Astra to operator recommendations, and keeps async tools and steering outside baseline model qualification.

`docs/core-model.md` also tightens the existing successful-completion projection: ordinary successful repository runs default to roughly 2–4 short sentences covering outcome, review artifact/status, canonical validation, and stop boundary, with one extra fact only when it changes operator review or action. Detailed evidence remains in the PR, issue, and durable records. The Codex adapter's duplicate completion checklist is removed so the core model remains the sole owner; material exceptions and specialized reporting remain intact. AGENTS.md, automations, scheduler settings, and account defaults are unchanged.

Linear: [CAK-228](https://linear.app/ctrl-alt-keith/issue/CAK-228). This is the initial documentation slice; CAK-228 remains open for workload qualification and automation assessment.

## Research and evidence boundary

Official sources checked 2026-09-04:

- [Astra model reference](https://developers.openai.com/api/docs/models/gpt-6-astra): `gpt-6-astra`; API efforts `low`, `medium`, `high`, `xhigh`, `max`; 1,050,000 context and 128,000 maximum output tokens. Standard API input/cached-input/output pricing is $10/$1/$50 per million tokens; input above 272K incurs the documented long-context rates. These are API prices, not Codex subscription costs.
- [Model comparison](https://developers.openai.com/api/docs/models/compare) and [Luna reference](https://developers.openai.com/api/docs/models/gpt-5.6-luna): the same context/output limits apply to Sol, Terra, and Luna. Their standard input/output prices are $4/$20, $2/$12, and $0.20/$1.20 respectively. A larger context window is therefore not an Astra-vs-GPT-5.6 advantage.
- [Model guide](https://developers.openai.com/api/docs/guides/latest-model): OpenAI positions Astra for difficult reasoning and multistep computer, coding, research, and professional work. Its reported quality, boundary adherence, and token-efficiency improvements are provider claims, not Playbook workload guarantees. The guide flags possible excess clarification, sensitivity to instruction files, and overtesting as behaviors to evaluate. Tool calling requires Responses; Chat Completions support does not establish tool support there.
- [Codex release guidance](https://learn.chatgpt.com/docs/whats-new): Astra is selectable once available to the account; rollout eligibility and enterprise administrator enablement still matter. This does not prove access for every scheduled surface.
- [Async tools](https://developers.openai.com/api/docs/guides/async-tool-calling) permit useful work while application-run tools are pending; the application owns execution and result correlation. [Steering](https://developers.openai.com/api/docs/guides/steering) accepts updates over Responses WebSockets and does not undo actions or cancel tools already started.
- [Misalignment monitoring](https://developers.openai.com/api/docs/guides/safety-checks/misalignment-monitoring) may stop covered conversations, miss issues, or flag legitimate activity. Coverage depends on API/context handling. A stop does not undo prior actions. Provider stop handling remains applicable; no relaxation of existing safeguards follows.

Runtime observation: the local Codex desktop session identifies OpenAI as provider, CLI/runtime version 0.153.1, and this turn as `gpt-6-astra` with `high` effort. The host's exposed task-control metadata advertises Astra and efforts through `ultra`; the public API reference lists only through `max`. Those are different evidence surfaces. No provider response attestation establishes effective backend effort or normalization/fallback for this run. No raw API, steering, computer-use benchmark, or automation probe was run. This execution is one observation, not qualification evidence.

## Disposition and limits

- **Immediate facts:** acknowledge Astra, current positioning, supported API effort names, conditional surface availability, and separate optional API features.
- **Provisional recommendation:** bounded quality-first escalation or difficult workflows spanning tools and artifacts when there is an observed need. Keep current defaults until representative comparisons measure accepted outcomes, boundary adherence, latency, cost, and interventions while controlling other variables.
- **CAK-101:** its description still parks work behind CAK-96, which is Done. However, its later comments establish a real `SURFACE_INCONCLUSIVE` blocker: effective reasoning effort and fallback could not be proven under the provider contract. Recommend replacing the stale sequencing description with that current blocker, preserving Blocked, and coordinating an Astra comparison through CAK-228 only after the qualification prerequisite is satisfied. Do not silently revise its frozen protocol.
- **CAK-115:** remains Backlog. Provider-specific facts stay in the Codex adapter, so its later shared-owner refactor need not precede this update.
- **CAK-113:** is Done with a no-change disposition. Preserve that completion; Astra async/steering investigation belongs to bounded CAK-228 work, with concrete caller support and telemetry, separately from model selection.
- **Automations:** the existing maintenance doctrine needs no architectural change. Deterministic hosted stewardship gains no model dependency. Residual model-backed jobs and scheduled surfaces require later qualification and verified access.
- **Deliberately unestablished:** universal access, backend effective-effort guarantees, runtime-only `ultra` as an API setting, superior cost/quality/safety for Playbook work, computer-use throughput, lower intervention rates, and automatic migration benefits. No defaults, prompts, or automation fleet were migrated.

## Completion-report regression review

The earlier CAK-228 chat completion unnecessarily replayed Airtable verification, runtime evidence, and adjacent issue dispositions already recorded here. Manual review against that concrete example confirms that the revised projection retains the review artifact/status, bounded Astra outcome, summary validation, and stop boundary while omitting routine evidence replay. The example's exact wording is not a template or test. No wording-presence tests were added.

## Validation and decision boundary

- `make check` passed on the final content: Markdown lint and all 176 repository tests.
- `make authoritative-source-check` passed with no non-authoritative source URLs found.
- `git diff --check` passed; the final diff preserves the existing task matrix and Astra work; the reporting revision is limited to the core projection and removal of the adapter's duplicate checklist. No wording-presence tests were added.
- Fetched current `origin/main`; base `769b518e3af56a64e90ee96f7ca68b2587540272` is an ancestor of reviewed head `0f1c873cb010be02fd187f4a8ace98b30eee263a`. No rebase was needed; no open PR overlap was found.

Implementation mode; non-material adapter and completion-presentation update under `feature-lifecycle.md`: no authority transfer, mandatory lifecycle-gate change, cross-owner obligation, architecture boundary, or reverse doctrine transition. Review consists of direct source checking and final diff inspection; no independent review is claimed.

Prepared under the verified CAK-228 handoff's explicit implementation, commit, push, and PR authority, plus the operator's explicit instruction to tighten completion reporting on this existing PR. Human review of the exact PR head is next. Promotion/merge authorization remains pending; no merge, auto-merge, release, broader adoption, or downstream experiment is authorized by this result.
