### PR TITLE
CAK-231: define prompt attempts and tracked execution handoffs

### DIFF
--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -359,6 +359,29 @@ replace the write and verification mechanics in
 not weaken its candidate, privacy, visibility, retention, ownership, or
 fail-closed boundaries.
 
+### Material attempts and conversational steering
+
+The unit of durable prompt transport is one material executor attempt. Keep
+one frozen effective prompt artifact for that attempt. Ordinary in-run
+steering and follow-up remain conversational; another human message alone
+does not create another Airtable record. The executor's own run or conversation
+record is sufficient forensic evidence for that steering unless another actor
+must independently reconstruct the changed executable contract.
+
+When later direction materially changes the executable contract and the revised
+contract must cross an execution, recovery, review, replay, restart, or handoff
+boundary, freeze a clean revised effective prompt as a new attempt artifact
+before that boundary. Carry forward the still-applicable scope, constraints,
+authority references, and completion boundary so the next actor need not
+reconstruct the contract from a chronological chain of steering records.
+Apply the admission and exact-identity checks below to the new artifact;
+preserve its predecessor identity without modifying the prior frozen prompt.
+
+In-run steering does not revise an immutable attempt's selected identities or
+turn changed inputs into replay. Apply current human direction and the owning
+authority checks before acting on it; freezing, retaining, or successfully
+retrieving a revised prompt supplies no authority.
+
 ### Admission
 
 A rendered prompt is eligible for durable handoff only when all six conditions

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -382,7 +382,10 @@ single-record request and response limits. The permitted Airtable route owns
 that runtime limit check. Payloads that do not qualify remain outside this
 normal text route; they do not trigger a fallback from it.
 
-Use one new Airtable record per producer attempt with these required fields:
+Apply the
+[`material-attempt and conversational-steering boundary`](prompt-contracts.md#material-attempts-and-conversational-steering)
+before selecting a new durable handoff. Use one new Airtable record per
+producer attempt with these required fields:
 
 - `Handoff Key`
 - `Payload`

--- a/docs/repo-readiness.md
+++ b/docs/repo-readiness.md
@@ -242,6 +242,27 @@ Keep this policy in the shared playbook. Repo-local `AGENTS.md` files should
 reference or rely on it rather than duplicate it, except where a repository
 truly requires different behavior.
 
+### Discussion to tracked execution
+
+Ordinary brainstorming and conceptual discussion remain lightweight. Detailed
+discussion, a worked-out design, or convergence on a recommendation does not
+establish commitment to execute. Recognize the transition when current human
+direction explicitly selects proceeding with the bounded work, for example
+"let's do this" in an unambiguous discussion of that work. Resolve what was
+selected under the interaction-mode preflight; intent to track or hand off
+work does not by itself authorize this controller to implement it.
+
+When the governing repository workflow requires a planning or task artifact,
+establish that owning artifact before producing downstream execution handoffs.
+Retrieve and use an existing applicable item, or create the required item
+within current authority, with the bounded outcome and completion boundary.
+If the required artifact cannot be established, stop the dependent handoff and
+report the blocker. Follow
+[`Issue And Planning Coordination`](feature-lifecycle.md#issue-and-planning-coordination)
+for planning ownership and completed-item or successor disposition; do not
+invent a ticket requirement for workflows that do not have one. The artifact
+records intent and scope; its existence supplies no execution authority.
+
 ### Repository mutation and decision boundaries
 
 Resolve the current requested deliverable and mutation authority before


### PR DESCRIPTION
# Summary

Ordinary follow-up messages could be mistaken for new durable prompt attempts, and execution handoffs could be prepared before the workflow's required planning item existed. This change defines both boundaries while keeping brainstorming and in-run steering conversational.

## What changed

- `docs/prompt-contracts.md` owns one frozen prompt per material executor attempt, the distinction from ordinary steering, and the requirement for a clean revised effective prompt when a material contract change must cross an execution, recovery, review, replay, restart, or handoff boundary.
- `docs/repo-readiness.md` owns the explicit discussion-to-tracked-execution transition and establishes any workflow-required planning artifact before downstream handoff generation. Existing planning and successor rules remain in `feature-lifecycle.md`.
- `docs/prompts.md` links Airtable delivery to the owning attempt rule. The general authority principles in `core-model.md` already apply and need no duplicate rule.

## Why

CAK-231 selects these two bounded workflow decisions. Detailed discussion does not commit the human to execution; a planning record or prompt artifact does not grant execution authority.

## Scope check

- [x] This PR contains one logical change.
- Documentation only; no changes to record schemas, tooling, AGENTS.md, or storage configuration.

## Interaction mode

Implementation, authorized by the CAK-231 attempt-2 handoff and current human direction. Delivery stops at this PR.

## Validation

- [x] `make check` — Markdown lint and all 176 existing tests passed.
- [x] Manual review — checked ordinary steering, a material revision crossing a durable boundary, exploratory discussion, explicit intent to proceed, existing planning items, and workflows without a planning-artifact requirement.
- [x] `git diff --check` passed.
- No prose-policing tests added. Freshly fetched main was the implementation base; the existing open PR #402 touches only the Codex adapter.

## Source evidence

- [CAK-231](https://linear.app/ctrl-alt-keith/issue/CAK-231/define-prompt-attempt-storage-and-discussion-to-execution-transition) owns the observed failures, selected outcome, and acceptance criteria.
- The exact attempt-2 Airtable handoff was independently verified before use.
- Current repository owners: `prompt-contracts.md`, `repo-readiness.md`, `prompts.md`, `core-model.md`, and `feature-lifecycle.md`.

## Residual risks / follow-ups

Candidate implementation identity: `a3b7db5271c00e4a26346ca729d807a1f29bc23e`.

This is a material doctrine proposal under `feature-lifecycle.md`: it adds a mandatory planning prerequisite before handoff and specifies a cross-executor prompt-attempt obligation. Governed independent artifact review and finding disposition remain required before human promotion. No governed review was performed in this PR-delivery task; manual review above is the implementer's inspection.

Recommendation: needs decision after the governed review prerequisite is satisfied. The next permitted step is review of this exact candidate, followed by explicit human promotion and merge authorization if accepted. Neither promotion nor merge is authorized or performed here. There are no separate design artifacts or outstanding implementation changes.

## Issue closure

Linear: CAK-231. Leave the planning issue open pending review and integration.
