### PR TITLE
CAK-230: Harden Airtable prompt routing and operator handoff

### DIFF
--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -344,7 +344,7 @@ fails closed and records diagnostic evidence when possible.
 Use this profile when exact rendered-prompt bytes become a dependency for an
 executor attempt, review, recovery, or replay. It is an operational
 profile of the prompt contract and governed-artifact lifecycle. For qualifying
-small canonical-text ChatGPT/Claude handoffs, it uses the shared
+small canonical-text ChatGPT, Claude, or Codex handoffs, it uses the shared
 [`Airtable canonical-text handoff`](prompts.md#airtable-canonical-text-handoff).
 It is not a general Airtable artifact store, prompt-management platform, or
 requirement to preserve routine prompts.

--- a/docs/prompt-contracts.md
+++ b/docs/prompt-contracts.md
@@ -344,7 +344,7 @@ fails closed and records diagnostic evidence when possible.
 Use this profile when exact rendered-prompt bytes become a dependency for an
 executor attempt, review, recovery, or replay. It is an operational
 profile of the prompt contract and governed-artifact lifecycle. For qualifying
-small canonical-text ChatGPT, Claude, or Codex handoffs, it uses the shared
+small canonical-text handoffs to an eligible machine recipient, it uses the shared
 [`Airtable canonical-text handoff`](prompts.md#airtable-canonical-text-handoff).
 It is not a general Airtable artifact store, prompt-management platform, or
 requirement to preserve routine prompts.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -351,15 +351,20 @@ material, isolated snippets, and incomplete fragments remain lightweight.
 ## Prompt Delivery Decision Model
 
 Keep prompt delivery small and deterministic. Classify the produced artifact,
-resolve the execution recipient independently from the human viewer, and then
-select one presentation:
+identify the human operator or viewer, resolve the execution recipient
+independently, and then select one presentation. Wording such as `show me`,
+`give me`, or `prompt me` can identify the human viewer without making that
+human the execution recipient. When the same request clearly designates a
+machine to execute the work, that machine remains the execution recipient even
+when the human manually creates or launches its downstream thread.
 
 - no prompt: no delivery action;
 - conceptual fragment: lightweight conversational presentation;
 - complete prompt for a human recipient: the canonical inline two-block
   presentation;
-- qualifying small canonical-text prompt for a ChatGPT or Claude machine
-  recipient with a permitted Airtable route: the Airtable record handoff below;
+- qualifying small canonical-text prompt for a ChatGPT, Claude, or Codex
+  machine recipient with a permitted Airtable route: the Airtable record
+  handoff below;
   or
 - missing, unresolved, or mismatched recipient, route, destination, or required
   identity: a clear blocked result with no alternate renderer.
@@ -370,11 +375,35 @@ for a qualifying small canonical-text handoff. A separately authorized workflow
 may select file-backed delivery only when its payload actually requires
 arbitrary bytes or provider file identity, revision, or checksum behavior.
 
+### Recipient-routing qualification cases
+
+These cases exercise the decision model above; they do not define another
+delivery model. The stable case IDs and semantic values are validated by the
+repository test suite. Request examples remain explanatory rather than
+machine-consumed text.
+
+| Case | Produced artifact | Operator/viewer | Execution recipient | Downstream surface | Route capability | Selected delivery |
+| --- | --- | --- | --- | --- | --- | --- |
+| `human-personal-use` | `complete` | `human` | `human` | `human` | `not-required` | `inline-two-block` |
+| `cak-228-prompt-me-codex` | `complete` | `human` | `codex` | `codex-fresh-thread` | `permitted` | `airtable-thin-handoff` |
+| `claude-executes` | `complete` | `human` | `claude` | `claude-execution` | `permitted` | `airtable-thin-handoff` |
+| `chatgpt-executes` | `complete` | `human` | `chatgpt` | `chatgpt-execution` | `permitted` | `airtable-thin-handoff` |
+| `manual-codex-launch` | `complete` | `human` | `codex` | `codex-manual-fresh-thread` | `permitted` | `airtable-thin-handoff` |
+| `machine-route-unavailable` | `complete` | `human` | `codex` | `codex-fresh-thread` | `unavailable` | `blocked` |
+| `machine-route-unresolved` | `complete` | `human` | `codex` | `codex-fresh-thread` | `unresolved` | `blocked` |
+| `human-reads-complete-prompt` | `complete` | `human` | `human` | `human` | `not-required` | `inline-two-block` |
+| `conceptual-fragment` | `fragment` | `human` | `none` | `none` | `not-applicable` | `lightweight` |
+
+For `cak-228-prompt-me-codex`, the representative request is “Prompt me to have
+Codex do X.” The operator receives launch guidance, while Codex receives and
+executes the complete prompt. `manual-codex-launch` makes the same distinction
+when the operator creates the Codex thread by hand.
+
 ### Airtable canonical-text handoff
 
-This section owns the shared ChatGPT/Claude handoff contract. Adapters map its
-operations to the connector actions exposed by each executor; they do not copy
-or redefine these rules.
+This section owns the shared ChatGPT/Claude/Codex handoff contract. Adapters map
+its operations to the connector actions exposed by each executor; they do not
+copy or redefine these rules.
 
 A handoff qualifies as small canonical text when the frozen payload fits
 unchanged in one `Payload` long-text field and within the current connector's
@@ -424,13 +453,17 @@ This section applies the decision model symmetrically when one executor
 produces a complete prompt for another: each direction is governed by the same
 shared presentation and handoff contract.
 
-For a qualifying small canonical-text ChatGPT/Claude machine handoff, apply the
-[Airtable contract](#airtable-canonical-text-handoff) and provide the target-
-shaped thin envelope without reproducing the complete prompt in chat. For a
-human execution recipient, use the matching adapter's canonical inline
-presentation. Inspect unknown connector capability before selection; if the
-required Airtable route or identity is unavailable, fail clearly rather than
-switching to file-backed delivery or reconstructing the prompt in chat.
+For a qualifying small canonical-text ChatGPT, Claude, or Codex machine
+handoff, apply the [Airtable contract](#airtable-canonical-text-handoff) and
+provide the target-shaped thin envelope without reproducing the complete prompt
+in chat. On success, keep the operator-visible result to the matching adapter's
+launch or configuration guidance plus the required external envelope. Do not
+replay the complete stored payload or routine discovery, creation, hashing, and
+readback mechanics. For a human execution recipient, use the matching adapter's
+canonical inline presentation. Inspect unknown connector capability before
+selection; if the required Airtable route or identity is unavailable, fail
+clearly rather than switching to file-backed delivery or reconstructing the
+prompt in chat.
 
 Prompt governance remains a separate selection. A material prompt that passes
 its admission test additionally applies the

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -378,20 +378,19 @@ arbitrary bytes or provider file identity, revision, or checksum behavior.
 ### Recipient-routing qualification cases
 
 These cases exercise the decision model above; they do not define another
-delivery model. The stable case IDs and semantic values are validated by the
-repository test suite. Request examples remain explanatory rather than
-machine-consumed text.
+delivery model. The repository test suite validates their routing properties
+without freezing the table's complete text. Request examples remain
+explanatory rather than machine-consumed text.
 
-| Case | Produced artifact | Operator/viewer | Execution recipient | Downstream surface | Route capability | Selected delivery |
+| Case | Produced artifact | Operator/viewer | Execution recipient | Downstream execution surface | Route capability | Selected delivery |
 | --- | --- | --- | --- | --- | --- | --- |
 | `human-personal-use` | `complete` | `human` | `human` | `human` | `not-required` | `inline-two-block` |
-| `cak-228-prompt-me-codex` | `complete` | `human` | `codex` | `codex-fresh-thread` | `permitted` | `airtable-thin-handoff` |
-| `claude-executes` | `complete` | `human` | `claude` | `claude-execution` | `permitted` | `airtable-thin-handoff` |
-| `chatgpt-executes` | `complete` | `human` | `chatgpt` | `chatgpt-execution` | `permitted` | `airtable-thin-handoff` |
-| `manual-codex-launch` | `complete` | `human` | `codex` | `codex-manual-fresh-thread` | `permitted` | `airtable-thin-handoff` |
-| `machine-route-unavailable` | `complete` | `human` | `codex` | `codex-fresh-thread` | `unavailable` | `blocked` |
-| `machine-route-unresolved` | `complete` | `human` | `codex` | `codex-fresh-thread` | `unresolved` | `blocked` |
-| `human-reads-complete-prompt` | `complete` | `human` | `human` | `human` | `not-required` | `inline-two-block` |
+| `cak-228-prompt-me-codex` | `complete` | `human` | `codex` | `codex` | `permitted` | `airtable-thin-handoff` |
+| `claude-executes` | `complete` | `human` | `claude` | `claude` | `permitted` | `airtable-thin-handoff` |
+| `chatgpt-executes` | `complete` | `human` | `chatgpt` | `chatgpt` | `permitted` | `airtable-thin-handoff` |
+| `manual-codex-launch` | `complete` | `human` | `codex` | `codex` | `permitted` | `airtable-thin-handoff` |
+| `machine-route-unavailable` | `complete` | `human` | `codex` | `codex` | `unavailable` | `blocked` |
+| `machine-identity-unresolved` | `complete` | `human` | `codex` | `codex` | `identity-unresolved-after-inspection` | `blocked` |
 | `conceptual-fragment` | `fragment` | `human` | `none` | `none` | `not-applicable` | `lightweight` |
 
 For `cak-228-prompt-me-codex`, the representative request is “Prompt me to have
@@ -399,11 +398,16 @@ Codex do X.” The operator receives launch guidance, while Codex receives and
 executes the complete prompt. `manual-codex-launch` makes the same distinction
 when the operator creates the Codex thread by hand.
 
+`identity-unresolved-after-inspection` means the required route or identity
+remains unverified after the applicable capability inspection; an unknown route
+that has not yet been inspected does not qualify for terminal blocking.
+
 ### Airtable canonical-text handoff
 
-This section owns the shared ChatGPT/Claude/Codex handoff contract. Adapters map
-its operations to the connector actions exposed by each executor; they do not
-copy or redefine these rules.
+This section owns the shared handoff contract for the eligible machine
+recipients named by the decision model. Adapters map its operations to the
+connector actions exposed by each executor; they do not copy or redefine these
+rules.
 
 A handoff qualifies as small canonical text when the frozen payload fits
 unchanged in one `Payload` long-text field and within the current connector's
@@ -453,17 +457,17 @@ This section applies the decision model symmetrically when one executor
 produces a complete prompt for another: each direction is governed by the same
 shared presentation and handoff contract.
 
-For a qualifying small canonical-text ChatGPT, Claude, or Codex machine
-handoff, apply the [Airtable contract](#airtable-canonical-text-handoff) and
-provide the target-shaped thin envelope without reproducing the complete prompt
-in chat. On success, keep the operator-visible result to the matching adapter's
-launch or configuration guidance plus the required external envelope. Do not
-replay the complete stored payload or routine discovery, creation, hashing, and
-readback mechanics. For a human execution recipient, use the matching adapter's
-canonical inline presentation. Inspect unknown connector capability before
-selection; if the required Airtable route or identity is unavailable, fail
-clearly rather than switching to file-backed delivery or reconstructing the
-prompt in chat.
+For a qualifying small canonical-text handoff to an eligible machine recipient,
+apply the [Airtable contract](#airtable-canonical-text-handoff) and provide the
+target-shaped thin envelope without reproducing the complete prompt in chat.
+On success, keep the operator-visible result to the matching adapter's launch
+or configuration guidance plus the required external envelope. Do not replay
+the complete stored payload or narrate routine discovery, creation, hashing,
+and readback mechanics. For a human execution recipient, use the matching
+adapter's canonical inline presentation. Inspect unknown connector capability
+before selection; if the required Airtable route or identity is unavailable,
+fail clearly rather than switching to file-backed delivery or reconstructing
+the prompt in chat.
 
 Prompt governance remains a separate selection. A material prompt that passes
 its admission test additionally applies the

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -351,12 +351,10 @@ material, isolated snippets, and incomplete fragments remain lightweight.
 ## Prompt Delivery Decision Model
 
 Keep prompt delivery small and deterministic. Classify the produced artifact,
-identify the human operator or viewer, resolve the execution recipient
-independently, and then select one presentation. Wording such as `show me`,
-`give me`, or `prompt me` can identify the human viewer without making that
-human the execution recipient. When the same request clearly designates a
-machine to execute the work, that machine remains the execution recipient even
-when the human manually creates or launches its downstream thread.
+resolve the human operator or viewer and execution recipient independently,
+then select one presentation. Wording such as `show me`, `give me`, or `prompt
+me` does not override a clearly named machine recipient, including when the
+human manually launches its downstream thread.
 
 - no prompt: no delivery action;
 - conceptual fragment: lightweight conversational presentation;
@@ -377,10 +375,8 @@ arbitrary bytes or provider file identity, revision, or checksum behavior.
 
 ### Recipient-routing qualification cases
 
-These cases exercise the decision model above; they do not define another
-delivery model. The repository test suite validates their routing properties
-without freezing the table's complete text. Request examples remain
-explanatory rather than machine-consumed text.
+These cases exercise the decision model above. Tests validate their routing
+relationships rather than the surrounding prose.
 
 | Case | Produced artifact | Operator/viewer | Execution recipient | Downstream execution surface | Route capability | Selected delivery |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -388,15 +384,13 @@ explanatory rather than machine-consumed text.
 | `cak-228-prompt-me-codex` | `complete` | `human` | `codex` | `codex` | `permitted` | `airtable-thin-handoff` |
 | `claude-executes` | `complete` | `human` | `claude` | `claude` | `permitted` | `airtable-thin-handoff` |
 | `chatgpt-executes` | `complete` | `human` | `chatgpt` | `chatgpt` | `permitted` | `airtable-thin-handoff` |
-| `manual-codex-launch` | `complete` | `human` | `codex` | `codex` | `permitted` | `airtable-thin-handoff` |
 | `machine-route-unavailable` | `complete` | `human` | `codex` | `codex` | `unavailable` | `blocked` |
 | `machine-identity-unresolved` | `complete` | `human` | `codex` | `codex` | `identity-unresolved-after-inspection` | `blocked` |
 | `conceptual-fragment` | `fragment` | `human` | `none` | `none` | `not-applicable` | `lightweight` |
 
-For `cak-228-prompt-me-codex`, the representative request is “Prompt me to have
-Codex do X.” The operator receives launch guidance, while Codex receives and
-executes the complete prompt. `manual-codex-launch` makes the same distinction
-when the operator creates the Codex thread by hand.
+`cak-228-prompt-me-codex` represents “Prompt me to have Codex do X,” including
+manual thread creation: the human is the viewer or launcher, while Codex
+receives and executes the complete prompt.
 
 `identity-unresolved-after-inspection` means the required route or identity
 remains unverified after the applicable capability inspection; an unknown route
@@ -405,9 +399,8 @@ that has not yet been inspected does not qualify for terminal blocking.
 ### Airtable canonical-text handoff
 
 This section owns the shared handoff contract for the eligible machine
-recipients named by the decision model. Adapters map its operations to the
-connector actions exposed by each executor; they do not copy or redefine these
-rules.
+recipients named above. Adapters map its operations to concrete connector
+actions without redefining it.
 
 A handoff qualifies as small canonical text when the frozen payload fits
 unchanged in one `Payload` long-text field and within the current connector's
@@ -460,10 +453,9 @@ shared presentation and handoff contract.
 For a qualifying small canonical-text handoff to an eligible machine recipient,
 apply the [Airtable contract](#airtable-canonical-text-handoff) and provide the
 target-shaped thin envelope without reproducing the complete prompt in chat.
-On success, keep the operator-visible result to the matching adapter's launch
-or configuration guidance plus the required external envelope. Do not replay
-the complete stored payload or narrate routine discovery, creation, hashing,
-and readback mechanics. For a human execution recipient, use the matching
+On success, return only the matching adapter's launch or configuration guidance
+and required external envelope; do not replay the stored payload or routine
+transport mechanics. For a human execution recipient, use the matching
 adapter's canonical inline presentation. Inspect unknown connector capability
 before selection; if the required Airtable route or identity is unavailable,
 fail clearly rather than switching to file-backed delivery or reconstructing

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -137,11 +137,6 @@ machine recipient is unknown, inspect or attempt it before resolving the route.
 Material prompts also apply the durable profile below; routine prompts do not
 inherit it from transport.
 
-Treat `show me`, `give me`, and `prompt me` as operator-presentation wording,
-not as a recipient override. When the request clearly names a machine executor,
-keep the human who manually instantiates that run as its viewer or launcher and
-apply the shared machine-recipient selection unchanged.
-
 Route failure and terminal blocking remain owned by the canonical decision
 model. ChatGPT must preserve the owning failure reason rather than choose
 another renderer.
@@ -234,10 +229,6 @@ Consume the current selection from the shared
 Its presentation is final input to this client projection: an Airtable route
 uses the thin handoff, a blocked route renders no complete prompt, and
 conceptual fragments remain lightweight.
-
-After a successful Airtable handoff, report only the useful operator
-configuration and the required external envelope. Do not duplicate the stored
-prompt or routine storage and verification mechanics in chat.
 
 For the canonical inline two-block presentation, emit the shared operator
 metadata and complete executable prompt as two consecutive fenced blocks with

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -124,8 +124,9 @@ Apply the shared
 [`prompt delivery decision model`](../prompts.md#prompt-delivery-decision-model),
 with the transport rules in
 [`cross-executor prompt presentation`](../prompts.md#cross-executor-prompt-presentation).
-For a qualifying small canonical-text prompt whose ChatGPT or Claude recipient
-has a permitted Airtable route, use the shared
+For a qualifying small canonical-text prompt whose resolved machine recipient
+is eligible under the shared model and has a permitted Airtable route, use the
+shared
 [`Airtable canonical-text handoff`](../prompts.md#airtable-canonical-text-handoff)
 and emit its compact external envelope. Do not add file preview,
 download-link, or attempt-local retrieval steps.
@@ -135,6 +136,11 @@ For a human execution recipient, use the existing
 machine recipient is unknown, inspect or attempt it before resolving the route.
 Material prompts also apply the durable profile below; routine prompts do not
 inherit it from transport.
+
+Treat `show me`, `give me`, and `prompt me` as operator-presentation wording,
+not as a recipient override. When the request clearly names a machine executor,
+keep the human who manually instantiates that run as its viewer or launcher and
+apply the shared machine-recipient selection unchanged.
 
 Route failure and terminal blocking remain owned by the canonical decision
 model. ChatGPT must preserve the owning failure reason rather than choose
@@ -228,6 +234,10 @@ Consume the current selection from the shared
 Its presentation is final input to this client projection: an Airtable route
 uses the thin handoff, a blocked route renders no complete prompt, and
 conceptual fragments remain lightweight.
+
+After a successful Airtable handoff, report only the useful operator
+configuration and the required external envelope. Do not duplicate the stored
+prompt or routine storage and verification mechanics in chat.
 
 For the canonical inline two-block presentation, emit the shared operator
 metadata and complete executable prompt as two consecutive fenced blocks with

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -319,22 +319,20 @@ For a material prompt:
 - require the execution or adoption layer to re-read live durable authority
   and verify the acting identity immediately before action.
 
-### Issue-Owned Durable Prompt Retrieval
+### Airtable Prompt Retrieval
 
 Apply the shared
 [`Airtable canonical-text handoff`](../prompts.md#airtable-canonical-text-handoff)
-and the
-[`issue-owned durable rendered-prompt handoff profile`](../prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile)
-when Codex receives an exact issue-owned prompt. Use the external envelope's
-exact Airtable base, table, and record IDs and retrieve that record through a
-currently permitted connector route. Require exactly one result and verify the
-expected key and field set before re-encoding the payload and independently
-checking its byte length and SHA-256.
+when Codex receives a qualifying small canonical-text prompt. Use the external
+envelope's exact Airtable base, table, and record IDs and retrieve that record
+through a currently permitted connector route. Require exactly one result and
+verify the expected key and field set before re-encoding the payload and
+independently checking its byte length and SHA-256.
 
-This receiver projection does not add Codex to the normal ChatGPT/Claude route
-selected by the shared decision model. It applies only when a narrower
-authorized contract supplies Codex an envelope that uses the same Airtable
-record format and verification rules.
+When the prompt is an exact issue-owned material prompt, also apply the
+[`issue-owned durable rendered-prompt handoff profile`](../prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile).
+Routine machine-recipient handoffs use the shared transport without acquiring
+that material-prompt governance.
 
 Fail closed on a missing, multiple, stale, transformed, truncated, or mismatched
 record. Do not substitute a local download, another delivery route, or

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -323,23 +323,19 @@ For a material prompt:
 
 Apply the shared
 [`Airtable canonical-text handoff`](../prompts.md#airtable-canonical-text-handoff)
-when Codex receives a qualifying small canonical-text prompt. Use the external
-envelope's exact Airtable base, table, and record IDs and retrieve that record
-through a currently permitted connector route. Require exactly one result and
-verify the expected key and field set before re-encoding the payload and
-independently checking its byte length and SHA-256.
+when Codex receives a qualifying small canonical-text prompt. Retrieve the
+envelope's exact record through a currently permitted connector route and apply
+the shared verification and fail-closed rules without choosing another route or
+renderer.
 
 When the prompt is an exact issue-owned material prompt, also apply the
 [`issue-owned durable rendered-prompt handoff profile`](../prompt-contracts.md#issue-owned-durable-rendered-prompt-handoff-profile).
 Routine machine-recipient handoffs use the shared transport without acquiring
 that material-prompt governance.
 
-Fail closed on a missing, multiple, stale, transformed, truncated, or mismatched
-record. Do not substitute a local download, another delivery route, or
-reconstructed chat text. Record the delivery operation and Codex attempt
-separately from the record and envelope; neither supplies authority. Concrete
-provider, account, destination, retention, and visibility policy stay in their
-owning contract, not this adapter.
+Record the delivery operation and Codex attempt separately from the record and
+envelope; neither supplies authority. Concrete provider, account, destination,
+retention, and visibility policy stay in their owning contract.
 
 ## Startup Deltas
 

--- a/tests/test_prompt_recipient_routing.py
+++ b/tests/test_prompt_recipient_routing.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROMPTS = REPO_ROOT / "docs" / "prompts.md"
+SECTION_HEADING = "### Recipient-routing qualification cases"
+EXPECTED_COLUMNS = (
+    "Case",
+    "Produced artifact",
+    "Operator/viewer",
+    "Execution recipient",
+    "Downstream surface",
+    "Route capability",
+    "Selected delivery",
+)
+
+
+def parse_qualification_cases() -> dict[str, dict[str, str]]:
+    lines = PROMPTS.read_text(encoding="utf-8").splitlines()
+    section_start = lines.index(SECTION_HEADING)
+    table_start = next(
+        index
+        for index in range(section_start + 1, len(lines))
+        if lines[index].startswith("| Case |")
+    )
+    header = tuple(cell.strip() for cell in lines[table_start].strip("|").split("|"))
+    if header != EXPECTED_COLUMNS:
+        raise AssertionError(f"unexpected qualification columns: {header}")
+
+    cases: dict[str, dict[str, str]] = {}
+    for line in lines[table_start + 2 :]:
+        if not line.startswith("|"):
+            break
+        values = [cell.strip().strip("`") for cell in line.strip("|").split("|")]
+        row = dict(zip(EXPECTED_COLUMNS, values, strict=True))
+        case_id = row.pop("Case")
+        if case_id in cases:
+            raise AssertionError(f"duplicate qualification case: {case_id}")
+        cases[case_id] = row
+    return cases
+
+
+class PromptRecipientRoutingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cases = parse_qualification_cases()
+
+    def test_required_regression_cases_have_expected_semantics(self) -> None:
+        expected = {
+            "human-personal-use": (
+                "complete",
+                "human",
+                "human",
+                "human",
+                "not-required",
+                "inline-two-block",
+            ),
+            "cak-228-prompt-me-codex": (
+                "complete",
+                "human",
+                "codex",
+                "codex-fresh-thread",
+                "permitted",
+                "airtable-thin-handoff",
+            ),
+            "claude-executes": (
+                "complete",
+                "human",
+                "claude",
+                "claude-execution",
+                "permitted",
+                "airtable-thin-handoff",
+            ),
+            "chatgpt-executes": (
+                "complete",
+                "human",
+                "chatgpt",
+                "chatgpt-execution",
+                "permitted",
+                "airtable-thin-handoff",
+            ),
+            "manual-codex-launch": (
+                "complete",
+                "human",
+                "codex",
+                "codex-manual-fresh-thread",
+                "permitted",
+                "airtable-thin-handoff",
+            ),
+            "machine-route-unavailable": (
+                "complete",
+                "human",
+                "codex",
+                "codex-fresh-thread",
+                "unavailable",
+                "blocked",
+            ),
+            "machine-route-unresolved": (
+                "complete",
+                "human",
+                "codex",
+                "codex-fresh-thread",
+                "unresolved",
+                "blocked",
+            ),
+            "human-reads-complete-prompt": (
+                "complete",
+                "human",
+                "human",
+                "human",
+                "not-required",
+                "inline-two-block",
+            ),
+            "conceptual-fragment": (
+                "fragment",
+                "human",
+                "none",
+                "none",
+                "not-applicable",
+                "lightweight",
+            ),
+        }
+        columns = EXPECTED_COLUMNS[1:]
+        observed = {
+            case_id: tuple(row[column] for column in columns)
+            for case_id, row in self.cases.items()
+        }
+        self.assertEqual(expected, observed)
+
+    def test_human_viewer_does_not_determine_execution_recipient(self) -> None:
+        human_viewer_cases = [
+            row for row in self.cases.values() if row["Operator/viewer"] == "human"
+        ]
+        self.assertEqual(
+            {row["Execution recipient"] for row in human_viewer_cases},
+            {"human", "codex", "claude", "chatgpt", "none"},
+        )
+        self.assertIn(
+            "airtable-thin-handoff",
+            {row["Selected delivery"] for row in human_viewer_cases},
+        )
+
+    def test_permitted_complete_machine_routes_use_airtable(self) -> None:
+        qualifying = [
+            row
+            for row in self.cases.values()
+            if row["Produced artifact"] == "complete"
+            and row["Execution recipient"] not in {"human", "none"}
+            and row["Route capability"] == "permitted"
+        ]
+        self.assertTrue(qualifying)
+        self.assertEqual(
+            {row["Selected delivery"] for row in qualifying},
+            {"airtable-thin-handoff"},
+        )
+
+    def test_machine_route_failure_never_falls_back_inline(self) -> None:
+        failures = [
+            row
+            for row in self.cases.values()
+            if row["Route capability"] in {"unavailable", "unresolved"}
+        ]
+        self.assertEqual(
+            {row["Selected delivery"] for row in failures},
+            {"blocked"},
+        )
+
+    def test_manual_launch_does_not_change_machine_recipient(self) -> None:
+        prompted = self.cases["cak-228-prompt-me-codex"]
+        manual = self.cases["manual-codex-launch"]
+        self.assertEqual(prompted["Execution recipient"], "codex")
+        self.assertEqual(manual["Execution recipient"], "codex")
+        self.assertEqual(
+            prompted["Selected delivery"],
+            manual["Selected delivery"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_recipient_routing.py
+++ b/tests/test_prompt_recipient_routing.py
@@ -12,7 +12,7 @@ EXPECTED_COLUMNS = (
     "Produced artifact",
     "Operator/viewer",
     "Execution recipient",
-    "Downstream surface",
+    "Downstream execution surface",
     "Route capability",
     "Selected delivery",
 )
@@ -48,88 +48,6 @@ class PromptRecipientRoutingTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.cases = parse_qualification_cases()
 
-    def test_required_regression_cases_have_expected_semantics(self) -> None:
-        expected = {
-            "human-personal-use": (
-                "complete",
-                "human",
-                "human",
-                "human",
-                "not-required",
-                "inline-two-block",
-            ),
-            "cak-228-prompt-me-codex": (
-                "complete",
-                "human",
-                "codex",
-                "codex-fresh-thread",
-                "permitted",
-                "airtable-thin-handoff",
-            ),
-            "claude-executes": (
-                "complete",
-                "human",
-                "claude",
-                "claude-execution",
-                "permitted",
-                "airtable-thin-handoff",
-            ),
-            "chatgpt-executes": (
-                "complete",
-                "human",
-                "chatgpt",
-                "chatgpt-execution",
-                "permitted",
-                "airtable-thin-handoff",
-            ),
-            "manual-codex-launch": (
-                "complete",
-                "human",
-                "codex",
-                "codex-manual-fresh-thread",
-                "permitted",
-                "airtable-thin-handoff",
-            ),
-            "machine-route-unavailable": (
-                "complete",
-                "human",
-                "codex",
-                "codex-fresh-thread",
-                "unavailable",
-                "blocked",
-            ),
-            "machine-route-unresolved": (
-                "complete",
-                "human",
-                "codex",
-                "codex-fresh-thread",
-                "unresolved",
-                "blocked",
-            ),
-            "human-reads-complete-prompt": (
-                "complete",
-                "human",
-                "human",
-                "human",
-                "not-required",
-                "inline-two-block",
-            ),
-            "conceptual-fragment": (
-                "fragment",
-                "human",
-                "none",
-                "none",
-                "not-applicable",
-                "lightweight",
-            ),
-        }
-        columns = EXPECTED_COLUMNS[1:]
-        observed = {
-            case_id: tuple(row[column] for column in columns)
-            for case_id, row in self.cases.items()
-        }
-        self.assertEqual(expected, observed)
-
     def test_human_viewer_does_not_determine_execution_recipient(self) -> None:
         human_viewer_cases = [
             row for row in self.cases.values() if row["Operator/viewer"] == "human"
@@ -161,7 +79,8 @@ class PromptRecipientRoutingTests(unittest.TestCase):
         failures = [
             row
             for row in self.cases.values()
-            if row["Route capability"] in {"unavailable", "unresolved"}
+            if row["Route capability"]
+            in {"unavailable", "identity-unresolved-after-inspection"}
         ]
         self.assertEqual(
             {row["Selected delivery"] for row in failures},
@@ -177,6 +96,15 @@ class PromptRecipientRoutingTests(unittest.TestCase):
             prompted["Selected delivery"],
             manual["Selected delivery"],
         )
+
+    def test_human_recipient_and_fragment_keep_lightweight_routes(self) -> None:
+        human = self.cases["human-personal-use"]
+        fragment = self.cases["conceptual-fragment"]
+        self.assertEqual(human["Execution recipient"], "human")
+        self.assertEqual(human["Selected delivery"], "inline-two-block")
+        self.assertEqual(human["Route capability"], "not-required")
+        self.assertEqual(fragment["Produced artifact"], "fragment")
+        self.assertEqual(fragment["Selected delivery"], "lightweight")
 
 
 if __name__ == "__main__":

--- a/tests/test_prompt_recipient_routing.py
+++ b/tests/test_prompt_recipient_routing.py
@@ -48,18 +48,12 @@ class PromptRecipientRoutingTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.cases = parse_qualification_cases()
 
-    def test_human_viewer_does_not_determine_execution_recipient(self) -> None:
-        human_viewer_cases = [
-            row for row in self.cases.values() if row["Operator/viewer"] == "human"
-        ]
-        self.assertEqual(
-            {row["Execution recipient"] for row in human_viewer_cases},
-            {"human", "codex", "claude", "chatgpt", "none"},
-        )
-        self.assertIn(
-            "airtable-thin-handoff",
-            {row["Selected delivery"] for row in human_viewer_cases},
-        )
+    def test_prompt_me_manual_launch_keeps_codex_recipient(self) -> None:
+        prompted = self.cases["cak-228-prompt-me-codex"]
+        self.assertEqual(prompted["Operator/viewer"], "human")
+        self.assertEqual(prompted["Execution recipient"], "codex")
+        self.assertEqual(prompted["Downstream execution surface"], "codex")
+        self.assertEqual(prompted["Selected delivery"], "airtable-thin-handoff")
 
     def test_permitted_complete_machine_routes_use_airtable(self) -> None:
         qualifying = [
@@ -85,16 +79,6 @@ class PromptRecipientRoutingTests(unittest.TestCase):
         self.assertEqual(
             {row["Selected delivery"] for row in failures},
             {"blocked"},
-        )
-
-    def test_manual_launch_does_not_change_machine_recipient(self) -> None:
-        prompted = self.cases["cak-228-prompt-me-codex"]
-        manual = self.cases["manual-codex-launch"]
-        self.assertEqual(prompted["Execution recipient"], "codex")
-        self.assertEqual(manual["Execution recipient"], "codex")
-        self.assertEqual(
-            prompted["Selected delivery"],
-            manual["Selected delivery"],
         )
 
     def test_human_recipient_and_fragment_keep_lightweight_routes(self) -> None:


### PR DESCRIPTION
## Summary

- Resolve the execution recipient independently from the human viewer/operator.
- Route eligible Codex prompts through the normal Airtable machine-recipient path, including “prompt me to have Codex do this” requests.
- Keep conceptual/lightweight requests inline, preserve blocked/no-fallback behavior, and keep the success handoff compact.
- Add semantic routing properties that cover human-only, conceptual, qualified Codex, CAK-228 artifact, manual-launch, and unresolved-recipient cases.

## Root cause

The shared prompt model limited the normal Airtable route to ChatGPT and Claude, while the Codex adapter explicitly excluded Codex from that route. Viewer-oriented wording such as “prompt me” could therefore be treated as the recipient decision even when the request named Codex as the executor.

## Validation

- Focused semantic suite: 5 tests passed.
- Full repository validation: 193 tests passed; generated content was byte-identical and markdown lint reported 0 issues.
- One earlier full-suite run hit a transient failure in the pre-existing live unrelated-worktree timing fixture; an unchanged rerun passed.
- Authoritative-source advisory check passed.
- Governed cross-boundary review: initial candidate f73650e was rejected, findings were corrected, and focused re-review accepted exact head 6cc8aff232cfd601889e73d3659c84bd03def950.

The automated tests prove the documented routing model and its properties. They do not prove behavior in a live ChatGPT runtime; that remains an operational qualification on the next real prompt handoff.

Linear: https://linear.app/ctrl-alt-keith/issue/CAK-230/harden-airtable-prompt-transport-routing-and-operator-handoff-ux