### PR TITLE
CAK-237: qualify Codex Astra selectors

### DIFF
--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -16,7 +16,7 @@ confidence required by the bounded task. Model selection and reasoning effort
 are separate configuration decisions: select both deliberately, and do not
 default substantial work to Sol or Astra merely because it is long-running.
 
-The official model references, checked 2026-09-04, position
+The official model references, checked 2026-09-05, position
 [GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra)
 (`gpt-6-astra`) for the hardest end-to-end reasoning, coding, computer-use,
 research, and document tasks;
@@ -91,6 +91,27 @@ Astra's existence does not require a change to the
 hosted stewardship gains no model dependency; residual model-backed jobs are
 candidates for later qualification on their actual execution surfaces.
 
+### Codex Selector Qualification
+
+For FRESH THREAD and CHILD TASK attempts, record the requested model, exact
+selector, runtime-reported effective model (or `unobservable`), and any
+substitution separately. API IDs are candidates, not Codex acceptance proof.
+Use only these exact mappings; reject aliases, near-matches, and guessed IDs.
+
+| Requested model | Exact Codex selector |
+| --- | --- |
+| `GPT-6 Astra` | `gpt-6-astra` |
+| `GPT-5.6 Luna` | `gpt-5.6-luna` |
+| `GPT-5.6 Terra` | `gpt-5.6-terra` |
+| `GPT-5.6 Sol` | `gpt-5.6-sol` |
+
+Use `scripts/codex-preflight` with the exact
+`CODEX_PREFLIGHT_REQUESTED_MODEL` value. Its read-only probe fails before
+substantive work on rejection; preserve and reuse its runtime evidence until
+the client, identity, policy, or surface changes. It never selects fallback:
+exact-model requirements fail closed, while advisory fallback remains
+orchestration-owned and explicit. Reasoning effort is independent.
+
 ### Escalation And Delegation
 
 Escalate a lower-cost task only on evidence: unresolved ambiguity after a
@@ -115,7 +136,8 @@ work for other purposes.
 Apply the shared `FRESH THREAD`, `SAME THREAD`, and `CHILD TASK` vocabulary in
 [`prompts.md`](../prompts.md#thread-routing-and-configuration-continuity). For
 a FRESH THREAD, select the task-appropriate model and effort using the matrix
-and provisional Astra guidance above.
+and provisional Astra guidance above, after the selected runtime qualifies its
+exact selector.
 For a SAME THREAD, preserve the requested parent model and effort by default:
 task-class sufficiency alone does not justify intentionally mutating an
 already-running configuration. Record the effective model and effort separately
@@ -210,7 +232,7 @@ executable prompt with this plain-text operator metadata:
 
 ```text
 Thread routing: <FRESH THREAD | SAME THREAD | CHILD TASK>
-Recommended model: <FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol | GPT-6 Astra (provisional); SAME THREAD: Preserve requested thread model and observe effective runtime model>
+Recommended model: <FRESH THREAD/CHILD TASK: GPT-5.6 Luna | GPT-5.6 Terra | GPT-5.6 Sol | GPT-6 Astra (provisional; exact Codex selector must be qualified); SAME THREAD: Preserve requested thread model and observe effective runtime model>
 Recommended reasoning level: <FRESH THREAD/CHILD TASK: Light | Medium | High; SAME THREAD: Preserve requested thread setting and observe effective runtime setting>
 
 Reason:
@@ -278,7 +300,7 @@ setting.
 This posture is derived from OpenAI's current
 [model guidance](https://developers.openai.com/api/docs/guides/latest-model)
 and [OpenAI models reference](https://developers.openai.com/api/docs/models),
-checked 2026-09-04. Provider positioning supports candidate selection; the
+checked 2026-09-05. Provider positioning supports candidate selection; the
 Playbook's task-class defaults still require workload evidence.
 
 ## Prompt-Contract Mapping

--- a/scripts/codex-preflight
+++ b/scripts/codex-preflight
@@ -36,6 +36,40 @@ require_command "ssh" "Install OpenSSH client tools, then rerun this preflight."
 require_command "gh" "Install GitHub CLI from https://cli.github.com/, then rerun this preflight."
 require_command "git" "Install Git, then rerun this preflight."
 
+qualify_requested_model() {
+    requested_model="$1"
+
+    case "$requested_model" in
+        "GPT-6 Astra") execution_selector="gpt-6-astra" ;;
+        "GPT-5.6 Luna") execution_selector="gpt-5.6-luna" ;;
+        "GPT-5.6 Terra") execution_selector="gpt-5.6-terra" ;;
+        "GPT-5.6 Sol") execution_selector="gpt-5.6-sol" ;;
+        *)
+            fail_check \
+                "requested model is an exact supported Playbook identity" \
+                "Use GPT-6 Astra, GPT-5.6 Luna, GPT-5.6 Terra, or GPT-5.6 Sol; do not use aliases or guessed identifiers."
+            ;;
+    esac
+
+    require_command "codex" "Install or update Codex CLI, then rerun this model qualification."
+    info_check "requested model: $requested_model"
+    info_check "execution selector: $execution_selector"
+
+    if codex exec \
+        --ephemeral \
+        --skip-git-repo-check \
+        --sandbox read-only \
+        --model "$execution_selector" \
+        "Return exactly MODEL_QUALIFICATION_OK. Do not call tools or inspect files."; then
+        pass_check "Codex runtime accepted execution selector $execution_selector"
+        info_check "record the effective model only from Codex runtime output; otherwise record it as unobservable"
+    else
+        fail_check \
+            "Codex runtime accepted execution selector $execution_selector" \
+            "Keep the requested model separate from any permitted fallback, preserve this runtime output as capability evidence, and requalify after the Codex client or model access changes."
+    fi
+}
+
 ssh_host="${SSH_TARGET#git@}"
 repo_authority="${REPO_URL#git@}"
 repo_host="${repo_authority%%:*}"
@@ -110,6 +144,10 @@ else
     fail_check \
         "playbook repository is reachable with git ls-remote" \
         "Confirm GitHub SSH access and repository permission, then rerun git ls-remote $REPO_URL HEAD."
+fi
+
+if [ -n "${CODEX_PREFLIGHT_REQUESTED_MODEL:-}" ]; then
+    qualify_requested_model "$CODEX_PREFLIGHT_REQUESTED_MODEL"
 fi
 
 printf 'PASS Codex local automation preflight complete\n'

--- a/tests/test_codex_preflight.py
+++ b/tests/test_codex_preflight.py
@@ -322,6 +322,106 @@ class CodexPreflightTest(unittest.TestCase):
         self.assertNotIn("ssh-add -l", result.stdout)
         self.assertNotIn("GitHub SSH connectivity works", result.stdout)
 
+    def test_exact_requested_model_uses_the_qualified_selector(self) -> None:
+        cases = {
+            "GPT-6 Astra": "gpt-6-astra",
+            "GPT-5.6 Luna": "gpt-5.6-luna",
+            "GPT-5.6 Terra": "gpt-5.6-terra",
+            "GPT-5.6 Sol": "gpt-5.6-sol",
+        }
+
+        for requested_model, selector in cases.items():
+            with self.subTest(requested_model=requested_model):
+                commands = self.fake_success_commands()
+                commands["codex"] = f"""
+                    if [ \"$1\" = \"exec\" ] && [ \"$2\" = \"--ephemeral\" ] && [ \"$3\" = \"--skip-git-repo-check\" ] && [ \"$4\" = \"--sandbox\" ] && [ \"$5\" = \"read-only\" ] && [ \"$6\" = \"--model\" ] && [ \"$7\" = \"{selector}\" ]; then
+                        printf '%s\\n' MODEL_QUALIFICATION_OK
+                        exit 0
+                    fi
+                    exit 2
+                """
+
+                result = self.run_preflight(
+                    commands,
+                    {"CODEX_PREFLIGHT_REQUESTED_MODEL": requested_model},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertIn(f"INFO requested model: {requested_model}", result.stdout)
+                self.assertIn(f"INFO execution selector: {selector}", result.stdout)
+                self.assertIn(
+                    f"PASS Codex runtime accepted execution selector {selector}",
+                    result.stdout,
+                )
+                self.assertIn(
+                    "INFO record the effective model only from Codex runtime output",
+                    result.stdout,
+                )
+
+    def test_successful_qualification_does_not_infer_effective_model(self) -> None:
+        commands = self.fake_success_commands()
+        commands["codex"] = """
+            if [ \"$1\" = \"exec\" ] && [ \"$7\" = \"gpt-6-astra\" ]; then
+                printf '%s\\n' MODEL_QUALIFICATION_OK
+                exit 0
+            fi
+            exit 2
+        """
+
+        result = self.run_preflight(
+            commands,
+            {"CODEX_PREFLIGHT_REQUESTED_MODEL": "GPT-6 Astra"},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS Codex runtime accepted execution selector gpt-6-astra", result.stdout)
+        self.assertIn(
+            "INFO record the effective model only from Codex runtime output",
+            result.stdout,
+        )
+        self.assertNotIn("effective model: GPT-6 Astra", result.stdout)
+        self.assertNotIn("effective model: gpt-6-astra", result.stdout)
+
+    def test_astra_runtime_rejection_fails_before_substantive_work(self) -> None:
+        commands = self.fake_success_commands()
+        commands["codex"] = """
+            if [ \"$1\" = \"exec\" ] && [ \"$7\" = \"gpt-6-astra\" ]; then
+                printf '%s\\n' 'The gpt-6-astra model requires a newer version of Codex.' >&2
+                exit 1
+            fi
+            exit 2
+        """
+
+        result = self.run_preflight(
+            commands,
+            {"CODEX_PREFLIGHT_REQUESTED_MODEL": "GPT-6 Astra"},
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("INFO requested model: GPT-6 Astra", result.stdout)
+        self.assertIn("INFO execution selector: gpt-6-astra", result.stdout)
+        self.assertIn("FAIL Codex runtime accepted execution selector gpt-6-astra", result.stdout)
+        self.assertIn("preserve this runtime output as capability evidence", result.stdout)
+        self.assertIn("requires a newer version of Codex", result.stderr)
+        self.assertNotIn("Codex local automation preflight complete", result.stdout)
+
+    def test_malformed_requested_model_is_rejected_without_calling_codex(self) -> None:
+        commands = self.fake_success_commands()
+        commands["codex"] = """
+            printf '%s\\n' SHOULD_NOT_RUN
+            exit 0
+        """
+
+        result = self.run_preflight(
+            commands,
+            {"CODEX_PREFLIGHT_REQUESTED_MODEL": "GPT-6 Astra v2"},
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("FAIL requested model is an exact supported Playbook identity", result.stdout)
+        self.assertIn("do not use aliases or guessed identifiers", result.stdout)
+        self.assertNotIn("SHOULD_NOT_RUN", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- qualify only exact Playbook model identities through the existing read-only Codex preflight
- record requested model, execution selector, runtime-reported effective model, and explicit substitutions separately
- fail before substantive work for unavailable selectors; fallback remains orchestration-owned

## Validation

- make check
- make authoritative-source-check
- python3 -m unittest tests/test_codex_preflight.py
- live read-only Astra qualification with codex-cli 0.153.4

Linear: CAK-237
Observed consumer: CAK-236 (not modified or restarted).