### PR TITLE
CAK-229: guard active task continuity against accidental unrelated prompts

### DIFF
--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -22,6 +22,13 @@ another retrieval.
 [`bootstrap-router.md`](bootstrap-router.md) is the one copy-ready router body.
 Do not maintain provider-specific copies of its text.
 
+The router projects the core model's active bounded-task continuity guard
+before its material-change bootstrap trigger. A strongly unrelated instruction
+without a clear transition signal therefore holds the active task and unrelated
+durable mutations until the operator chooses whether to switch or continue;
+ordinary steering and explicit switches pass through to the existing routing
+rules.
+
 The final hard precondition in that body is scoped by the first-action or
 material-change trigger. It permits the retrieval needed to obtain and apply
 `start-here.md`, but blocks all response, task reasoning, and unrelated tool

--- a/distributions/global-bootstrap/README.md
+++ b/distributions/global-bootstrap/README.md
@@ -23,11 +23,8 @@ another retrieval.
 Do not maintain provider-specific copies of its text.
 
 The router projects the core model's active bounded-task continuity guard
-before its material-change bootstrap trigger. A strongly unrelated instruction
-without a clear transition signal therefore holds the active task and unrelated
-durable mutations until the operator chooses whether to switch or continue;
-ordinary steering and explicit switches pass through to the existing routing
-rules.
+before its material-change bootstrap trigger without copying that guard's
+behavior or cases into the distribution.
 
 The final hard precondition in that body is scoped by the first-action or
 material-change trigger. It permits the retrieval needed to obtain and apply

--- a/distributions/global-bootstrap/bootstrap-router.md
+++ b/distributions/global-bootstrap/bootstrap-router.md
@@ -1,11 +1,8 @@
 # AI Workflow Playbook Bootstrap
 
-When a conversation already has an active bounded task, do not treat a
-strongly unrelated instruction without a clear transition signal as a material
-task or repository change. Preserve the active task, ask whether to switch or
-continue, and make no task-owned or durable mutation for the unrelated request
-until the operator's intent is resolved. Ordinary task-local steering and
-clear task switches proceed normally.
+When a conversation already has an active bounded task, apply the current
+active bounded-task continuity guard before treating a strongly unrelated
+instruction as a material task or repository change.
 
 Before the first project action, and again only when the task/repository
 materially changes, retrieve the current `docs/start-here.md` from

--- a/distributions/global-bootstrap/bootstrap-router.md
+++ b/distributions/global-bootstrap/bootstrap-router.md
@@ -1,5 +1,12 @@
 # AI Workflow Playbook Bootstrap
 
+When a conversation already has an active bounded task, do not treat a
+strongly unrelated instruction without a clear transition signal as a material
+task or repository change. Preserve the active task, ask whether to switch or
+continue, and make no task-owned or durable mutation for the unrelated request
+until the operator's intent is resolved. Ordinary task-local steering and
+clear task switches proceed normally.
+
 Before the first project action, and again only when the task/repository
 materially changes, retrieve the current `docs/start-here.md` from
 `ctrl-alt-keith/ai-workflow-playbook` and follow its routing and startup

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -355,6 +355,40 @@ When a workflow accepts, integrates, or synthesizes evidence, apply the
 [`evidence lifecycle`](evidence-lifecycle.md) before crossing into decision
 production.
 
+## Active Bounded-Task Continuity
+
+When a conversation already has an active bounded task, preserve that task
+across related follow-ups, corrections, steering, questions, and task-local
+tangents. Clear human direction to start a new task, switch topics, ask an
+unrelated question, or make an equivalent transition adopts the new task
+without another confirmation and then applies the normal task-change,
+activation-routing, interaction-mode, and execution-surface rules.
+
+When a new instruction is strongly unrelated and has no clear transition
+signal, treat the discontinuity as a plausible wrong-thread prompt. Preserve
+the active task, briefly ask whether to switch this conversation to the new
+task or continue the active task, and make no task-owned planning,
+repository, execution, or other durable mutation for the unrelated request
+while intent is unresolved. If the human confirms the switch, adopt the new
+task and apply the normal routing and source-refresh rules before acting.
+
+Use this guard only for a strong discontinuity from an active bounded task. It
+does not create a general intent taxonomy, confidence score, classifier, or
+confirmation framework.
+
+The qualification cases below protect the semantic boundary rather than
+classifying natural language.
+
+<!-- qualification: active-bounded-task-continuity -->
+
+| Case | Relationship to active task | Transition signal | Outcome | Unrelated durable mutation |
+| --- | --- | --- | --- | --- |
+| `related-implementation-follow-up` | related | none required | continue | not applicable |
+| `correction-steering-or-task-local-tangent` | related | none required | continue | not applicable |
+| `explicit-unrelated-topic-switch` | unrelated | explicit | switch and re-route | only after normal current-task gates |
+| `abrupt-unrelated-without-switch-signal` | unrelated | absent | confirm and hold | prohibited while unresolved |
+| `confirmed-switch-after-hold` | unrelated | confirmed | switch and re-route | only after normal current-task gates |
+
 ## Durable Continuity
 
 Durable project artifacts are the recoverable continuity substrate for a

--- a/docs/core-model.md
+++ b/docs/core-model.md
@@ -361,25 +361,27 @@ When a conversation already has an active bounded task, preserve that task
 across related follow-ups, corrections, steering, questions, and task-local
 tangents. Clear human direction to start a new task, switch topics, ask an
 unrelated question, or make an equivalent transition adopts the new task
-without another confirmation and then applies the normal task-change,
-activation-routing, interaction-mode, and execution-surface rules.
+without another confirmation.
 
 When a new instruction is strongly unrelated and has no clear transition
 signal, treat the discontinuity as a plausible wrong-thread prompt. Preserve
 the active task, briefly ask whether to switch this conversation to the new
 task or continue the active task, and make no task-owned planning,
 repository, execution, or other durable mutation for the unrelated request
-while intent is unresolved. If the human confirms the switch, adopt the new
-task and apply the normal routing and source-refresh rules before acting.
+while intent is unresolved.
+
+After a clear or confirmed switch, adopt the new task and apply the normal
+task-change, activation-routing, interaction-mode, execution-surface, and
+source-refresh rules before acting.
 
 Use this guard only for a strong discontinuity from an active bounded task. It
 does not create a general intent taxonomy, confidence score, classifier, or
 confirmation framework.
 
-The qualification cases below protect the semantic boundary rather than
-classifying natural language.
+### Active-task continuity qualification cases
 
-<!-- qualification: active-bounded-task-continuity -->
+These cases protect the semantic boundary rather than classifying natural
+language.
 
 | Case | Relationship to active task | Transition signal | Outcome | Unrelated durable mutation |
 | --- | --- | --- | --- | --- |

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -52,10 +52,9 @@ tool call, or the passage of another conversational turn is not by itself a
 material change. Before treating a strongly unrelated instruction as a
 material task change, apply the core model's
 [`active bounded-task continuity`](core-model.md#active-bounded-task-continuity)
-guard. After that guard resolves a switch, re-run routing when the target
-repository changes or when the task materially changes the interaction mode,
-workflow, authoritative-source requirements, execution locality, or authority
-boundary.
+guard. Re-run routing when the target repository changes or when the task
+materially changes the interaction mode, workflow, authoritative-source
+requirements, execution locality, or authority boundary.
 
 When that first-action or material-change trigger applies, bootstrap remains a
 hard precondition: do not respond, reason about the task, or invoke another

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -49,9 +49,13 @@ reasoning step, or tool call. Its timing invariant is:
 After a successful bootstrap, reuse the still-current repository operating
 mode and verified sources across subsequent turns. A follow-up message, a new
 tool call, or the passage of another conversational turn is not by itself a
-material change. Re-run routing when the target repository changes or when the
-task materially changes the interaction mode, workflow, authoritative-source
-requirements, execution locality, or authority boundary.
+material change. Before treating a strongly unrelated instruction as a
+material task change, apply the core model's
+[`active bounded-task continuity`](core-model.md#active-bounded-task-continuity)
+guard. After that guard resolves a switch, re-run routing when the target
+repository changes or when the task materially changes the interaction mode,
+workflow, authoritative-source requirements, execution locality, or authority
+boundary.
 
 When that first-action or material-change trigger applies, bootstrap remains a
 hard precondition: do not respond, reason about the task, or invoke another

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -48,12 +48,13 @@ repository follow-up whose task shape remains sufficient, reuse still-current
 verified sources. Before adopting a strongly unrelated instruction as a task
 change, apply the core model's
 [`active bounded-task continuity`](../core-model.md#active-bounded-task-continuity)
-guard across both Chat and Work. After a switch is clear or confirmed, re-run
-the current activation route when the task materially changes interaction
+guard across both Chat and Work. If the task materially changes interaction
 mode, artifact, workflow, source need, execution locality, or authority
-boundary. Retrieve newly activated owners without replaying unchanged doctrine
-or hydrating unrelated documents. This is the persistent-context projection
-of the [activation-sufficiency invariant](../start-here.md#required-repository-invariants);
+boundary, re-run the current activation route before responding, planning,
+drafting, or acting. Retrieve newly activated owners without replaying
+unchanged doctrine or hydrating unrelated documents. This is the
+persistent-context projection of the
+[activation-sufficiency invariant](../start-here.md#required-repository-invariants);
 [`repo-readiness.md`](../repo-readiness.md) owns interaction-mode selection.
 
 ## Chat, Work, and execution locality

--- a/docs/tool-adapters/chatgpt.md
+++ b/docs/tool-adapters/chatgpt.md
@@ -45,12 +45,15 @@ prompts, [`prompt-contracts.md`](../prompt-contracts.md).
 
 Repository mode may continue across Chat and Work turns. For an ordinary
 repository follow-up whose task shape remains sufficient, reuse still-current
-verified sources. If the task materially changes interaction mode, artifact,
-workflow, source need, execution locality, or authority boundary, re-run the
-current activation route before responding, planning, drafting, or acting.
-Retrieve newly activated owners without replaying unchanged doctrine or
-hydrating unrelated documents. This is the persistent-context projection of
-the [activation-sufficiency invariant](../start-here.md#required-repository-invariants);
+verified sources. Before adopting a strongly unrelated instruction as a task
+change, apply the core model's
+[`active bounded-task continuity`](../core-model.md#active-bounded-task-continuity)
+guard across both Chat and Work. After a switch is clear or confirmed, re-run
+the current activation route when the task materially changes interaction
+mode, artifact, workflow, source need, execution locality, or authority
+boundary. Retrieve newly activated owners without replaying unchanged doctrine
+or hydrating unrelated documents. This is the persistent-context projection
+of the [activation-sufficiency invariant](../start-here.md#required-repository-invariants);
 [`repo-readiness.md`](../repo-readiness.md) owns interaction-mode selection.
 
 ## Chat, Work, and execution locality

--- a/tests/test_active_task_continuity.py
+++ b/tests/test_active_task_continuity.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CORE_MODEL = REPO_ROOT / "docs" / "core-model.md"
+TABLE_MARKER = "<!-- qualification: active-bounded-task-continuity -->"
+EXPECTED_COLUMNS = (
+    "Case",
+    "Relationship to active task",
+    "Transition signal",
+    "Outcome",
+    "Unrelated durable mutation",
+)
+
+
+def parse_qualification_cases() -> dict[str, dict[str, str]]:
+    lines = CORE_MODEL.read_text(encoding="utf-8").splitlines()
+    marker_index = lines.index(TABLE_MARKER)
+    table_start = next(
+        index
+        for index in range(marker_index + 1, len(lines))
+        if lines[index].startswith("| Case |")
+    )
+    header = tuple(cell.strip() for cell in lines[table_start].strip("|").split("|"))
+    if header != EXPECTED_COLUMNS:
+        raise AssertionError(f"unexpected qualification columns: {header}")
+
+    cases: dict[str, dict[str, str]] = {}
+    for line in lines[table_start + 2 :]:
+        if not line.startswith("|"):
+            break
+        values = [cell.strip().strip("`") for cell in line.strip("|").split("|")]
+        row = dict(zip(EXPECTED_COLUMNS, values, strict=True))
+        case_id = row.pop("Case")
+        if case_id in cases:
+            raise AssertionError(f"duplicate qualification case: {case_id}")
+        cases[case_id] = row
+    return cases
+
+
+class ActiveTaskContinuityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cases = parse_qualification_cases()
+
+    def test_related_follow_up_and_steering_continue(self) -> None:
+        related = [
+            row
+            for row in self.cases.values()
+            if row["Relationship to active task"] == "related"
+        ]
+        self.assertEqual(len(related), 2)
+        self.assertEqual({row["Outcome"] for row in related}, {"continue"})
+        self.assertEqual(
+            {row["Unrelated durable mutation"] for row in related},
+            {"not applicable"},
+        )
+
+    def test_explicit_or_confirmed_switch_re_routes_normally(self) -> None:
+        switches = [
+            row
+            for row in self.cases.values()
+            if row["Transition signal"] in {"explicit", "confirmed"}
+        ]
+        self.assertEqual(len(switches), 2)
+        self.assertEqual(
+            {row["Outcome"] for row in switches},
+            {"switch and re-route"},
+        )
+        self.assertEqual(
+            {row["Unrelated durable mutation"] for row in switches},
+            {"only after normal current-task gates"},
+        )
+
+    def test_abrupt_unrelated_prompt_confirms_and_holds_mutation(self) -> None:
+        held = self.cases["abrupt-unrelated-without-switch-signal"]
+        self.assertEqual(held["Relationship to active task"], "unrelated")
+        self.assertEqual(held["Transition signal"], "absent")
+        self.assertEqual(held["Outcome"], "confirm and hold")
+        self.assertEqual(
+            held["Unrelated durable mutation"],
+            "prohibited while unresolved",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_active_task_continuity.py
+++ b/tests/test_active_task_continuity.py
@@ -6,7 +6,7 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CORE_MODEL = REPO_ROOT / "docs" / "core-model.md"
-TABLE_MARKER = "<!-- qualification: active-bounded-task-continuity -->"
+SECTION_HEADING = "### Active-task continuity qualification cases"
 EXPECTED_COLUMNS = (
     "Case",
     "Relationship to active task",
@@ -18,10 +18,10 @@ EXPECTED_COLUMNS = (
 
 def parse_qualification_cases() -> dict[str, dict[str, str]]:
     lines = CORE_MODEL.read_text(encoding="utf-8").splitlines()
-    marker_index = lines.index(TABLE_MARKER)
+    section_start = lines.index(SECTION_HEADING)
     table_start = next(
         index
-        for index in range(marker_index + 1, len(lines))
+        for index in range(section_start + 1, len(lines))
         if lines[index].startswith("| Case |")
     )
     header = tuple(cell.strip() for cell in lines[table_start].strip("|").split("|"))
@@ -52,7 +52,7 @@ class ActiveTaskContinuityTests(unittest.TestCase):
             for row in self.cases.values()
             if row["Relationship to active task"] == "related"
         ]
-        self.assertEqual(len(related), 2)
+        self.assertTrue(related)
         self.assertEqual({row["Outcome"] for row in related}, {"continue"})
         self.assertEqual(
             {row["Unrelated durable mutation"] for row in related},
@@ -61,11 +61,9 @@ class ActiveTaskContinuityTests(unittest.TestCase):
 
     def test_explicit_or_confirmed_switch_re_routes_normally(self) -> None:
         switches = [
-            row
-            for row in self.cases.values()
-            if row["Transition signal"] in {"explicit", "confirmed"}
+            self.cases["explicit-unrelated-topic-switch"],
+            self.cases["confirmed-switch-after-hold"],
         ]
-        self.assertEqual(len(switches), 2)
         self.assertEqual(
             {row["Outcome"] for row in switches},
             {"switch and re-route"},
@@ -76,13 +74,20 @@ class ActiveTaskContinuityTests(unittest.TestCase):
         )
 
     def test_abrupt_unrelated_prompt_confirms_and_holds_mutation(self) -> None:
-        held = self.cases["abrupt-unrelated-without-switch-signal"]
-        self.assertEqual(held["Relationship to active task"], "unrelated")
-        self.assertEqual(held["Transition signal"], "absent")
-        self.assertEqual(held["Outcome"], "confirm and hold")
+        held = [
+            row
+            for row in self.cases.values()
+            if row["Relationship to active task"] == "unrelated"
+            and row["Transition signal"] == "absent"
+        ]
+        self.assertTrue(held)
         self.assertEqual(
-            held["Unrelated durable mutation"],
-            "prohibited while unresolved",
+            {row["Outcome"] for row in held},
+            {"confirm and hold"},
+        )
+        self.assertEqual(
+            {row["Unrelated durable mutation"] for row in held},
+            {"prohibited while unresolved"},
         )
 
 


### PR DESCRIPTION
## Summary

- define the canonical active bounded-task continuity invariant and its continue, switch, and confirmation/hold cases
- route the invariant through `start-here.md`, the Chat/Work adapter, and the pointer-sized global bootstrap distribution
- add data-driven contract tests for the behavior table without pinning presentation details

## Authority and review

- Governing issue: [CAK-229](https://linear.app/ctrl-alt-keith/issue/CAK-229/guard-active-task-continuity-against-accidental-unrelated-prompts)
- Reviewed head: `7249454d86bc9f2789e6e5c5c32d821b23443be4`
- Original governed review `CAK-229-governed-review-20260905T124220Z`: ACCEPT WITH CHANGES
- Focused re-review `CAK-229-focused-review-20260905T125127Z`: ACCEPT
- All four original findings were fixed. One optional suggestion to generalize the two required switch-case tests was declined to avoid speculative permanent coverage; one router-bootstrap observation required no change.
- Durable evidence index: Dropbox `id:FHKdoRfTdTUAAAAAAAAKBg`, `ns:14959974083//issues/CAK-229/CAK-229-review-evidence-index-v1-2026-09-05.md`, SHA-256 `83987daa98dfbec0f16918ae208d9be7c039c9ea1522377609f954f157bc9dfc`

The review record, delivery record, and this PR do not create merge or doctrine-promotion authority.

## Validation

- `make check` — passed: 195 tests, markdownlint zero issues, generated recovery section byte-identical
- `git diff --check origin/main...HEAD` — passed
- latest `origin/main` is an ancestor of the reviewed head
