### PR TITLE
fix: qualify Fable reviewer configuration

### DIFF
--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -305,22 +305,14 @@ evidence. The first `system/init` record must report exactly `Bash`, `Glob`,
 `Grep`, and `Read`; no MCP servers, plugins, skills, slash commands, or
 capability-startup error; `dontAsk` permission mode; the requested model family;
 and the exact attempt-scratch runtime directory. Stop the process on a mismatch
-and reject any eventual output. Family qualification is anchored rather than a
-substring check: the `fable` request currently admits only `fable`,
-`claude-fable-5`, and `claude-fable-5-1`. It rejects other families, malformed
-near-matches, and unqualified future Fable IDs until the accepted set is updated
-from current source evidence.
+and reject any eventual output. A `fable` request admits only `fable`,
+`claude-fable-5`, and `claude-fable-5-1`; other, malformed, and unknown future
+identities fail qualification.
 
-The initialization record reports the effective model, but it does not report
-effective effort. For an explicit governed effort request, the generated
-`PreToolUse` hook records the hook input's `effort.level`, which Anthropic
-documents as the level currently in effect and as reflecting any downgrade from
-an unsupported request. The receipt keeps requested effort separate from this
-hook-observed effective value. A mismatch or absent/invalid observation fails
-closed; in particular, requesting `high` never by itself supports an effective
-High claim. The launcher also removes inherited `CLAUDE_CODE_EFFORT_LEVEL` when
-it supplies an explicit `--effort`, preventing inherited configuration from
-silently replacing the task-owned request.
+Initialization does not report effective effort. For an explicit effort, the
+`PreToolUse` hook's current `effort.level` is the effective evidence. Receipts
+keep requested and observed effort separate; missing, invalid, or mismatched
+evidence fails closed, and a request alone never proves effective effort.
 
 The launcher still performs whole-source,
 Git-index, and Git-administration integrity checks because provider flags,
@@ -533,7 +525,7 @@ Other providers and error paths need not expose the same evidence or perform a
 server-side fallback. If effective identity is unavailable, record that
 limitation rather than treating the request as proof. Requalify, escalate, or
 stop only when the effective result violates a required capability or exact-model
-or effort reviewer qualification; a runtime event is not automatically fatal.
+reviewer qualification; a runtime event is not automatically fatal.
 
 If a lower-capability SAME THREAD reaches unresolved ambiguity, an architecture
 or authority decision, conflicting authoritative evidence, repeated residual

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -305,7 +305,24 @@ evidence. The first `system/init` record must report exactly `Bash`, `Glob`,
 `Grep`, and `Read`; no MCP servers, plugins, skills, slash commands, or
 capability-startup error; `dontAsk` permission mode; the requested model family;
 and the exact attempt-scratch runtime directory. Stop the process on a mismatch
-and reject any eventual output. The launcher still performs whole-source,
+and reject any eventual output. Family qualification is anchored rather than a
+substring check: the `fable` request currently admits only `fable`,
+`claude-fable-5`, and `claude-fable-5-1`. It rejects other families, malformed
+near-matches, and unqualified future Fable IDs until the accepted set is updated
+from current source evidence.
+
+The initialization record reports the effective model, but it does not report
+effective effort. For an explicit governed effort request, the generated
+`PreToolUse` hook records the hook input's `effort.level`, which Anthropic
+documents as the level currently in effect and as reflecting any downgrade from
+an unsupported request. The receipt keeps requested effort separate from this
+hook-observed effective value. A mismatch or absent/invalid observation fails
+closed; in particular, requesting `high` never by itself supports an effective
+High claim. The launcher also removes inherited `CLAUDE_CODE_EFFORT_LEVEL` when
+it supplies an explicit `--effort`, preventing inherited configuration from
+silently replacing the task-owned request.
+
+The launcher still performs whole-source,
 Git-index, and Git-administration integrity checks because provider flags,
 hooks, command-canary evidence, and initialization metadata are defense in
 depth, not proof that no effect occurred. It snapshots candidate-worktree and
@@ -437,7 +454,7 @@ retention, and visibility values remain outside this adapter.
 
 Choose the lowest-cost Claude Code model/configuration expected to preserve the
 confidence required by the bounded task. Do not infer a mapping from OpenAI
-model names or tiers. Current Claude Code documentation, checked 2026-08-10,
+model names or tiers. Current Claude Code documentation, checked 2026-09-04,
 establishes the executor-native `haiku`, `sonnet`, `opus`, and `fable` aliases:
 Haiku for simple fast tasks, Sonnet for daily coding, Opus for complex reasoning,
 and Fable for the hardest and longest-running tasks.
@@ -516,7 +533,7 @@ Other providers and error paths need not expose the same evidence or perform a
 server-side fallback. If effective identity is unavailable, record that
 limitation rather than treating the request as proof. Requalify, escalate, or
 stop only when the effective result violates a required capability or exact-model
-reviewer qualification; a runtime event is not automatically fatal.
+or effort reviewer qualification; a runtime event is not automatically fatal.
 
 If a lower-capability SAME THREAD reaches unresolved ambiguity, an architecture
 or authority decision, conflicting authoritative evidence, repeated residual
@@ -595,6 +612,7 @@ only when it materially affects operator review or action.
 Behavioral claims above are grounded in official Anthropic documentation,
 including [Claude Code memory](https://code.claude.com/docs/en/memory),
 [permissions](https://code.claude.com/docs/en/permissions),
+[hooks](https://code.claude.com/docs/en/hooks),
 [the tools reference](https://code.claude.com/docs/en/tools-reference),
 [subagents](https://code.claude.com/docs/en/sub-agents), and
 [worktrees](https://code.claude.com/docs/en/worktrees). Surface and hydration
@@ -611,4 +629,4 @@ guide](https://platform.claude.com/docs/en/about-claude/models/choosing-a-model)
 [models overview](https://platform.claude.com/docs/en/about-claude/models/overview),
 [thinking guide](https://platform.claude.com/docs/en/build-with-claude/thinking),
 and [fallback guide](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback),
-checked 2026-08-10.
+checked 2026-09-04.

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -41,6 +41,10 @@ INSTALLATION_SCHEMA_VERSION = 3
 QUALIFICATION_SCHEMA_VERSION = 3
 REVISION_ATOM = re.compile(r"(?:[0-9a-f]{40}|[0-9a-f]{64}|HEAD|origin/main)")
 REQUIRED_TOOLS = {"Bash", "Glob", "Grep", "Read"}
+MODEL_FAMILY_ALIASES = {"fable", "opus", "sonnet", "haiku"}
+CURRENT_FABLE_IDENTITIES = {"fable", "claude-fable-5", "claude-fable-5-1"}
+EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
+EFFORT_EVIDENCE_NAME = "effective-effort.json"
 WORKTREE_ADMIN_PATHS = ("HEAD", "index", "logs/HEAD", "COMMIT_EDITMSG", "ORIG_HEAD")
 OAUTH_REAUTHENTICATION_DISPOSITION = (
     "REVIEWER INFRASTRUCTURE FAILURE — OPERATOR REAUTHENTICATION REQUIRED"
@@ -1009,6 +1013,8 @@ def failure_fields(classification: str | None) -> dict[str, Any]:
 
 def preflight_arguments(arguments: list[str]) -> list[str]:
     """Keep the preflight harmless while retaining selected model/effort context."""
+    for option in ("--model", "--effort"):
+        selected_claude_option(arguments, option)
     selected: list[str] = []
     permitted = {"--model", "--effort"}
     index = 0
@@ -1031,6 +1037,53 @@ def preflight_arguments(arguments: list[str]) -> list[str]:
         else:
             index += 1
     return [*selected, "--tools", "", "--no-session-persistence"]
+
+
+def selected_claude_option(arguments: list[str], option: str) -> str | None:
+    """Return one exact Claude option value and reject ambiguous repetition."""
+    values: list[str] = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == option:
+            if index + 1 >= len(arguments):
+                raise ValueError(f"{option} requires a value")
+            value = arguments[index + 1]
+            if not value or value.startswith("-"):
+                raise ValueError(f"{option} requires a non-empty value, not another option")
+            values.append(value)
+            index += 2
+        elif argument.startswith(f"{option}="):
+            value = argument.partition("=")[2]
+            if not value or value.startswith("-"):
+                raise ValueError(f"{option} requires a valid value")
+            values.append(value)
+            index += 1
+        else:
+            index += 1
+    if len(values) > 1:
+        raise ValueError(f"{option} must be provided at most once")
+    return values[0] if values else None
+
+
+def model_family_matches(requested_model: str, effective_model: object) -> bool:
+    """Match documented Claude aliases to strict, currently qualified family IDs."""
+    if not isinstance(effective_model, str):
+        return False
+    requested = requested_model.lower()
+    if requested not in MODEL_FAMILY_ALIASES:
+        return requested_model == effective_model
+    if effective_model != effective_model.lower():
+        return False
+    if requested == "fable":
+        return effective_model in CURRENT_FABLE_IDENTITIES
+    if effective_model == requested:
+        return True
+    family = re.escape(requested)
+    return re.fullmatch(
+        rf"(?:claude-{family}-(?:3|4|5)(?:-[0-9]+)*|claude-(?:3|4|5)(?:-[0-9]+)*-{family}(?:-[0-9]+)*)",
+        effective_model,
+    ) is not None
 
 
 def redacted_argv(argv: list[str]) -> list[str]:
@@ -2393,7 +2446,12 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
     )
 
 
-def permission_hook(config_path: Path, expected_digest: str | None) -> int:
+def permission_hook(
+    config_path: Path,
+    expected_digest: str | None,
+    expected_effort: str | None,
+    effort_evidence_path: Path | None,
+) -> int:
     try:
         config = load_governed_config(config_path)
         if expected_digest is None or config.digest != expected_digest:
@@ -2407,10 +2465,50 @@ def permission_hook(config_path: Path, expected_digest: str | None) -> int:
             and command in allowed
             and tool_input.get("dangerouslyDisableSandbox") is not True
         )
-    except (OSError, ValueError, json.JSONDecodeError, TypeError):
+        effort_matches = True
+        if expected_effort is not None:
+            if expected_effort not in EFFORT_LEVELS or effort_evidence_path is None:
+                raise ValueError("effort qualification arguments are invalid")
+            hook_cwd = Path(hook_input["cwd"]).resolve(strict=True)
+            evidence_parent = effort_evidence_path.parent.resolve(strict=True)
+            if (
+                not effort_evidence_path.is_absolute()
+                or effort_evidence_path.name != EFFORT_EVIDENCE_NAME
+                or evidence_parent != hook_cwd
+            ):
+                raise ValueError("effort evidence path is outside the exact provider runtime directory")
+            raw_effort = hook_input.get("effort")
+            observed_effort = raw_effort.get("level") if isinstance(raw_effort, dict) else None
+            observation_status = "observed" if observed_effort in EFFORT_LEVELS else "unobservable"
+            observed_effort = observed_effort if observation_status == "observed" else None
+            effort_matches = observation_status == "observed" and observed_effort == expected_effort
+            evidence = {
+                "kind": "claude_governed_review_effort_qualification",
+                "requested_effort": expected_effort,
+                "effective_effort_observation": {
+                    "status": observation_status,
+                    "value": observed_effort,
+                    "source": "pre_tool_use_hook_input",
+                },
+                "matches": effort_matches,
+                "zero_authority": True,
+            }
+            encoded = canonical_json_bytes(evidence)
+            if effort_evidence_path.exists() or effort_evidence_path.is_symlink():
+                if effort_evidence_path.is_symlink() or effort_evidence_path.read_bytes() != encoded:
+                    raise ValueError("effort qualification evidence changed within one attempt")
+            else:
+                exclusive_write(effort_evidence_path, encoded)
+            permitted = permitted and effort_matches
+    except (OSError, ValueError, json.JSONDecodeError, KeyError, TypeError):
         permitted = False
     decision = "allow" if permitted else "deny"
-    reason = "exact observational command grant" if permitted else "command is outside the exact governed review grant"
+    if permitted:
+        reason = "exact observational command and effort grant"
+    elif expected_effort is not None and not locals().get("effort_matches", False):
+        reason = "effective effort did not exactly satisfy the governed review request"
+    else:
+        reason = "command is outside the exact governed review grant"
     print(
         json.dumps(
             {
@@ -2595,12 +2693,36 @@ def governed_system_prompt(config: GovernedReviewConfig) -> str:
     )
 
 
-def governed_claude_arguments(config: GovernedReviewConfig, model_arguments: list[str]) -> tuple[list[str], str]:
+def governed_claude_arguments(
+    config: GovernedReviewConfig,
+    model_arguments: list[str],
+    effort_evidence_path: Path | None = None,
+) -> tuple[list[str], str]:
     allowed_model_arguments = preflight_arguments(model_arguments)
     if len(allowed_model_arguments) != len(model_arguments) + 3:  # adds --tools, empty value, and no-persistence
         raise ValueError("governed review accepts only --model and --effort Claude arguments")
     allowed_model_arguments = allowed_model_arguments[:-3]
     allowed_tools = ["Read", "Grep", "Glob", *[f"Bash({shlex.join(list(argv))})" for argv in config.allowed_commands]]
+    requested_effort = selected_claude_option(model_arguments, "--effort")
+    if requested_effort is not None and requested_effort not in EFFORT_LEVELS:
+        raise ValueError("governed review effort is not a currently supported exact value")
+    hook_args = [
+        "--permission-hook",
+        str(config.path),
+        "--permission-hook-digest",
+        config.digest,
+    ]
+    if requested_effort is not None:
+        if effort_evidence_path is None:
+            raise ValueError("governed effort qualification requires an exact evidence path")
+        hook_args.extend(
+            (
+                "--permission-hook-expected-effort",
+                requested_effort,
+                "--permission-hook-effort-evidence",
+                str(effort_evidence_path),
+            )
+        )
     hook_settings = {
         "hooks": {
             "PreToolUse": [
@@ -2610,12 +2732,7 @@ def governed_claude_arguments(config: GovernedReviewConfig, model_arguments: lis
                         {
                             "type": "command",
                             "command": str(Path(__file__).resolve()),
-                            "args": [
-                                "--permission-hook",
-                                str(config.path),
-                                "--permission-hook-digest",
-                                config.digest,
-                            ],
+                            "args": hook_args,
                         }
                     ],
                 }
@@ -2840,26 +2957,71 @@ def init_capability_failure(
         return "invalid_effective_runtime_cwd"
     if effective_cwd != expected_cwd.resolve(strict=True):
         return "effective_runtime_cwd_mismatch"
-    requested_model = None
-    for index, argument in enumerate(model_arguments):
-        if argument == "--model" and index + 1 < len(model_arguments):
-            requested_model = model_arguments[index + 1]
-        elif argument.startswith("--model="):
-            requested_model = argument.split("=", 1)[1]
+    requested_model = selected_claude_option(model_arguments, "--model")
     if requested_model:
         effective_model = init.get("model")
-        aliases = {"opus", "sonnet", "haiku"}
-        matches = (
-            isinstance(effective_model, str)
-            and (
-                requested_model.lower() in effective_model.lower()
-                if requested_model.lower() in aliases
-                else requested_model == effective_model
-            )
-        )
-        if not matches:
+        if not model_family_matches(requested_model, effective_model):
             return "effective_model_mismatch"
     return None
+
+
+def effort_qualification_evidence(path: Path | None, requested_effort: str | None) -> tuple[dict[str, object], str | None]:
+    """Read exact hook-observed effort evidence for the completed attempt."""
+    if requested_effort is None:
+        return {
+            "requested_effort": None,
+            "effective_effort_observation": {"status": "not_requested", "value": None, "source": None},
+            "matches": None,
+        }, None
+    if path is None or not path.exists() or path.is_symlink():
+        return {
+            "requested_effort": requested_effort,
+            "effective_effort_observation": {
+                "status": "unobservable",
+                "value": None,
+                "source": "pre_tool_use_hook_input",
+            },
+            "matches": False,
+        }, "effective_effort_unobservable"
+    try:
+        evidence = json.loads(path.read_bytes())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {
+            "requested_effort": requested_effort,
+            "effective_effort_observation": {
+                "status": "invalid_evidence",
+                "value": None,
+                "source": "pre_tool_use_hook_input",
+            },
+            "matches": False,
+        }, "effective_effort_evidence_invalid"
+    expected_keys = {
+        "kind",
+        "requested_effort",
+        "effective_effort_observation",
+        "matches",
+        "zero_authority",
+    }
+    observation = evidence.get("effective_effort_observation") if isinstance(evidence, dict) else None
+    valid = (
+        isinstance(evidence, dict)
+        and set(evidence) == expected_keys
+        and evidence.get("kind") == "claude_governed_review_effort_qualification"
+        and evidence.get("requested_effort") == requested_effort
+        and isinstance(observation, dict)
+        and set(observation) == {"status", "value", "source"}
+        and observation.get("status") in {"observed", "unobservable"}
+        and observation.get("source") == "pre_tool_use_hook_input"
+        and evidence.get("zero_authority") is True
+        and isinstance(evidence.get("matches"), bool)
+    )
+    if not valid:
+        return evidence if isinstance(evidence, dict) else {}, "effective_effort_evidence_invalid"
+    if observation["status"] == "unobservable":
+        return evidence, "effective_effort_unobservable"
+    if observation["value"] not in EFFORT_LEVELS or evidence["matches"] is not True:
+        return evidence, "effective_effort_mismatch"
+    return evidence, None
 
 
 def retry_classification(parsed: dict[str, object], exit_code: int) -> tuple[str, bool]:
@@ -2962,7 +3124,12 @@ def run_governed_review(
     diagnostics_destination: Path | None,
 ) -> int:
     prompt_digest = sha256_bytes(prompt)
-    arguments, system_prompt = governed_claude_arguments(config, model_arguments)
+    preflight_arguments(model_arguments)
+    requested_model = selected_claude_option(model_arguments, "--model")
+    requested_effort = selected_claude_option(model_arguments, "--effort")
+    if requested_effort is not None and requested_effort not in EFFORT_LEVELS:
+        raise ValueError("governed review effort is not a currently supported exact value")
+    system_prompt = governed_system_prompt(config)
     contract_identity = {
         "config_sha256": config.digest,
         "prompt_sha256": prompt_digest,
@@ -3041,7 +3208,6 @@ def run_governed_review(
             emit_diagnostics(record, diagnostics_destination)
             return REVIEWER_FAILURE_EXIT
 
-        command = [executable, "-p", *arguments]
         attempt_summaries: list[dict[str, object]] = []
         candidate_identity_checks: list[dict[str, object]] = []
         final_output: str | None = None
@@ -3097,6 +3263,15 @@ def run_governed_review(
                 return REVIEWER_FAILURE_EXIT
             attempt_scratch = AttemptScratch.allocate(child_environment, "claude-review-attempt-")
             environment = safe_command_environment(child_environment, attempt_scratch.path)
+            effort_evidence_path = (
+                attempt_scratch.path / EFFORT_EVIDENCE_NAME if requested_effort is not None else None
+            )
+            arguments, _ = governed_claude_arguments(
+                config,
+                model_arguments,
+                effort_evidence_path,
+            )
+            command = [executable, "-p", *arguments]
             attempt_id = f"{config.body['review_id']}-{attempt_number}-{uuid.uuid4().hex}"
             attempt_snapshot = source_snapshot(
                 list(config.guard_roots), config.candidate, environment, config.allowed_commands, config.candidate_head
@@ -3443,6 +3618,10 @@ def run_governed_review(
                 expected_cwd=attempt_scratch.path,
                 model_arguments=model_arguments,
             )
+            effort_evidence, effort_failure = effort_qualification_evidence(
+                effort_evidence_path,
+                requested_effort,
+            )
             canary_failure = provider_command_canary_failure(parsed, config.allowed_commands[0])
             classification, retryable = retry_classification(parsed, process.returncode)
             auth_failure = classify_failure(
@@ -3457,7 +3636,10 @@ def run_governed_review(
                 classification = capability_failure or live_capability_failure or "startup_capability_error"
                 retryable = False
                 live_state["capability_failure"] = classification
-            if canary_failure:
+            elif effort_failure:
+                classification = effort_failure
+                retryable = False
+            elif canary_failure:
                 classification = canary_failure
                 retryable = False
             if live_state.get("termination_authority"):
@@ -3531,6 +3713,26 @@ def run_governed_review(
                     "provider_runtime_cwd": str(attempt_scratch.path),
                     "HOME": environment["HOME"],
                     "effective_init": parsed.get("init"),
+                    "configuration_qualification": {
+                        "requested": {
+                            "model": requested_model,
+                            "effort": requested_effort,
+                        },
+                        "effective": {
+                            "model": (
+                                parsed["init"].get("model")
+                                if isinstance(parsed.get("init"), dict)
+                                else None
+                            ),
+                            "effort": effort_evidence["effective_effort_observation"],
+                        },
+                        "model_matches": (
+                            model_family_matches(requested_model, parsed["init"].get("model"))
+                            if requested_model is not None and isinstance(parsed.get("init"), dict)
+                            else None
+                        ),
+                        "effort_matches": effort_evidence["matches"],
+                    },
                 },
                 "attempt_scratch": {**scratch_record, "cleanup": scratch_cleanup},
                 "failure_classification": None if classification == "success" else classification,
@@ -3685,6 +3887,8 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     operation.add_argument("--review-config-fixture", type=Path, help=argparse.SUPPRESS)
     operation.add_argument("--permission-hook", type=Path)
     parser.add_argument("--permission-hook-digest")
+    parser.add_argument("--permission-hook-expected-effort")
+    parser.add_argument("--permission-hook-effort-evidence", type=Path)
     operation.add_argument("--request-termination", type=Path)
     operation.add_argument("--decline-termination", type=Path)
     operation.add_argument("--terminate", type=Path)
@@ -3702,6 +3906,15 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
         parser.error("do not pass Claude prompt flags; provide the prompt on standard input")
     if args.permission_hook is None and args.permission_hook_digest is not None:
         parser.error("--permission-hook-digest requires --permission-hook")
+    effort_hook_arguments = (
+        args.permission_hook_expected_effort,
+        args.permission_hook_effort_evidence,
+    )
+    if args.permission_hook is None and any(value is not None for value in effort_hook_arguments):
+        parser.error("effort qualification arguments require --permission-hook")
+    if args.permission_hook is not None and any(value is not None for value in effort_hook_arguments):
+        if not all(value is not None for value in effort_hook_arguments):
+            parser.error("effort qualification requires both expected effort and evidence path")
     if args.terminate is None and any(
         value is not None for value in (args.termination_authority, args.grace_seconds)
     ):
@@ -3732,7 +3945,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.review_config_fixture is not None:
         args.review_config = args.review_config_fixture
     if args.permission_hook:
-        return permission_hook(args.permission_hook, args.permission_hook_digest)
+        return permission_hook(
+            args.permission_hook,
+            args.permission_hook_digest,
+            args.permission_hook_expected_effort,
+            args.permission_hook_effort_evidence,
+        )
     if args.request_termination:
         return request_or_decline_termination(args.request_termination, decline=False)
     if args.decline_termination:
@@ -3889,6 +4107,8 @@ def main(argv: list[str] | None = None) -> int:
     inherited_home = os.environ.get("HOME")
     child_environment = os.environ.copy()
     child_environment.pop("CLAUDE_REVIEW_TEST_EFFECTIVE_HOME", None)
+    if selected_claude_option(args.claude_args, "--effort") is not None:
+        child_environment.pop("CLAUDE_CODE_EFFORT_LEVEL", None)
     if not execution_fixture:
         child_environment.pop("CLAUDE_REVIEW_TEST_FIXTURE", None)
         child_environment.pop("CLAUDE_REVIEW_TEST_SCRATCH_PARENT", None)

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -2023,7 +2023,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "candidate = pathlib.Path(os.environ['FAKE_CANDIDATE'])\n"
             "package = pathlib.Path(os.environ['FAKE_PACKAGE'])\n"
             "tools = ['Bash','Glob','Grep'] if scenario == 'tool_mismatch' else ['Bash','Glob','Grep','Read']\n"
-            "model = 'wrong-exact-model' if scenario == 'model_mismatch' else os.environ.get('FAKE_EFFECTIVE_MODEL', 'fake-opus')\n"
+            "model = 'wrong-exact-model' if scenario == 'model_mismatch' else os.environ.get('FAKE_EFFECTIVE_MODEL', 'claude-opus-5')\n"
             "cwd = str(candidate) if scenario == 'cwd_mismatch' else os.getcwd()\n"
             "print(json.dumps({'type':'system','subtype':'init','session_id':f's{attempt}','model':model,'tools':tools,'mcp_servers':[],'permissionMode':'dontAsk','plugins':[],'skills':[],'slash_commands':[],'cwd':cwd} ), flush=True)\n"
             "canary_id = f'canary-{attempt}'\n"
@@ -2031,7 +2031,17 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "canary_input = {'command': canary_command}\n"
             "if scenario == 'canary_bypass': canary_input['dangerouslyDisableSandbox'] = True\n"
             "print(json.dumps({'type':'assistant','message':{'content':[{'type':'tool_use','id':canary_id,'name':'Bash','input':canary_input}]}}), flush=True)\n"
-            "print(json.dumps({'type':'user','message':{'content':[{'type':'tool_result','tool_use_id':canary_id,'content':'canary','is_error':scenario == 'dead_command_grant'}]}}), flush=True)\n"
+            "settings_index = sys.argv.index('--settings')\n"
+            "settings = json.loads(sys.argv[settings_index + 1])\n"
+            "hook = settings['hooks']['PreToolUse'][0]['hooks'][0]\n"
+            "hook_input = {'cwd':os.getcwd(),'permission_mode':'dontAsk','hook_event_name':'PreToolUse','tool_name':'Bash','tool_input':canary_input}\n"
+            "effective_effort = os.environ.get('FAKE_EFFECTIVE_EFFORT','high')\n"
+            "if scenario == 'inherited_effort_override': effective_effort = os.environ.get('CLAUDE_CODE_EFFORT_LEVEL', effective_effort)\n"
+            "if scenario != 'effort_unobservable': hook_input['effort'] = {'level':effective_effort}\n"
+            "hook_result = subprocess.run([hook['command'], *hook['args']], input=json.dumps(hook_input), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
+            "hook_output = json.loads(hook_result.stdout)\n"
+            "hook_denied = hook_output['hookSpecificOutput']['permissionDecision'] != 'allow'\n"
+            "print(json.dumps({'type':'user','message':{'content':[{'type':'tool_result','tool_use_id':canary_id,'content':'canary','is_error':scenario == 'dead_command_grant' or hook_denied}]}}), flush=True)\n"
             "if scenario == 'non_object_json': print('null', flush=True)\n"
             "if scenario == 'tool_mismatch': time.sleep(0.08)\n"
             "if scenario == 'cwd_mismatch': time.sleep(0.08)\n"
@@ -2166,7 +2176,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         path.write_text(json.dumps(body or self.config_body()), encoding="utf-8")
         return path
 
-    def environment(self, scenario):
+    def environment(self, scenario, *, effective_model=None, effective_effort=None):
         environment = os.environ.copy()
         environment.update(
             {
@@ -2186,9 +2196,22 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             environment["FAKE_PRIMARY_WORKTREE"] = str(self.primary_worktree)
         if hasattr(self, "isolated_home"):
             environment["CLAUDE_REVIEW_TEST_EFFECTIVE_HOME"] = str(self.isolated_home)
+        if effective_model is not None:
+            environment["FAKE_EFFECTIVE_MODEL"] = effective_model
+        if effective_effort is not None:
+            environment["FAKE_EFFECTIVE_EFFORT"] = effective_effort
         return environment
 
-    def run_governed(self, scenario="success", *, body=None, model="opus"):
+    def run_governed(
+        self,
+        scenario="success",
+        *,
+        body=None,
+        model="opus",
+        effort="high",
+        effective_model=None,
+        effective_effort=None,
+    ):
         config = self.write_config(body)
         diagnostics = self.evidence / "overall.json"
         if diagnostics.exists() or diagnostics.is_symlink():
@@ -2217,14 +2240,18 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
                 "--model",
                 model,
                 "--effort",
-                "high",
+                effort,
             ],
             check=False,
             input="exact review prompt\n",
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            env=self.environment(scenario),
+            env=self.environment(
+                scenario,
+                effective_model=effective_model,
+                effective_effort=effective_effort,
+            ),
         )
         if diagnostics.exists():
             diagnostic = json.loads(diagnostics.read_text(encoding="utf-8"))
@@ -2376,11 +2403,93 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertTrue(receipt["lifecycle"]["process_group_terminal"])
 
     def test_exact_model_selector_is_enforced(self):
-        exact, _ = self.run_governed(model="fake-opus")
+        exact, _ = self.run_governed(model="fake-opus", effective_model="fake-opus")
         self.assertEqual(exact.returncode, 0)
-        mismatch, diagnostic = self.run_governed("model_mismatch", model="fake-opus")
+        mismatch, diagnostic = self.run_governed(
+            "model_mismatch",
+            model="fake-opus",
+            effective_model="fake-opus",
+        )
         self.assertEqual(mismatch.returncode, 70)
         self.assertEqual(diagnostic["failure_classification"], "effective_model_mismatch")
+
+    def test_fable_family_accepts_current_exact_runtime_identity(self):
+        completed, _ = self.run_governed(model="fable", effective_model="claude-fable-5")
+        self.assertEqual(completed.returncode, 0)
+
+    def test_fable_family_rejects_other_or_unknown_runtime_identities(self):
+        for effective_model in (
+            "claude-opus-5",
+            "claude-sonnet-5",
+            "unknown",
+            "claude-fable-6",
+            "claude-fable-5-preview",
+            "Claude-Fable-5",
+        ):
+            with self.subTest(effective_model=effective_model):
+                completed, diagnostic = self.run_governed(
+                    model="fable",
+                    effective_model=effective_model,
+                )
+                self.assertEqual(completed.returncode, 70)
+                self.assertEqual(diagnostic["failure_classification"], "effective_model_mismatch")
+
+    def test_non_fable_family_rejects_fable_runtime_identity(self):
+        completed, diagnostic = self.run_governed(
+            model="opus",
+            effective_model="claude-fable-5",
+        )
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "effective_model_mismatch")
+
+    def test_existing_family_aliases_accept_canonical_runtime_identities(self):
+        for family in ("haiku", "sonnet", "opus"):
+            with self.subTest(family=family):
+                completed, _ = self.run_governed(
+                    model=family,
+                    effective_model=f"claude-{family}-5",
+                )
+                self.assertEqual(completed.returncode, 0)
+
+    def test_effective_high_effort_is_observed_separately_from_request(self):
+        completed, _ = self.run_governed(effort="high", effective_effort="high")
+        self.assertEqual(completed.returncode, 0)
+        qualification = self.receipts()[0]["runtime"]["configuration_qualification"]
+        self.assertEqual(qualification["requested"]["effort"], "high")
+        self.assertEqual(
+            qualification["effective"]["effort"],
+            {
+                "status": "observed",
+                "value": "high",
+                "source": "pre_tool_use_hook_input",
+            },
+        )
+        self.assertTrue(qualification["effort_matches"])
+
+    def test_effective_effort_mismatch_fails_closed(self):
+        completed, diagnostic = self.run_governed(effort="high", effective_effort="low")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "effective_effort_mismatch")
+        qualification = self.receipts()[0]["runtime"]["configuration_qualification"]
+        self.assertEqual(qualification["effective"]["effort"]["value"], "low")
+        self.assertFalse(qualification["effort_matches"])
+
+    def test_explicit_effort_removes_inherited_effort_override(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_EFFORT_LEVEL": "low"}):
+            completed, _ = self.run_governed("inherited_effort_override", effort="high")
+        self.assertEqual(completed.returncode, 0)
+        qualification = self.receipts()[0]["runtime"]["configuration_qualification"]
+        self.assertEqual(qualification["effective"]["effort"]["value"], "high")
+
+    def test_unobservable_effective_effort_fails_closed_without_claiming_high(self):
+        completed, diagnostic = self.run_governed("effort_unobservable", effort="high")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "effective_effort_unobservable")
+        qualification = self.receipts()[0]["runtime"]["configuration_qualification"]
+        self.assertEqual(qualification["requested"]["effort"], "high")
+        self.assertEqual(qualification["effective"]["effort"]["status"], "unobservable")
+        self.assertIsNone(qualification["effective"]["effort"]["value"])
+        self.assertFalse(qualification["effort_matches"])
 
     def test_candidate_head_drift_before_first_attempt_baseline_stops_without_provider_spawn(self):
         result, diagnostic = self.run_governed_with_head_mutation(verification_call=2)
@@ -2456,6 +2565,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         arguments, system_prompt = module.governed_claude_arguments(
             config,
             ["--model", "opus", "--effort", "high"],
+            scratch / module.EFFORT_EVIDENCE_NAME,
         )
         settings = json.loads(arguments[arguments.index("--settings") + 1])
         self.assertNotIn("sandbox", settings)


### PR DESCRIPTION
## Summary

- add strict Fable-family qualification, including the observed claude-fable-5 runtime identity, while rejecting other families, malformed near-matches, and unknown future identities
- qualify requested effort against the effective level reported by the PreToolUse hook, preserving requested and observed values separately and failing closed when High is downgraded or unobservable
- retain the existing governed canary, executable identity, source-integrity, retry, and lifecycle controls; add focused regression coverage and update the Claude adapter from official model and hook sources

Linear: [CAK-234](https://linear.app/ctrl-alt-keith/issue/CAK-234/teach-governed-claude-review-launcher-to-qualify-fable-and-verify-high)

## Validation

- focused Fable and effort qualification cases: 8 passed
- full Claude launcher module: 139 passed
- make check: Markdown lint clean; 184 tests passed
- git diff --check: passed

## Production installation boundary

The reviewed launcher source is 99b9b942934d4ba1c0d0991e04f4bcb39175f9fea07366b7816517bd2c77e6b6. The current machine-local launcher remains b0f1ac98a6c45185ec38f4a0fcf1c754641ff7a5f6fb1c8ac217a9a2f60ef2ad under immutable entry contract sha256:8fac51d95541277381ca91036747227c585d5aebbf6b7e284e26c3dda5663c77. The governed installer refuses a different existing launcher object, and CAK-234 does not authorize unsafe/manual replacement. Therefore no launcher, qualification receipt, or Codex rule was mutated. A separate human-owned transition must authorize either a governed contract-upgrade mechanism or retirement and reviewed reinstallation of the existing contract before production activation.

No CAK-233 review was launched or retried. PR #404 was not touched. Nothing was merged.