### PR TITLE
CAK-219: Simplify Claude review controller

### DIFF
--- a/.codex/rule-templates/claude-review.rules
+++ b/.codex/rule-templates/claude-review.rules
@@ -1,5 +1,5 @@
 # Generated from the reviewed Playbook template. Do not substitute a relative
-# launcher: the exact absolute installed path is the execution identity bound.
+# controller: the exact absolute installed path is the execution identity bound.
 prefix_rule(
     pattern=[
         "__CLAUDE_REVIEW_LAUNCHER__",
@@ -18,11 +18,11 @@ prefix_rule(
 prefix_rule(
     pattern=["__CLAUDE_REVIEW_LAUNCHER__", "--auth-preflight"],
     decision="allow",
-    justification="The exact installed reviewed launcher constrains authentication preflight execution.",
+    justification="The exact installed review controller constrains authentication preflight execution.",
 )
 
 prefix_rule(
     pattern=["__CLAUDE_REVIEW_LAUNCHER__", "--review-config"],
     decision="allow",
-    justification="The exact installed reviewed launcher constrains governed review execution.",
+    justification="The exact installed review controller constrains governed review execution.",
 )

--- a/.codex/rules/claude-review.rules
+++ b/.codex/rules/claude-review.rules
@@ -1,4 +1,4 @@
-# Repository-relative launcher bytes are writable during development, so the
+# Repository-relative controller bytes are writable during development, so the
 # project layer never auto-allows them outside the sandbox. Production allow
 # rules are rendered in the user layer for one exact installed absolute path.
 prefix_rule(

--- a/docs/external-ai-reviewer.md
+++ b/docs/external-ai-reviewer.md
@@ -109,7 +109,8 @@ A governed review begins with a controller-owned launch contract, not with a
 provider command assembled ad hoc. The contract must bind the exact prompt and
 configuration identities, candidate worktree and commit, complete source graph,
 logical launch root, additional readable directories, guarded roots, exact observational
-commands, evidence destination, retry bound, and cancellation policy. Choose a
+commands, evidence destination, attempt count and any explicit retry policy, and
+cancellation policy. Choose a
 logical launch root that commonly owns the source graph when practical; otherwise
 declare every additional directory explicitly. A narrow package-directory
 launch that cannot reach the candidate is a contract failure, not a partially
@@ -117,8 +118,8 @@ qualified review. A provider may run from fresh attempt-local scratch to contain
 its own startup mechanics only when the launcher exposes every logical source
 root explicitly and verifies the effective runtime directory during initialization.
 
-Bind an exact immutable stream and terminal-receipt path for every permitted
-attempt and a distinct exact path for successful final reviewer output. Keep
+Bind an exact immutable stream and terminal-receipt path for every explicitly
+authorized attempt and a distinct exact path for successful final reviewer output. Keep
 mutable live-process mechanics in private controller-owned
 attempt-local scratch and expose their exact locator while the controller is
 live; do not turn a replace-in-place state file into a durable artifact. Only
@@ -204,7 +205,7 @@ remaining fail-closed when attribution is ambiguous.
 
 Bind every attempt to the configured candidate commit again immediately before
 capturing its attempt baseline and immediately before creating the reviewer
-process. Apply both checks to the first attempt and every retry, and record the
+process. Apply both checks to each explicitly authorized attempt, and record the
 observed commit and symbolic-ref identity. Drift at either boundary stops before
 that attempt can start; it never becomes a new governed baseline.
 
@@ -225,8 +226,8 @@ controller-owned transient lock by exact path, actor, and lifetime and must not
 apply to terminal postflight.
 
 Keep raw observation separate from candidate-integrity disposition. Preflight,
-live monitoring, emergency-stop decisions, terminal postflight, retry
-eligibility, and receipts must use the same classification semantics. Record
+live monitoring, emergency-stop decisions, terminal postflight,
+successor-attempt eligibility, and receipts must use the same classification semantics. Record
 each changed Git-administration object by normalized path relative to its owning
 Git directory, owner scope, change type, before and after identities,
 classification evidence, and blocking or tolerated disposition. A review may
@@ -237,15 +238,14 @@ ambiguous changes qualify as unauthorized mutation for emergency stopping.
 An attempt is complete only after the exact reviewer process group is terminal,
 all output collectors reach end-of-stream, its output is captured, its terminal
 receipt is durable, and no-delta
-postflight passes. A fresh attempt may repeat the exact inputs only for an
-explicitly documented transient provider class, after the prior attempt is
-fully terminal, under the same controller and contract identity, and within a
-small declared cap. This is a fresh execution with an exact-input repeat, not a
-historical replay. Authentication, billing, access, capability, command,
+postflight passes. The Claude review controller authorizes exactly one provider
+attempt; any later review is a new explicit controller invocation with its own
+contract and evidence. Another adapter may own a bounded fresh exact-input
+repeat only when its current contract explicitly declares that responsibility,
+the prior attempt is fully terminal, and the terminal provider class is
+documented as eligible. Authentication, billing, access, capability, command,
 mutation, cancellation, and unknown failures are not automatically retryable.
-Provider-internal retry events are evidence inside one attempt unless the
-outer contract explicitly classifies the terminal result as eligible for a new
-attempt.
+Provider-internal retry events remain evidence inside one attempt.
 
 Apply the shared live-process rules in
 [`orchestration-and-parallelism.md#live-process-lifecycle`](orchestration-and-parallelism.md#live-process-lifecycle).

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -225,8 +225,9 @@ A versioned JSON review config binds the
 source graph, launch root and exact additional directories, guard roots,
 candidate and exact `HEAD`, disjoint evidence directory, immutable
 preflight-receipt and final-output paths, exact stream and terminal-receipt
-paths for every permitted attempt, observational
-command argv, retry cap, observation intervals, and cancellation policy. Mutable
+paths for the single explicit provider attempt, observational
+command argv, observation intervals, and cancellation policy. Schema version 2
+rejects the former `max_attempts` and `attempt_artifacts` fields. Mutable
 live-state mechanics remain in private controller attempt-local scratch. The
 launcher accepts
 only model and supported effort selection after `--`; it owns the tool,
@@ -257,7 +258,9 @@ rollback; returning to older bytes is a new transition. Qualification is
 evidence and capability gating only and grants no review, candidate, merge, or
 other task authority.
 
-The generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits
+The governed invocation uses Claude's provider-native `--restricted` mode,
+available in Claude Code 2.1.248 and later, to isolate settings and confine file
+tools. The generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits
 `Bash` only when its command text exactly equals the shell rendering of one
 configured argv vector and the tool input does not request sandbox bypass. The
 launcher does not force-enable Claude's provider sandbox because bounded review
@@ -333,9 +336,9 @@ lock, symlink, mode, vanished, special-object, or other ambiguity. Git
 configuration, packed refs, replacement, alternate, shallow, graft, attribute,
 candidate-specific, and unknown shared changes remain blocking.
 
-The configured candidate commit is reverified immediately before every attempt
-baseline and again immediately before provider process creation, including on
-retries. Each observation includes the symbolic-ref identity. A mismatch stops
+The configured candidate commit is reverified immediately before the attempt
+baseline and again immediately before provider process creation. Each
+observation includes the symbolic-ref identity. A mismatch stops
 before the provider starts and is preserved as structured evidence; the newly
 observed commit cannot silently become the next attempt's baseline.
 
@@ -348,7 +351,7 @@ unattached changes do not gain that exception, and terminal postflight remains
 fully fail-closed.
 
 Use that classification unchanged in preflight, live monitoring, emergency
-stopping, terminal postflight, retry eligibility, and receipts. Receipts retain
+stopping, terminal postflight, and receipts. Receipts retain
 exact Git-directory-relative paths, owner scope, change type, before/after
 identities, proof, and blocking or tolerated disposition. Proven-unrelated raw
 change can coexist with a passing candidate-integrity result; it must not be
@@ -368,13 +371,12 @@ whole-source no-delta checks remain required controls rather than assumptions
 about undocumented provider internals.
 
 Claude's structured `system/api_retry` event is an in-process provider retry
-inside the same attempt. Only a terminal `overloaded` or `server_error` result
-may qualify for the launcher's bounded fresh exact-input repeat. Rate limiting,
-authentication, billing, capability, access, command, mutation, cancellation,
-and unknown errors stop without an outer retry. After the direct provider
-process exits, the launcher keeps awaiting the same process group until it is
-terminal, then waits for both output collectors to reach end-of-stream before
-freezing the stream artifact or considering a retry. The launcher records the
+inside the same controller attempt. A terminal result ends that attempt; the
+controller never starts a fresh automatic exact-input repeat. A later review is
+a new explicit invocation with its own contract and evidence. After the direct
+provider process exits, the controller keeps awaiting the same process group
+until it is terminal, then waits for both output collectors to reach
+end-of-stream before freezing the stream artifact. The controller records the
 exact process group as required by the shared
 [`live-process lifecycle`](../orchestration-and-parallelism.md#live-process-lifecycle).
 Mutable control state in controller scratch preserves request, decline,

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -260,10 +260,13 @@ other task authority.
 
 The governed invocation uses Claude's provider-native `--restricted` mode,
 available in Claude Code 2.1.248 and later, to isolate settings and confine file
-tools. The generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits
-`Bash` only when its command text exactly equals the shell rendering of one
-configured argv vector and the tool input does not request sandbox bypass. The
-launcher does not force-enable Claude's provider sandbox because bounded review
+tools. The controller enforces that version floor before provider launch. The
+generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits `Bash`
+only when its command text exactly equals the shell rendering of one configured
+argv vector and the tool input does not request sandbox bypass. The controller
+requires an exact attempt-local hook-liveness record even when no effort was
+requested. The controller does not force-enable Claude's provider sandbox
+because bounded review
 under a nested host sandbox showed that it can make every granted Bash command
 unusable. Instead, the controller independently executes each configured
 command before review under a safe environment that disables system Git
@@ -339,8 +342,8 @@ candidate-specific, and unknown shared changes remain blocking.
 The configured candidate commit is reverified immediately before the attempt
 baseline and again immediately before provider process creation. Each
 observation includes the symbolic-ref identity. A mismatch stops
-before the provider starts and is preserved as structured evidence; the newly
-observed commit cannot silently become the next attempt's baseline.
+before the provider starts and is preserved as structured evidence; an observed
+commit cannot silently replace the configured identity.
 
 Git may write a commit object or an exact per-worktree administration file
 milliseconds before updating the unrelated HEAD/ref transition that attributes

--- a/docs/tool-adapters/claude.md
+++ b/docs/tool-adapters/claude.md
@@ -260,7 +260,9 @@ other task authority.
 
 The governed invocation uses Claude's provider-native `--restricted` mode,
 available in Claude Code 2.1.248 and later, to isolate settings and confine file
-tools. The controller enforces that version floor before provider launch. The
+tools. The controller enforces that version floor before provider launch and
+retains an explicit empty `--setting-sources` selection as independently
+observable argv evidence. The
 generated `PreToolUse` hook permits `Read`, `Grep`, and `Glob`, and permits `Bash`
 only when its command text exactly equals the shell rendering of one configured
 argv vector and the tool input does not request sandbox bypass. The controller

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -799,8 +799,9 @@ substantive review output.
 The governed provider argv includes Claude's `--restricted` mode, available in
 Claude Code 2.1.248 and later, so provider-managed settings and filesystem
 confinement carry the controls they can express. The controller enforces that
-version floor before provider launch and requires attempt-local evidence that
-its exact-command hook ran, even when no effort was requested. The controller
+version floor before provider launch, keeps setting sources explicitly empty,
+and requires attempt-local evidence that its exact-command hook ran, even when
+no effort was requested. The controller
 still owns the exact argv and entry identity, standard-input EOF, stream
 drainage, process-group lifecycle, exact-command hook and canary, source
 no-delta checks, redaction, and receipts. Claude owns its structured session,

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -607,16 +607,21 @@ For local development and lifecycle controls, use the repository's
 environment assignment. It derives the effective operating-system account,
 normalizes `USER`, `LOGNAME`, and `HOME` for the Claude child, reads the review
 prompt from standard input rather than argv, and emits bounded diagnostics plus
-append-only attempt receipts. For substantive review, pass `--review-config`
+append-only attempt receipts. The command is the review controller even though
+its compatibility name remains `claude-review`: Codex
+[prefix rules](https://learn.chatgpt.com/docs/agent-configuration/rules) match
+arbitrary trailing arguments, so allowing the Claude executable directly would
+also allow unreviewed flags beyond an approved prefix. For substantive review,
+pass `--review-config`
 with the versioned governed-launch JSON and pass only model and supported effort
-selection after `--`. The launcher owns the Claude tools, permission mode, MCP,
+selection after `--`. The controller owns the Claude tools, permission mode, MCP,
 settings, hook, output, and session-persistence flags; do not append competing
 review flags. Production auth and review use the byte-exact machine-local
 installation made by
 [`install-claude-review`](../../scripts/install-claude-review), not the writable
 repository path. Put `--review-config` immediately after that exact installed
 absolute path. Authentication preflight follows the same convention.
-The launcher rejects either mode when combined with permission-hook or lifecycle
+The controller rejects either mode when combined with permission-hook or lifecycle
 control modes, so an allowed review prefix cannot authorize those controls.
 
 Before an expensive independent review, run the same launcher with
@@ -759,8 +764,8 @@ controller and keep awaiting that exact launcher until its live-state record is
 terminal. The review config must cover every source root, bind the candidate and
 exact `HEAD`, and bind the
 disjoint admitted evidence destination, enumerate exact observational command
-argv and immutable per-attempt artifact paths, and declare retry and cancellation
-policy. Do not use a Codex tool timeout
+argv and immutable single-attempt artifact paths, and declare cancellation
+policy. Schema version 2 rejects the former automatic-retry fields. Do not use a Codex tool timeout
 or missing output as evidence that Claude exited, and do not launch a replacement
 while the recorded process group may still be live. If the interactive contract
 requires a disposition, use the launcher's request, decline, or authority-bound
@@ -778,17 +783,30 @@ Controller-side command preflight is followed by an in-provider exact-command
 canary. The launcher rejects a missing or failed canary and any
 `dangerouslyDisableSandbox` request; do not bypass a nested-sandbox failure.
 After Claude's direct process exits, keep awaiting the recorded process group
-and complete both stream collectors before freezing output or considering an
-eligible exact-input repeat.
+and complete both stream collectors before freezing output. A terminal provider
+failure ends this explicit controller attempt; a later review is a new,
+separately authorized invocation.
 
 The launcher performs representative access and command-effect preflight,
 validates Claude's effective initialization metadata, snapshots all guarded
 source bytes and the Git index, and requires a positive no-delta postflight.
-Its retry cap applies only to fresh executions that repeat exact input after a
-fully terminal, explicitly transient provider outcome. Provider-internal retry
-events remain part of one attempt. Preserve each attempt receipt even when no
+Provider-internal retry events remain part of the one controller attempt; the
+controller does not automatically launch a fresh exact-input repeat. Preserve
+the attempt receipt even when no
 candidate verdict is produced, and apply finding disposition only to successful
 substantive review output.
+
+The governed provider argv includes Claude's `--restricted` mode, available in
+Claude Code 2.1.248 and later, so provider-managed settings and filesystem
+confinement carry the controls they can express. The controller still owns the
+exact argv and entry identity, standard-input EOF, stream drainage, process-group
+lifecycle, exact-command hook and canary, source no-delta checks, redaction, and
+receipts. Claude owns its structured session, message, tool, provider-retry,
+result, and usage events plus credential storage and refresh. The controller is
+the owner for privacy-safe live stream interpretation and publication; the
+provider stream is evidence, not a second authority boundary. Do not add
+`--permission-prompts none` until the selected Claude is at least 2.1.259 and
+that behavior has been separately qualified.
 
 The launcher preserves distinct documented failure classes when provider output
 supports them: `AUTH_OAUTH_TOKEN_EXPIRED_401`,

--- a/docs/tool-adapters/codex.md
+++ b/docs/tool-adapters/codex.md
@@ -798,13 +798,16 @@ substantive review output.
 
 The governed provider argv includes Claude's `--restricted` mode, available in
 Claude Code 2.1.248 and later, so provider-managed settings and filesystem
-confinement carry the controls they can express. The controller still owns the
-exact argv and entry identity, standard-input EOF, stream drainage, process-group
-lifecycle, exact-command hook and canary, source no-delta checks, redaction, and
-receipts. Claude owns its structured session, message, tool, provider-retry,
-result, and usage events plus credential storage and refresh. The controller is
-the owner for privacy-safe live stream interpretation and publication; the
-provider stream is evidence, not a second authority boundary. Do not add
+confinement carry the controls they can express. The controller enforces that
+version floor before provider launch and requires attempt-local evidence that
+its exact-command hook ran, even when no effort was requested. The controller
+still owns the exact argv and entry identity, standard-input EOF, stream
+drainage, process-group lifecycle, exact-command hook and canary, source
+no-delta checks, redaction, and receipts. Claude owns its structured session,
+message, tool, provider-retry, result, and usage events plus credential storage
+and refresh. The controller is the owner for privacy-safe live stream
+interpretation and publication; the provider stream is evidence, not a second
+authority boundary. Do not add
 `--permission-prompts none` until the selected Claude is at least 2.1.259 and
 that behavior has been separately qualified.
 

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -951,7 +951,7 @@ def version_of(executable: str, environment: dict[str, str], *, cwd: str) -> str
 def parsed_claude_version(reported: object) -> tuple[int, int, int] | None:
     if not isinstance(reported, str):
         return None
-    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", reported)
+    match = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?(?:\s|$)", reported)
     if match is None:
         return None
     return int(match.group(1)), int(match.group(2)), int(match.group(3) or 0)
@@ -2453,6 +2453,18 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
     )
 
 
+def write_idempotent_hook_evidence(path: Path, encoded: bytes, label: str) -> None:
+    if path.exists() or path.is_symlink():
+        if path.is_symlink() or path.read_bytes() != encoded:
+            raise ValueError(f"{label} evidence changed within one attempt")
+        return
+    try:
+        exclusive_write(path, encoded)
+    except FileExistsError:
+        if path.is_symlink() or path.read_bytes() != encoded:
+            raise ValueError(f"{label} evidence changed within one attempt")
+
+
 def permission_hook(
     config_path: Path,
     expected_digest: str | None,
@@ -2490,11 +2502,12 @@ def permission_hook(
             "zero_authority": True,
         }
         encoded_liveness = canonical_json_bytes(liveness_evidence)
-        if liveness_evidence_path.exists() or liveness_evidence_path.is_symlink():
-            if liveness_evidence_path.is_symlink() or liveness_evidence_path.read_bytes() != encoded_liveness:
-                raise ValueError("permission-hook liveness evidence changed within one attempt")
-        elif permitted:
-            exclusive_write(liveness_evidence_path, encoded_liveness)
+        if permitted:
+            write_idempotent_hook_evidence(
+                liveness_evidence_path,
+                encoded_liveness,
+                "permission-hook liveness",
+            )
         effort_matches = True
         if expected_effort is not None:
             if expected_effort not in EFFORT_LEVELS or effort_evidence_path is None:
@@ -2523,11 +2536,11 @@ def permission_hook(
                 "zero_authority": True,
             }
             encoded = canonical_json_bytes(evidence)
-            if effort_evidence_path.exists() or effort_evidence_path.is_symlink():
-                if effort_evidence_path.is_symlink() or effort_evidence_path.read_bytes() != encoded:
-                    raise ValueError("effort qualification evidence changed within one attempt")
-            else:
-                exclusive_write(effort_evidence_path, encoded)
+            write_idempotent_hook_evidence(
+                effort_evidence_path,
+                encoded,
+                "effort qualification",
+            )
             permitted = permitted and effort_matches
     except (OSError, ValueError, json.JSONDecodeError, KeyError, TypeError):
         permitted = False
@@ -2789,6 +2802,8 @@ def governed_claude_arguments(
         "--strict-mcp-config",
         "--mcp-config",
         '{"mcpServers":{}}',
+        "--setting-sources",
+        "",
         "--settings",
         json.dumps(hook_settings, separators=(",", ":")),
         "--append-system-prompt",
@@ -3706,17 +3721,21 @@ def run_governed_review(
             )
             if auth_failure and auth_failure.startswith("AUTH_"):
                 classification = auth_failure
-            if capability_failure or capability_signal_sent:
+            if capability_signal_sent:
                 classification = capability_failure or live_capability_failure or "startup_capability_error"
                 live_state["capability_failure"] = classification
-            elif canary_failure == "provider_command_canary_requested_sandbox_bypass":
-                classification = canary_failure
-            elif hook_liveness_failure:
-                classification = hook_liveness_failure
-            elif effort_failure:
-                classification = effort_failure
-            elif canary_failure:
-                classification = canary_failure
+            elif classification == "success":
+                if capability_failure:
+                    classification = capability_failure
+                    live_state["capability_failure"] = classification
+                elif canary_failure == "provider_command_canary_requested_sandbox_bypass":
+                    classification = canary_failure
+                elif hook_liveness_failure:
+                    classification = hook_liveness_failure
+                elif effort_failure:
+                    classification = effort_failure
+                elif canary_failure:
+                    classification = canary_failure
             if live_state.get("termination_authority"):
                 classification = "operator_authorized_termination"
             post_snapshot, postflight_observation_failure = observed_source_snapshot(

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -33,9 +33,7 @@ AUTH_PREFLIGHT_RESPONSE = "CLAUDE_AUTH_OK"
 AUTH_PREFLIGHT_BENIGN_NOTICES = {
     "Client.listTools() called but server does not advertise tools capability - returning empty list",
 }
-GOVERNED_CONFIG_VERSION = 1
-MAX_GOVERNED_ATTEMPTS = 3
-TRANSIENT_OUTER_RETRY_ERRORS = {"overloaded", "server_error"}
+GOVERNED_CONFIG_VERSION = 2
 SAFE_EXECUTABLES = {"git", "shasum"}
 INSTALLATION_SCHEMA_VERSION = 3
 QUALIFICATION_SCHEMA_VERSION = 3
@@ -2315,9 +2313,9 @@ class GovernedReviewConfig:
     evidence_directory: Path
     preflight_receipt: Path
     final_output: Path
-    attempt_artifacts: tuple[tuple[Path, Path], ...]
+    attempt_stream: Path
+    attempt_terminal_receipt: Path
     allowed_commands: tuple[tuple[str, ...], ...]
-    max_attempts: int
     observation_interval: float
     soft_liveness_threshold: float
     graceful_termination_seconds: float
@@ -2328,6 +2326,12 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
     body = json.loads(raw)
     if not isinstance(body, dict) or body.get("schema_version") != GOVERNED_CONFIG_VERSION:
         raise ValueError(f"review config must use schema_version {GOVERNED_CONFIG_VERSION}")
+    obsolete_attempt_fields = {"attempt_artifacts", "max_attempts"}.intersection(body)
+    if obsolete_attempt_fields:
+        raise ValueError(
+            "review config schema_version 2 uses one explicit provider attempt and rejects: "
+            + ", ".join(sorted(obsolete_attempt_fields))
+        )
     required_strings = (
         "review_id",
         "contract_id",
@@ -2386,26 +2390,18 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
         raise ValueError("every declared source root must be covered by a guarded no-delta root")
     if any(contained(evidence, root) or contained(root, evidence) for root in guard_roots):
         raise ValueError("evidence directory must be disjoint from every guarded source root")
-    max_attempts = body.get("max_attempts", MAX_GOVERNED_ATTEMPTS)
-    if not isinstance(max_attempts, int) or isinstance(max_attempts, bool) or not 1 <= max_attempts <= MAX_GOVERNED_ATTEMPTS:
-        raise ValueError(f"max_attempts must be between 1 and {MAX_GOVERNED_ATTEMPTS}")
-    attempt_artifacts: list[tuple[Path, Path]] = []
-    for item in body.get("attempt_artifacts", []):
-        if not isinstance(item, dict) or not isinstance(item.get("stream"), str) or not isinstance(
-            item.get("terminal_receipt"), str
-        ):
-            raise ValueError("each attempt_artifacts item requires stream and terminal_receipt paths")
-        paths: list[Path] = []
-        for value in (item["stream"], item["terminal_receipt"]):
-            parent = Path(value).parent.resolve(strict=True)
-            artifact = parent / Path(value).name
-            if not contained(artifact, evidence):
-                raise ValueError("every attempt artifact must be inside the declared evidence directory")
-            paths.append(artifact)
-        attempt_artifacts.append((paths[0], paths[1]))
-    if len(attempt_artifacts) != max_attempts:
-        raise ValueError("attempt_artifacts must provide one exact stream/receipt pair for each allowed attempt")
-    artifact_paths = [preflight_receipt, final_output, *(path for pair in attempt_artifacts for path in pair)]
+    attempt_paths: list[Path] = []
+    for key in ("attempt_stream", "attempt_terminal_receipt"):
+        value = body.get(key)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"review config requires non-empty {key}")
+        parent = Path(value).parent.resolve(strict=True)
+        artifact = parent / Path(value).name
+        if not contained(artifact, evidence):
+            raise ValueError("every attempt artifact must be inside the declared evidence directory")
+        attempt_paths.append(artifact)
+    attempt_stream, attempt_terminal_receipt = attempt_paths
+    artifact_paths = [preflight_receipt, final_output, attempt_stream, attempt_terminal_receipt]
     if len(set(artifact_paths)) != len(artifact_paths):
         raise ValueError("governed artifact paths must be distinct")
     validated_commands = [validate_command(value) for value in body.get("allowed_commands", [])]
@@ -2437,9 +2433,9 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
         evidence_directory=evidence,
         preflight_receipt=preflight_receipt,
         final_output=final_output,
-        attempt_artifacts=tuple(attempt_artifacts),
+        attempt_stream=attempt_stream,
+        attempt_terminal_receipt=attempt_terminal_receipt,
         allowed_commands=commands,
-        max_attempts=max_attempts,
         observation_interval=observation,
         soft_liveness_threshold=soft,
         graceful_termination_seconds=grace,
@@ -2615,10 +2611,9 @@ def git_worktree_capability_error(
 def preflight_review(config: GovernedReviewConfig, environment: dict[str, str]) -> dict[str, object]:
     if config.final_output.exists() or config.final_output.is_symlink():
         raise RuntimeError(f"configured governed artifact already exists: {config.final_output}")
-    for stream_path, terminal_receipt_path in config.attempt_artifacts:
-        for artifact in (stream_path, terminal_receipt_path):
-            if artifact.exists() or artifact.is_symlink():
-                raise RuntimeError(f"configured governed artifact already exists: {artifact}")
+    for artifact in (config.attempt_stream, config.attempt_terminal_receipt):
+        if artifact.exists() or artifact.is_symlink():
+            raise RuntimeError(f"configured governed artifact already exists: {artifact}")
     path_results: list[dict[str, object]] = []
     for root, representative in config.source_locations:
         if representative.is_dir():
@@ -2746,6 +2741,7 @@ def governed_claude_arguments(
         "stream-json",
         "--verbose",
         "--no-session-persistence",
+        "--restricted",
         "--disable-slash-commands",
         "--no-chrome",
         "--permission-mode",
@@ -2757,8 +2753,6 @@ def governed_claude_arguments(
         "--strict-mcp-config",
         "--mcp-config",
         '{"mcpServers":{}}',
-        "--setting-sources",
-        "",
         "--settings",
         json.dumps(hook_settings, separators=(",", ":")),
         "--append-system-prompt",
@@ -3024,20 +3018,20 @@ def effort_qualification_evidence(path: Path | None, requested_effort: str | Non
     return evidence, None
 
 
-def retry_classification(parsed: dict[str, object], exit_code: int) -> tuple[str, bool]:
+def terminal_classification(parsed: dict[str, object], exit_code: int) -> str:
     result = parsed.get("result")
     retries = parsed.get("retry_events")
     if isinstance(result, dict) and result.get("subtype") == "success" and not result.get("is_error") and exit_code == 0:
-        return "success", False
+        return "success"
     if isinstance(retries, list) and retries:
         last_error = retries[-1].get("error")
-        if last_error in TRANSIENT_OUTER_RETRY_ERRORS and isinstance(result, dict) and result.get("is_error"):
-            return f"terminal_transient_{last_error}", True
         if last_error == "rate_limit":
-            return "terminal_rate_limit_policy_owned_by_cak_154", False
+            return "terminal_rate_limit_policy_owned_by_cak_154"
         if last_error in {"authentication_failed", "oauth_org_not_allowed", "billing_error"}:
-            return "terminal_auth_or_billing_failure", False
-    return "terminal_unclassified_failure", False
+            return "terminal_auth_or_billing_failure"
+        if isinstance(last_error, str):
+            return f"terminal_provider_{last_error}"
+    return "terminal_unclassified_failure"
 
 
 def terminate_recorded_group(live_state_path: Path, authority: str, *, force_authorized: bool, grace_seconds: float | None) -> int:
@@ -3214,7 +3208,7 @@ def run_governed_review(
         final_exit = REVIEWER_FAILURE_EXIT
         last_verified_snapshot = post_preflight_snapshot
         expected_symbolic_ref = preflight["candidate_identity"]["symbolic_ref"]
-        for attempt_number in range(1, config.max_attempts + 1):
+        for attempt_number in (1,):
             try:
                 candidate_identity = verified_candidate_head(
                     config.candidate,
@@ -3251,7 +3245,7 @@ def run_governed_review(
                         "failure_classification": "candidate_identity_changed_before_attempt",
                         "candidate_verdict": "not_produced",
                         "substantive_review_started": bool(attempt_summaries),
-                        "automated_retry_attempted": attempt_number > 1,
+                        "automated_retry_attempted": False,
                         "candidate_identity_stage": "before_attempt_baseline",
                         "candidate_identity_checks": candidate_identity_checks,
                         "candidate_identity_observation": getattr(error, "observation", None),
@@ -3276,7 +3270,8 @@ def run_governed_review(
             attempt_snapshot = source_snapshot(
                 list(config.guard_roots), config.candidate, environment, config.allowed_commands, config.candidate_head
             )
-            output_path, receipt_path = config.attempt_artifacts[attempt_number - 1]
+            output_path = config.attempt_stream
+            receipt_path = config.attempt_terminal_receipt
             live_state_path = scratch / f"{attempt_id}-live-state.json"
             if not contained(live_state_path, scratch):
                 raise RuntimeError("live-state path escaped controller scratch")
@@ -3306,7 +3301,7 @@ def run_governed_review(
                         "attempts": attempt_summaries,
                         "attempt_number": attempt_number,
                         "substantive_review_started": bool(attempt_summaries),
-                        "automated_retry_attempted": attempt_number > 1,
+                        "automated_retry_attempted": False,
                         "no_delta_postflight": comparison,
                         "attempt_scratch": {**scratch_record, "cleanup": {"passed": True}},
                         "error": bounded_redacted(str(error)),
@@ -3353,7 +3348,7 @@ def run_governed_review(
                         "failure_classification": "candidate_identity_changed_before_execution",
                         "candidate_verdict": "not_produced",
                         "substantive_review_started": bool(attempt_summaries),
-                        "automated_retry_attempted": attempt_number > 1,
+                        "automated_retry_attempted": False,
                         "candidate_identity_stage": "immediately_before_provider_spawn",
                         "candidate_identity_checks": candidate_identity_checks,
                         "candidate_identity_observation": getattr(error, "observation", None),
@@ -3623,7 +3618,7 @@ def run_governed_review(
                 requested_effort,
             )
             canary_failure = provider_command_canary_failure(parsed, config.allowed_commands[0])
-            classification, retryable = retry_classification(parsed, process.returncode)
+            classification = terminal_classification(parsed, process.returncode)
             auth_failure = classify_failure(
                 stderr.decode("utf-8", errors="replace"),
                 stdout.decode("utf-8", errors="replace"),
@@ -3631,20 +3626,15 @@ def run_governed_review(
             )
             if auth_failure and auth_failure.startswith("AUTH_"):
                 classification = auth_failure
-                retryable = False
             if capability_failure or capability_signal_sent:
                 classification = capability_failure or live_capability_failure or "startup_capability_error"
-                retryable = False
                 live_state["capability_failure"] = classification
             elif effort_failure:
                 classification = effort_failure
-                retryable = False
             elif canary_failure:
                 classification = canary_failure
-                retryable = False
             if live_state.get("termination_authority"):
                 classification = "operator_authorized_termination"
-                retryable = False
             post_snapshot, postflight_observation_failure = observed_source_snapshot(
                 list(config.guard_roots),
                 config.candidate,
@@ -3660,10 +3650,8 @@ def run_governed_review(
                 changes = list(postflight_comparison["blocking_paths"])
             if live_observation_failure is not None or postflight_observation_failure is not None:
                 classification = "source_observation_failure"
-                retryable = False
             elif changes:
                 classification = "reviewer_side_effect_failure"
-                retryable = False
             claude_version = execution_identity.get("version")
             scratch_record = attempt_scratch.record()
             try:
@@ -3676,7 +3664,6 @@ def run_governed_review(
                     "error": bounded_redacted(str(error)),
                 }
                 classification = "attempt_scratch_cleanup_failure"
-                retryable = False
             result = parsed.get("result")
             if classification == "success" and isinstance(result, dict) and isinstance(result.get("result"), str):
                 final_output = result["result"]
@@ -3693,7 +3680,7 @@ def run_governed_review(
                 "controller_id": controller_id,
                 "attempt_id": attempt_id,
                 "attempt_number": attempt_number,
-                "execution_kind": "fresh_execution_exact_input_repeat" if attempt_number > 1 else "fresh_execution",
+                "execution_kind": "fresh_execution",
                 "contract_identity": contract_identity,
                 "candidate_identity_checks": list(candidate_identity_checks),
                 "preflight": preflight,
@@ -3736,7 +3723,6 @@ def run_governed_review(
                 },
                 "attempt_scratch": {**scratch_record, "cleanup": scratch_cleanup},
                 "failure_classification": None if classification == "success" else classification,
-                "retry_eligible": retryable,
                 "candidate_verdict": "uninterpreted" if classification == "success" else "not_produced",
                 "substantive_review_output": classification == "success",
                 "raw_output": {"path": str(output_path), "size": len(stdout), "sha256": sha256_bytes(stdout)},
@@ -3829,14 +3815,9 @@ def run_governed_review(
                     "attempt_id": attempt_id,
                     "receipt": str(receipt_path),
                     "classification": classification,
-                    "retry_eligible": retryable,
                     "live_state": str(live_state_path),
                 }
             )
-            if retryable and post_snapshot is not None and not changes:
-                last_verified_snapshot = post_snapshot
-            if classification == "success" or not retryable or attempt_number == config.max_attempts:
-                break
 
         overall = {
             "kind": "claude_governed_review",
@@ -3849,7 +3830,7 @@ def run_governed_review(
             "candidate_verdict": "uninterpreted" if final_exit == 0 else "not_produced",
             "substantive_review_output": final_exit == 0,
             "failure_classification": None if final_exit == 0 else attempt_summaries[-1]["classification"],
-            "automated_retry_attempted": len(attempt_summaries) > 1,
+            "automated_retry_attempted": False,
         }
         if final_output is not None:
             final_output_bytes = final_output.encode("utf-8")
@@ -4163,7 +4144,8 @@ def main(argv: list[str] | None = None) -> int:
                 config.path,
                 config.preflight_receipt,
                 config.final_output,
-                *(path for pair in config.attempt_artifacts for path in pair),
+                config.attempt_stream,
+                config.attempt_terminal_receipt,
             }
             diagnostics_destination = qualified_diagnostics_destination(
                 args.diagnostics_file,

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -34,6 +34,7 @@ AUTH_PREFLIGHT_BENIGN_NOTICES = {
     "Client.listTools() called but server does not advertise tools capability - returning empty list",
 }
 GOVERNED_CONFIG_VERSION = 2
+CLAUDE_MINIMUM_VERSION_FOR_RESTRICTED = (2, 1, 248)
 SAFE_EXECUTABLES = {"git", "shasum"}
 INSTALLATION_SCHEMA_VERSION = 3
 QUALIFICATION_SCHEMA_VERSION = 3
@@ -43,6 +44,7 @@ MODEL_FAMILY_ALIASES = {"fable", "opus", "sonnet", "haiku"}
 CURRENT_FABLE_IDENTITIES = {"fable", "claude-fable-5", "claude-fable-5-1"}
 EFFORT_LEVELS = {"low", "medium", "high", "xhigh", "max"}
 EFFORT_EVIDENCE_NAME = "effective-effort.json"
+HOOK_LIVENESS_EVIDENCE_NAME = "permission-hook-liveness.json"
 WORKTREE_ADMIN_PATHS = ("HEAD", "index", "logs/HEAD", "COMMIT_EDITMSG", "ORIG_HEAD")
 OAUTH_REAUTHENTICATION_DISPOSITION = (
     "REVIEWER INFRASTRUCTURE FAILURE — OPERATOR REAUTHENTICATION REQUIRED"
@@ -944,6 +946,15 @@ def version_of(executable: str, environment: dict[str, str], *, cwd: str) -> str
     if result.returncode != 0:
         return None
     return bounded_redacted((result.stdout or result.stderr).strip()) or None
+
+
+def parsed_claude_version(reported: object) -> tuple[int, int, int] | None:
+    if not isinstance(reported, str):
+        return None
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", reported)
+    if match is None:
+        return None
+    return int(match.group(1)), int(match.group(2)), int(match.group(3) or 0)
 
 
 def emit_diagnostics(record: dict[str, Any], destination: Path | None) -> None:
@@ -2445,6 +2456,7 @@ def load_governed_config(path: Path) -> GovernedReviewConfig:
 def permission_hook(
     config_path: Path,
     expected_digest: str | None,
+    liveness_evidence_path: Path | None,
     expected_effort: str | None,
     effort_evidence_path: Path | None,
 ) -> int:
@@ -2461,11 +2473,32 @@ def permission_hook(
             and command in allowed
             and tool_input.get("dangerouslyDisableSandbox") is not True
         )
+        if liveness_evidence_path is None:
+            raise ValueError("permission-hook liveness evidence path is required")
+        hook_cwd = Path(hook_input["cwd"]).resolve(strict=True)
+        liveness_parent = liveness_evidence_path.parent.resolve(strict=True)
+        if (
+            not liveness_evidence_path.is_absolute()
+            or liveness_evidence_path.name != HOOK_LIVENESS_EVIDENCE_NAME
+            or liveness_parent != hook_cwd
+        ):
+            raise ValueError("permission-hook liveness evidence is outside the exact provider runtime directory")
+        liveness_evidence = {
+            "kind": "claude_governed_review_permission_hook_liveness",
+            "config_sha256": expected_digest,
+            "observed": True,
+            "zero_authority": True,
+        }
+        encoded_liveness = canonical_json_bytes(liveness_evidence)
+        if liveness_evidence_path.exists() or liveness_evidence_path.is_symlink():
+            if liveness_evidence_path.is_symlink() or liveness_evidence_path.read_bytes() != encoded_liveness:
+                raise ValueError("permission-hook liveness evidence changed within one attempt")
+        elif permitted:
+            exclusive_write(liveness_evidence_path, encoded_liveness)
         effort_matches = True
         if expected_effort is not None:
             if expected_effort not in EFFORT_LEVELS or effort_evidence_path is None:
                 raise ValueError("effort qualification arguments are invalid")
-            hook_cwd = Path(hook_input["cwd"]).resolve(strict=True)
             evidence_parent = effort_evidence_path.parent.resolve(strict=True)
             if (
                 not effort_evidence_path.is_absolute()
@@ -2691,6 +2724,7 @@ def governed_system_prompt(config: GovernedReviewConfig) -> str:
 def governed_claude_arguments(
     config: GovernedReviewConfig,
     model_arguments: list[str],
+    hook_liveness_evidence_path: Path,
     effort_evidence_path: Path | None = None,
 ) -> tuple[list[str], str]:
     allowed_model_arguments = preflight_arguments(model_arguments)
@@ -2706,6 +2740,8 @@ def governed_claude_arguments(
         str(config.path),
         "--permission-hook-digest",
         config.digest,
+        "--permission-hook-liveness-evidence",
+        str(hook_liveness_evidence_path),
     ]
     if requested_effort is not None:
         if effort_evidence_path is None:
@@ -2959,6 +2995,26 @@ def init_capability_failure(
     return None
 
 
+def hook_liveness_evidence(path: Path, config_digest: str) -> tuple[dict[str, object], str | None]:
+    if not path.exists() or path.is_symlink():
+        return {"observed": False}, "permission_hook_unobservable"
+    try:
+        evidence = json.loads(path.read_bytes())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {"observed": False}, "permission_hook_evidence_invalid"
+    valid = (
+        isinstance(evidence, dict)
+        and set(evidence) == {"kind", "config_sha256", "observed", "zero_authority"}
+        and evidence.get("kind") == "claude_governed_review_permission_hook_liveness"
+        and evidence.get("config_sha256") == config_digest
+        and evidence.get("observed") is True
+        and evidence.get("zero_authority") is True
+    )
+    if not valid:
+        return evidence if isinstance(evidence, dict) else {}, "permission_hook_evidence_invalid"
+    return evidence, None
+
+
 def effort_qualification_evidence(path: Path | None, requested_effort: str | None) -> tuple[dict[str, object], str | None]:
     """Read exact hook-observed effort evidence for the completed attempt."""
     if requested_effort is None:
@@ -3029,8 +3085,10 @@ def terminal_classification(parsed: dict[str, object], exit_code: int) -> str:
             return "terminal_rate_limit_policy_owned_by_cak_154"
         if last_error in {"authentication_failed", "oauth_org_not_allowed", "billing_error"}:
             return "terminal_auth_or_billing_failure"
-        if isinstance(last_error, str):
+        if last_error in {"overloaded", "server_error"}:
             return f"terminal_provider_{last_error}"
+        if isinstance(last_error, str):
+            return "terminal_provider_failure"
     return "terminal_unclassified_failure"
 
 
@@ -3138,6 +3196,23 @@ def run_governed_review(
         "reviewer_execution_identity": execution_identity,
     }
     controller_id = uuid.uuid4().hex
+    claude_semantic_version = parsed_claude_version(execution_identity.get("version"))
+    if claude_semantic_version is None or claude_semantic_version < CLAUDE_MINIMUM_VERSION_FOR_RESTRICTED:
+        emit_diagnostics(
+            {
+                "kind": "claude_governed_review",
+                "review_id": config.body["review_id"],
+                "contract_id": config.body["contract_id"],
+                "controller_id": controller_id,
+                "contract_identity": contract_identity,
+                "failure_classification": "claude_restricted_mode_version_unsupported",
+                "candidate_verdict": "not_produced",
+                "substantive_review_started": False,
+                "error": "governed review requires Claude Code 2.1.248 or later for restricted mode",
+            },
+            diagnostics_destination,
+        )
+        return REVIEWER_FAILURE_EXIT
     with AttemptScratch.allocate(child_environment, "claude-review-controller-") as scratch:
         controller_environment = safe_command_environment(child_environment, scratch)
         environment = controller_environment
@@ -3206,7 +3281,6 @@ def run_governed_review(
         candidate_identity_checks: list[dict[str, object]] = []
         final_output: str | None = None
         final_exit = REVIEWER_FAILURE_EXIT
-        last_verified_snapshot = post_preflight_snapshot
         expected_symbolic_ref = preflight["candidate_identity"]["symbolic_ref"]
         for attempt_number in (1,):
             try:
@@ -3249,7 +3323,7 @@ def run_governed_review(
                         "candidate_identity_stage": "before_attempt_baseline",
                         "candidate_identity_checks": candidate_identity_checks,
                         "candidate_identity_observation": getattr(error, "observation", None),
-                        "no_delta_postflight": no_delta_evidence(last_verified_snapshot, drift_snapshot),
+                        "no_delta_postflight": no_delta_evidence(post_preflight_snapshot, drift_snapshot),
                         "error": bounded_redacted(str(error)),
                     },
                     diagnostics_destination,
@@ -3260,9 +3334,11 @@ def run_governed_review(
             effort_evidence_path = (
                 attempt_scratch.path / EFFORT_EVIDENCE_NAME if requested_effort is not None else None
             )
+            hook_liveness_path = attempt_scratch.path / HOOK_LIVENESS_EVIDENCE_NAME
             arguments, _ = governed_claude_arguments(
                 config,
                 model_arguments,
+                hook_liveness_path,
                 effort_evidence_path,
             )
             command = [executable, "-p", *arguments]
@@ -3613,6 +3689,10 @@ def run_governed_review(
                 expected_cwd=attempt_scratch.path,
                 model_arguments=model_arguments,
             )
+            hook_liveness, hook_liveness_failure = hook_liveness_evidence(
+                hook_liveness_path,
+                config.digest,
+            )
             effort_evidence, effort_failure = effort_qualification_evidence(
                 effort_evidence_path,
                 requested_effort,
@@ -3629,6 +3709,10 @@ def run_governed_review(
             if capability_failure or capability_signal_sent:
                 classification = capability_failure or live_capability_failure or "startup_capability_error"
                 live_state["capability_failure"] = classification
+            elif canary_failure == "provider_command_canary_requested_sandbox_bypass":
+                classification = canary_failure
+            elif hook_liveness_failure:
+                classification = hook_liveness_failure
             elif effort_failure:
                 classification = effort_failure
             elif canary_failure:
@@ -3719,6 +3803,7 @@ def run_governed_review(
                             else None
                         ),
                         "effort_matches": effort_evidence["matches"],
+                        "permission_hook_liveness": hook_liveness,
                     },
                 },
                 "attempt_scratch": {**scratch_record, "cleanup": scratch_cleanup},
@@ -3868,6 +3953,7 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
     operation.add_argument("--review-config-fixture", type=Path, help=argparse.SUPPRESS)
     operation.add_argument("--permission-hook", type=Path)
     parser.add_argument("--permission-hook-digest")
+    parser.add_argument("--permission-hook-liveness-evidence", type=Path)
     parser.add_argument("--permission-hook-expected-effort")
     parser.add_argument("--permission-hook-effort-evidence", type=Path)
     operation.add_argument("--request-termination", type=Path)
@@ -3887,6 +3973,10 @@ def parse_arguments(argv: list[str]) -> argparse.Namespace:
         parser.error("do not pass Claude prompt flags; provide the prompt on standard input")
     if args.permission_hook is None and args.permission_hook_digest is not None:
         parser.error("--permission-hook-digest requires --permission-hook")
+    if args.permission_hook is None and args.permission_hook_liveness_evidence is not None:
+        parser.error("permission-hook liveness evidence requires --permission-hook")
+    if args.permission_hook is not None and args.permission_hook_liveness_evidence is None:
+        parser.error("--permission-hook requires a liveness evidence path")
     effort_hook_arguments = (
         args.permission_hook_expected_effort,
         args.permission_hook_effort_evidence,
@@ -3929,6 +4019,7 @@ def main(argv: list[str] | None = None) -> int:
         return permission_hook(
             args.permission_hook,
             args.permission_hook_digest,
+            args.permission_hook_liveness_evidence,
             args.permission_hook_expected_effort,
             args.permission_hook_effort_evidence,
         )

--- a/scripts/claude-review
+++ b/scripts/claude-review
@@ -2458,11 +2458,19 @@ def write_idempotent_hook_evidence(path: Path, encoded: bytes, label: str) -> No
         if path.is_symlink() or path.read_bytes() != encoded:
             raise ValueError(f"{label} evidence changed within one attempt")
         return
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary_created = False
     try:
-        exclusive_write(path, encoded)
-    except FileExistsError:
-        if path.is_symlink() or path.read_bytes() != encoded:
-            raise ValueError(f"{label} evidence changed within one attempt")
+        exclusive_write(temporary, encoded)
+        temporary_created = True
+        try:
+            os.link(temporary, path, follow_symlinks=False)
+        except FileExistsError:
+            if path.is_symlink() or path.read_bytes() != encoded:
+                raise ValueError(f"{label} evidence changed within one attempt")
+    finally:
+        if temporary_created and temporary.exists() and not temporary.is_symlink():
+            temporary.unlink()
 
 
 def permission_hook(

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -2128,7 +2128,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         )
         self.fake.chmod(0o755)
 
-    def config_body(self, *, launch_root=None, additional=None, max_attempts=3):
+    def config_body(self, *, launch_root=None, additional=None):
         candidate_head = subprocess.run(
             ["git", "-C", str(self.candidate), "rev-parse", "HEAD"],
             check=True,
@@ -2136,7 +2136,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             stdout=subprocess.PIPE,
         ).stdout.strip()
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "review_id": "CAK-155-fixture",
             "contract_id": "sha256:fixture-contract",
             "launch_root": str(launch_root or self.root),
@@ -2151,17 +2151,11 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "evidence_directory": str(self.evidence),
             "preflight_receipt": str(self.evidence / "preflight-receipt.json"),
             "final_output": str(self.evidence / "review-output.md"),
-            "attempt_artifacts": [
-                {
-                    "stream": str(self.evidence / f"attempt-{number}-stream.jsonl"),
-                    "terminal_receipt": str(self.evidence / f"attempt-{number}-terminal-receipt.json"),
-                }
-                for number in range(1, max_attempts + 1)
-            ],
+            "attempt_stream": str(self.evidence / "attempt-stream.jsonl"),
+            "attempt_terminal_receipt": str(self.evidence / "attempt-terminal-receipt.json"),
             "allowed_commands": [
                 ["git", "-C", str(self.candidate), "status", "--porcelain=v2", "--untracked-files=all"]
             ],
-            "max_attempts": max_attempts,
             "observation_interval_seconds": 0.005,
             "soft_liveness_threshold_seconds": 0.02,
             "graceful_termination_seconds": 0.05,
@@ -2222,11 +2216,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         final_output = Path((body or self.config_body())["final_output"])
         if final_output.exists() or final_output.is_symlink():
             final_output.unlink()
-        for item in (body or self.config_body())["attempt_artifacts"]:
-            for value in item.values():
-                artifact = Path(value)
-                if artifact.exists() or artifact.is_symlink():
-                    artifact.unlink()
+        for key in ("attempt_stream", "attempt_terminal_receipt"):
+            artifact = Path((body or self.config_body())[key])
+            if artifact.exists() or artifact.is_symlink():
+                artifact.unlink()
         completed = subprocess.run(
             [
                 str(LAUNCHER),
@@ -2298,11 +2291,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         *,
         verification_call,
         scenario="success",
-        max_attempts=1,
         symbolic_ref_only=False,
     ):
         module = load_script(f"claude_review_head_drift_{verification_call}_{scenario}", LAUNCHER)
-        body = self.config_body(max_attempts=max_attempts)
+        body = self.config_body()
         config = module.load_governed_config(self.write_config(body))
         diagnostics = self.evidence / "overall.json"
         environment = self.environment(scenario)
@@ -2523,22 +2515,9 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             )
         )
 
-    def test_candidate_head_drift_before_retry_preserves_first_attempt_and_stops_second_spawn(self):
-        result, diagnostic = self.run_governed_with_head_mutation(
-            verification_call=4,
-            scenario="transient_once",
-            max_attempts=2,
-        )
-        self.assertEqual(result, 70)
-        self.assertEqual(diagnostic["failure_classification"], "candidate_identity_changed_before_attempt")
-        self.assertEqual(self.count.read_text(encoding="utf-8"), "1")
-        self.assertEqual(len(diagnostic["attempts"]), 1)
-        self.assertTrue((self.evidence / "attempt-1-terminal-receipt.json").exists())
-        self.assertFalse((self.evidence / "attempt-2-terminal-receipt.json").exists())
-
     def test_detached_candidate_remains_bound_to_configured_commit(self):
         subprocess.run(["git", "-C", str(self.candidate), "checkout", "--detach", "-q", "HEAD"], check=True)
-        completed, diagnostic = self.run_governed("success", body=self.config_body(max_attempts=1))
+        completed, diagnostic = self.run_governed("success", body=self.config_body())
         self.assertEqual(completed.returncode, 0, diagnostic)
         self.assertEqual(diagnostic["preflight"]["candidate_identity"]["symbolic_ref"], None)
         self.assertEqual(
@@ -2567,6 +2546,8 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             ["--model", "opus", "--effort", "high"],
             scratch / module.EFFORT_EVIDENCE_NAME,
         )
+        self.assertIn("--restricted", arguments)
+        self.assertNotIn("--setting-sources", arguments)
         settings = json.loads(arguments[arguments.index("--settings") + 1])
         self.assertNotIn("sandbox", settings)
         self.assertIn("Before substantive analysis", system_prompt)
@@ -2760,29 +2741,29 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 70)
         self.assertEqual(diagnostic["failure_classification"], "reviewer_side_effect_failure")
 
-    def test_transient_retry_recovers_without_contract_or_controller_drift(self):
+    def test_terminal_transient_failure_stops_without_controller_retry(self):
         completed, diagnostic = self.run_governed("transient_once")
-        self.assertEqual(completed.returncode, 0)
-        self.assertEqual(len(diagnostic["attempts"]), 2)
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "terminal_provider_server_error")
+        self.assertFalse(diagnostic["automated_retry_attempted"])
+        self.assertEqual(len(diagnostic["attempts"]), 1)
         receipts = self.receipts()
-        self.assertEqual(len(receipts), 2)
+        self.assertEqual(len(receipts), 1)
         self.assertEqual({receipt["controller_id"] for receipt in receipts}, {diagnostic["controller_id"]})
-        self.assertEqual(len({json.dumps(receipt["contract_identity"], sort_keys=True) for receipt in receipts}), 1)
-        self.assertEqual(receipts[1]["execution_kind"], "fresh_execution_exact_input_repeat")
+        self.assertEqual(receipts[0]["execution_kind"], "fresh_execution")
         scratch_paths = [receipt["attempt_scratch"]["path"] for receipt in receipts]
-        self.assertEqual(len(set(scratch_paths)), 2)
         self.assertTrue(all(receipt["attempt_scratch"]["cleanup"]["passed"] for receipt in receipts))
         self.assertTrue(all(not Path(path).exists() for path in scratch_paths))
 
-    def test_retry_identity_drift_preserves_prior_attempt_evidence_and_stops_before_second_spawn(self):
+    def test_provider_terminal_failure_does_not_recheck_for_a_second_spawn(self):
         completed, diagnostic = self.run_governed("transient_then_executable_drift")
         self.assertEqual(completed.returncode, 70)
         self.assertEqual(self.count.read_text(encoding="utf-8"), "1")
-        self.assertEqual(diagnostic["failure_classification"], "reviewer_identity_changed_before_execution")
+        self.assertEqual(diagnostic["failure_classification"], "terminal_provider_server_error")
         self.assertEqual(diagnostic["candidate_verdict"], "not_produced")
-        self.assertEqual(diagnostic["attempt_number"], 2)
-        self.assertTrue(diagnostic["substantive_review_started"])
-        self.assertTrue(diagnostic["automated_retry_attempted"])
+        self.assertEqual(self.receipts()[0]["attempt_number"], 1)
+        self.assertFalse(diagnostic["substantive_review_output"])
+        self.assertFalse(diagnostic["automated_retry_attempted"])
         self.assertEqual((self.root / "version-count").read_text(encoding="utf-8"), "2")
         self.assertEqual(len(diagnostic["attempts"]), 1)
         prior_attempt = diagnostic["attempts"][0]
@@ -2792,10 +2773,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertTrue(Path(receipt["raw_output"]["path"]).exists())
         self.assertEqual(len(self.receipts()), 1)
 
-    def test_lingering_process_group_blocks_retry_until_terminal(self):
+    def test_lingering_process_group_reaches_terminal_before_attempt_receipt(self):
         completed, diagnostic = self.run_governed("transient_with_lingering_child")
-        self.assertEqual(completed.returncode, 0)
-        self.assertEqual(len(diagnostic["attempts"]), 2)
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(len(diagnostic["attempts"]), 1)
         receipts = self.receipts()
         self.assertTrue(all(receipt["lifecycle"]["process_group_terminal"] for receipt in receipts))
         self.assertTrue(
@@ -2835,10 +2816,12 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertFalse(stream_evidence["collectors_reached_eof_before_stream_freeze"])
         self.assertEqual(stream_evidence["collector_read_errors"]["stdout"], "fixture reader failure")
 
-    def test_retry_exhaustion_stops_at_three_and_auth_stops_at_one(self):
+    def test_provider_failure_and_auth_each_stop_after_one_explicit_attempt(self):
         exhausted, exhausted_diagnostic = self.run_governed("transient_always")
         self.assertEqual(exhausted.returncode, 70)
-        self.assertEqual(len(exhausted_diagnostic["attempts"]), 3)
+        self.assertEqual(exhausted_diagnostic["failure_classification"], "terminal_provider_server_error")
+        self.assertEqual(len(exhausted_diagnostic["attempts"]), 1)
+        self.assertFalse(exhausted_diagnostic["automated_retry_attempted"])
 
         auth_root = self.root / "auth-evidence"
         auth_root.mkdir()
@@ -2847,13 +2830,8 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         body["evidence_directory"] = str(auth_root)
         body["preflight_receipt"] = str(auth_root / "preflight-receipt.json")
         body["final_output"] = str(auth_root / "review-output.md")
-        body["attempt_artifacts"] = [
-            {
-                "stream": str(auth_root / f"attempt-{number}-stream.jsonl"),
-                "terminal_receipt": str(auth_root / f"attempt-{number}-terminal-receipt.json"),
-            }
-            for number in range(1, body["max_attempts"] + 1)
-        ]
+        body["attempt_stream"] = str(auth_root / "attempt-stream.jsonl")
+        body["attempt_terminal_receipt"] = str(auth_root / "attempt-terminal-receipt.json")
         config = auth_root / "review-config.json"
         config.write_text(json.dumps(body), encoding="utf-8")
         diagnostics = auth_root / "overall.json"
@@ -2868,6 +2846,16 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 78)
         self.assertEqual(len(json.loads(diagnostics.read_text())["attempts"]), 1)
+
+    def test_schema_two_rejects_obsolete_automatic_retry_fields(self):
+        module = load_script("claude_review_obsolete_retry_fields", LAUNCHER)
+        for obsolete_field, value in (("max_attempts", 2), ("attempt_artifacts", [])):
+            body = self.config_body()
+            body[obsolete_field] = value
+            with self.subTest(obsolete_field=obsolete_field), self.assertRaisesRegex(
+                ValueError, "one explicit provider attempt"
+            ):
+                module.load_governed_config(self.write_config(body))
 
     def test_precise_terminal_auth_record_stops_without_retry(self):
         completed, diagnostic = self.run_governed("auth_precise")
@@ -3008,7 +2996,8 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "deny",
         )
 
-        changed = self.config_body(max_attempts=2)
+        changed = self.config_body()
+        changed["contract_id"] = "sha256:changed-fixture-contract"
         config.write_text(json.dumps(changed), encoding="utf-8")
         denied = subprocess.run(
             command,
@@ -3217,7 +3206,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
 
     def test_live_primary_worktree_commit_passes_for_a_linked_candidate(self):
         self.use_linked_candidate("fixture-live-primary")
-        body = self.config_body(max_attempts=1)
+        body = self.config_body()
         # Observe the completed Git operation, not its deliberately blocking transient lock.
         body["observation_interval_seconds"] = 0.5
         completed, diagnostic = self.run_governed("primary_worktree_commit_then_wait", body=body)
@@ -3235,7 +3224,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.use_linked_candidate("fixture-primary-mixed")
         completed, diagnostic = self.run_governed(
             "primary_worktree_and_candidate_mutation",
-            body=self.config_body(max_attempts=1),
+            body=self.config_body(),
         )
         self.assertEqual(completed.returncode, 70)
         self.assertEqual(diagnostic["failure_classification"], "reviewer_side_effect_failure")
@@ -3830,7 +3819,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             ],
             check=True,
         )
-        completed, diagnostic = self.run_governed("unrelated_worktree_commit_then_wait", body=self.config_body(max_attempts=1))
+        completed, diagnostic = self.run_governed("unrelated_worktree_commit_then_wait", body=self.config_body())
         receipts = self.receipts()
         self.assertEqual(completed.returncode, 0, {"diagnostic": diagnostic, "receipts": receipts})
         self.assertIsNone(diagnostic["failure_classification"])
@@ -3860,7 +3849,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertNotIn("emergency_condition", receipt["lifecycle"])
 
     def test_live_unattributed_object_write_remains_fail_closed_after_stabilization(self):
-        completed, diagnostic = self.run_governed("unattributed_object_then_wait", body=self.config_body(max_attempts=1))
+        completed, diagnostic = self.run_governed("unattributed_object_then_wait", body=self.config_body())
         self.assertNotEqual(completed.returncode, 0)
         self.assertEqual(diagnostic["failure_classification"], "reviewer_side_effect_failure")
         receipt = self.receipts()[0]
@@ -3876,7 +3865,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
     def test_governed_review_creates_no_local_or_cross_attempt_state(self):
         self.isolated_home = self.root / "isolated-home"
         self.isolated_home.mkdir()
-        completed, diagnostic = self.run_governed("success", body=self.config_body(max_attempts=1))
+        completed, diagnostic = self.run_governed("success", body=self.config_body())
         self.assertEqual(completed.returncode, 0)
         self.assertIsNone(diagnostic["failure_classification"])
         receipt = self.receipts()[0]
@@ -3914,7 +3903,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             check=True,
         )
         completed, diagnostic = self.run_governed(
-            "unrelated_worktree_and_candidate_mutation", body=self.config_body(max_attempts=1)
+            "unrelated_worktree_and_candidate_mutation", body=self.config_body()
         )
         self.assertEqual(completed.returncode, 70)
         self.assertEqual(diagnostic["failure_classification"], "reviewer_side_effect_failure")

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -3079,13 +3079,13 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         module = load_script("claude_review_hook_evidence_race", LAUNCHER)
         evidence_path = self.root / "hook-race-evidence.json"
         encoded = b'{"observed":true}'
-        real_exclusive_write = module.exclusive_write
+        real_link = module.os.link
 
-        def concurrent_winner(path, content):
-            real_exclusive_write(path, content)
-            raise FileExistsError(path)
+        def concurrent_winner(source, destination, **kwargs):
+            real_link(source, destination, **kwargs)
+            raise FileExistsError(destination)
 
-        with mock.patch.object(module, "exclusive_write", side_effect=concurrent_winner):
+        with mock.patch.object(module.os, "link", side_effect=concurrent_winner):
             module.write_idempotent_hook_evidence(evidence_path, encoded, "hook")
         self.assertEqual(evidence_path.read_bytes(), encoded)
 

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -2012,14 +2012,22 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "    version_count = pathlib.Path(os.environ['FAKE_VERSION_COUNT'])\n"
             "    count = int(version_count.read_text()) + 1 if version_count.exists() else 1\n"
             "    version_count.write_text(str(count))\n"
-            "    version = '2.1.247' if os.environ.get('FAKE_SCENARIO') == 'restricted_unsupported' else '2.1.252'\n"
-            "    print(f'fake-claude {version}')\n"
+            "    scenario = os.environ.get('FAKE_SCENARIO')\n"
+            "    if scenario == 'version_banner': print('Node 22.1.0; fake-claude 2.1.252')\n"
+            "    else:\n"
+            "        version = '2.1.247' if scenario == 'restricted_unsupported' else '2.1.252'\n"
+            "        print(f'{version} (fake-claude)')\n"
             "    raise SystemExit(0)\n"
             "prompt = sys.stdin.read()\n"
             "count = pathlib.Path(os.environ['FAKE_COUNT'])\n"
             "attempt = int(count.read_text()) + 1 if count.exists() else 1\n"
             "count.write_text(str(attempt))\n"
             "scenario = os.environ.get('FAKE_SCENARIO', 'success')\n"
+            "if scenario in {'early_server_error','early_auth_error'}:\n"
+            "    error = 'server_error' if scenario == 'early_server_error' else 'authentication_failed'\n"
+            "    print(json.dumps({'type':'system','subtype':'api_retry','session_id':f's{attempt}','error':error}), flush=True)\n"
+            "    print(json.dumps({'type':'result','subtype':'error_during_execution','is_error':True,'session_id':f's{attempt}'}), flush=True)\n"
+            "    raise SystemExit(1)\n"
             "if scenario == 'ignore_term': signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
             "candidate = pathlib.Path(os.environ['FAKE_CANDIDATE'])\n"
             "package = pathlib.Path(os.environ['FAKE_PACKAGE'])\n"
@@ -2509,6 +2517,15 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertFalse(diagnostic["substantive_review_started"])
         self.assertFalse(self.count.exists())
 
+    def test_restricted_mode_version_floor_rejects_a_prefixed_version_banner(self):
+        completed, diagnostic = self.run_governed("version_banner")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(
+            diagnostic["failure_classification"],
+            "claude_restricted_mode_version_unsupported",
+        )
+        self.assertFalse(self.count.exists())
+
     def test_candidate_head_drift_before_first_attempt_baseline_stops_without_provider_spawn(self):
         result, diagnostic = self.run_governed_with_head_mutation(verification_call=2)
         self.assertEqual(result, 70)
@@ -2574,7 +2591,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             scratch / module.EFFORT_EVIDENCE_NAME,
         )
         self.assertIn("--restricted", arguments)
-        self.assertNotIn("--setting-sources", arguments)
+        self.assertEqual(arguments[arguments.index("--setting-sources") + 1], "")
         settings = json.loads(arguments[arguments.index("--settings") + 1])
         self.assertNotIn("sandbox", settings)
         self.assertIn("Before substantive analysis", system_prompt)
@@ -2789,6 +2806,15 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         serialized = json.dumps({"diagnostic": diagnostic, "receipts": self.receipts()})
         self.assertNotIn("secret-token-value", serialized)
         self.assertLess(len(diagnostic["failure_classification"]), 100)
+
+    def test_provider_failure_before_init_preserves_terminal_class_and_exit_policy(self):
+        server, server_diagnostic = self.run_governed("early_server_error")
+        self.assertEqual(server.returncode, 70)
+        self.assertEqual(server_diagnostic["failure_classification"], "terminal_provider_server_error")
+
+        auth, auth_diagnostic = self.run_governed("early_auth_error")
+        self.assertEqual(auth.returncode, 78)
+        self.assertEqual(auth_diagnostic["failure_classification"], "AUTH_UNKNOWN_FAIL_CLOSED")
 
     def test_provider_terminal_failure_does_not_recheck_for_a_second_spawn(self):
         completed, diagnostic = self.run_governed("transient_then_executable_drift")
@@ -3048,6 +3074,20 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(json.loads(denied.stdout)["hookSpecificOutput"]["permissionDecision"], "deny")
+
+    def test_idempotent_hook_evidence_accepts_an_identical_concurrent_winner(self):
+        module = load_script("claude_review_hook_evidence_race", LAUNCHER)
+        evidence_path = self.root / "hook-race-evidence.json"
+        encoded = b'{"observed":true}'
+        real_exclusive_write = module.exclusive_write
+
+        def concurrent_winner(path, content):
+            real_exclusive_write(path, content)
+            raise FileExistsError(path)
+
+        with mock.patch.object(module, "exclusive_write", side_effect=concurrent_winner):
+            module.write_idempotent_hook_evidence(evidence_path, encoded, "hook")
+        self.assertEqual(evidence_path.read_bytes(), encoded)
 
     def test_soft_liveness_threshold_never_terminates_or_replaces_attempt(self):
         completed, _ = self.run_governed("silent")

--- a/tests/test_claude_review_launcher.py
+++ b/tests/test_claude_review_launcher.py
@@ -2012,7 +2012,8 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "    version_count = pathlib.Path(os.environ['FAKE_VERSION_COUNT'])\n"
             "    count = int(version_count.read_text()) + 1 if version_count.exists() else 1\n"
             "    version_count.write_text(str(count))\n"
-            "    print('fake-claude 2.1.241')\n"
+            "    version = '2.1.247' if os.environ.get('FAKE_SCENARIO') == 'restricted_unsupported' else '2.1.252'\n"
+            "    print(f'fake-claude {version}')\n"
             "    raise SystemExit(0)\n"
             "prompt = sys.stdin.read()\n"
             "count = pathlib.Path(os.environ['FAKE_COUNT'])\n"
@@ -2038,9 +2039,11 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "effective_effort = os.environ.get('FAKE_EFFECTIVE_EFFORT','high')\n"
             "if scenario == 'inherited_effort_override': effective_effort = os.environ.get('CLAUDE_CODE_EFFORT_LEVEL', effective_effort)\n"
             "if scenario != 'effort_unobservable': hook_input['effort'] = {'level':effective_effort}\n"
-            "hook_result = subprocess.run([hook['command'], *hook['args']], input=json.dumps(hook_input), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
-            "hook_output = json.loads(hook_result.stdout)\n"
-            "hook_denied = hook_output['hookSpecificOutput']['permissionDecision'] != 'allow'\n"
+            "hook_denied = False\n"
+            "if scenario != 'hook_unobservable':\n"
+            "    hook_result = subprocess.run([hook['command'], *hook['args']], input=json.dumps(hook_input), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)\n"
+            "    hook_output = json.loads(hook_result.stdout)\n"
+            "    hook_denied = hook_output['hookSpecificOutput']['permissionDecision'] != 'allow'\n"
             "print(json.dumps({'type':'user','message':{'content':[{'type':'tool_result','tool_use_id':canary_id,'content':'canary','is_error':scenario == 'dead_command_grant' or hook_denied}]}}), flush=True)\n"
             "if scenario == 'non_object_json': print('null', flush=True)\n"
             "if scenario == 'tool_mismatch': time.sleep(0.08)\n"
@@ -2122,6 +2125,10 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             "    raise SystemExit(1)\n"
             "if scenario == 'auth_precise':\n"
             "    print(json.dumps({'type':'result','subtype':'error_during_execution','is_error':True,'session_id':f's{attempt}','result':'API Error: 401 OAuth access token has expired'}), flush=True)\n"
+            "    raise SystemExit(1)\n"
+            "if scenario == 'hostile_retry_error':\n"
+            "    print(json.dumps({'type':'system','subtype':'api_retry','session_id':f's{attempt}','error':'authorization: Bearer secret-token-value' + 'x' * 2000}), flush=True)\n"
+            "    print(json.dumps({'type':'result','subtype':'error_during_execution','is_error':True,'session_id':f's{attempt}'}), flush=True)\n"
             "    raise SystemExit(1)\n"
             "print(json.dumps({'type':'result','subtype':'success','is_error':False,'session_id':f's{attempt}','result':'ACCEPT'}), flush=True)\n",
             encoding="utf-8",
@@ -2220,6 +2227,9 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             artifact = Path((body or self.config_body())[key])
             if artifact.exists() or artifact.is_symlink():
                 artifact.unlink()
+        claude_arguments = ["--model", model]
+        if effort is not None:
+            claude_arguments.extend(("--effort", effort))
         completed = subprocess.run(
             [
                 str(LAUNCHER),
@@ -2230,10 +2240,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
                 "--review-config-fixture",
                 str(config),
                 "--",
-                "--model",
-                model,
-                "--effort",
-                effort,
+                *claude_arguments,
             ],
             check=False,
             input="exact review prompt\n",
@@ -2457,6 +2464,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
             },
         )
         self.assertTrue(qualification["effort_matches"])
+        self.assertTrue(qualification["permission_hook_liveness"]["observed"])
 
     def test_effective_effort_mismatch_fails_closed(self):
         completed, diagnostic = self.run_governed(effort="high", effective_effort="low")
@@ -2482,6 +2490,24 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertEqual(qualification["effective"]["effort"]["status"], "unobservable")
         self.assertIsNone(qualification["effective"]["effort"]["value"])
         self.assertFalse(qualification["effort_matches"])
+
+    def test_permission_hook_liveness_is_required_without_an_effort_request(self):
+        completed, diagnostic = self.run_governed("hook_unobservable", effort=None)
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "permission_hook_unobservable")
+        qualification = self.receipts()[0]["runtime"]["configuration_qualification"]
+        self.assertEqual(qualification["requested"]["effort"], None)
+        self.assertEqual(qualification["permission_hook_liveness"], {"observed": False})
+
+    def test_restricted_mode_version_floor_stops_before_provider_spawn(self):
+        completed, diagnostic = self.run_governed("restricted_unsupported")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(
+            diagnostic["failure_classification"],
+            "claude_restricted_mode_version_unsupported",
+        )
+        self.assertFalse(diagnostic["substantive_review_started"])
+        self.assertFalse(self.count.exists())
 
     def test_candidate_head_drift_before_first_attempt_baseline_stops_without_provider_spawn(self):
         result, diagnostic = self.run_governed_with_head_mutation(verification_call=2)
@@ -2544,6 +2570,7 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         arguments, system_prompt = module.governed_claude_arguments(
             config,
             ["--model", "opus", "--effort", "high"],
+            scratch / module.HOOK_LIVENESS_EVIDENCE_NAME,
             scratch / module.EFFORT_EVIDENCE_NAME,
         )
         self.assertIn("--restricted", arguments)
@@ -2755,6 +2782,14 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         self.assertTrue(all(receipt["attempt_scratch"]["cleanup"]["passed"] for receipt in receipts))
         self.assertTrue(all(not Path(path).exists() for path in scratch_paths))
 
+    def test_unknown_provider_retry_error_uses_a_fixed_safe_classification(self):
+        completed, diagnostic = self.run_governed("hostile_retry_error")
+        self.assertEqual(completed.returncode, 70)
+        self.assertEqual(diagnostic["failure_classification"], "terminal_provider_failure")
+        serialized = json.dumps({"diagnostic": diagnostic, "receipts": self.receipts()})
+        self.assertNotIn("secret-token-value", serialized)
+        self.assertLess(len(diagnostic["failure_classification"]), 100)
+
     def test_provider_terminal_failure_does_not_recheck_for_a_second_spawn(self):
         completed, diagnostic = self.run_governed("transient_then_executable_drift")
         self.assertEqual(completed.returncode, 70)
@@ -2951,16 +2986,20 @@ class GovernedClaudeReviewLauncherTests(unittest.TestCase):
         digest = module.sha256_bytes(config.read_bytes())
         hook_input = json.dumps(
             {
+                "cwd": str(self.root),
                 "tool_name": "Bash",
                 "tool_input": {"command": shlex.join(self.config_body()["allowed_commands"][0])},
             }
         )
+        liveness_evidence = self.root / module.HOOK_LIVENESS_EVIDENCE_NAME
         command = [
             str(LAUNCHER),
             "--permission-hook",
             str(config),
             "--permission-hook-digest",
             digest,
+            "--permission-hook-liveness-evidence",
+            str(liveness_evidence),
         ]
         allowed = subprocess.run(
             command,


### PR DESCRIPTION
# Summary

## What changed

- Retains `scripts/claude-review` as the review controller, but removes its controller-level retry loop and reduces the receipt contract to one provider attempt per invocation.
- Delegates provider request/response streaming to Claude's native structured stream while keeping controller-owned invocation qualification, source integrity, privacy-safe event interpretation, fail-closed lifecycle handling, and evidence binding.
- Adds the Claude `--restricted` boundary with an explicit supported-version floor, unconditional hook-liveness evidence, fixed failure classifications, and atomic hook evidence publication.
- Updates Codex command rules, installation behavior, adapter guidance, reviewer documentation, and launcher tests.

## Why

CAK-219 asked whether the launcher should be deleted, reduced, or retained after CAK-157 Phase A established provider-native structured-stream capabilities. Full deletion is unsafe because Codex command-rule prefix matching permits arbitrary trailing arguments: the controller remains the only enforceable boundary for exact Claude invocation/configuration and the read-only/fail-closed guarantees provider events do not replace. Automatic retries were redundant machinery and are now removed.

## Scope check

- [x] This PR contains one logical change.

## Interaction mode

Implementation.

## Validation

- [x] `make check` — 18 recovery tests, byte-identical generated prose, markdownlint, and 198 primary tests passed.
- [x] Manual review — four real Codex→Claude independent review invocations using Claude Code 2.1.252; the final exact-commit review returned `ACCEPT`.

## Source evidence

- Governing planning and CAK-157 Phase A architecture evidence: Linear CAK-219.
- Provider behavior refreshed from the official Claude Code CLI, headless/structured-output, hooks, and sandboxing documentation on 2026-09-05.
- Codex command-rule trailing-argument behavior refreshed from the official OpenAI Codex rules documentation on 2026-09-05.
- Immutable review packages and exact readback evidence: Dropbox `/issues/CAK-219/`.
- Final reviewed commit: `8ef4ebb3050d752b70800e1727cdbe72f8f9af8b`.
- Final review artifact: `2026-09-05-cak-219-review-4-final.md`, SHA-256 `cf9a391618a9df415a15274abe1bc2141be3286a4f91668c2a16b696d84beffb`.

## Residual risks / follow-ups

- Claude `--permission-prompts none` remains unavailable at the qualified 2.1.252 boundary (introduced in 2.1.259), so the existing hook/canary boundary remains active.
- CAK-157 Phase B owns exercising live stream parsing/publication; this PR only selects the production entrypoint and assigns that responsibility to the controller.

## Issue closure

Linear CAK-219.
